### PR TITLE
Adds CI for unit testing TE build

### DIFF
--- a/.github/workflows/_test_te.yaml
+++ b/.github/workflows/_test_te.yaml
@@ -33,7 +33,7 @@ jobs:
           docker pull ${{ inputs.JAX_TE_IMAGE }}
 
       - name: Run JAX-TE unit tests w/ docker
-        shell: docker run -v /tmp/pytest-log:/tmp/pytest-log --gpus all ${{ inputs.JAX_TE_IMAGE }} bash -x {0}
+        shell: docker run -v /tmp/pytest-log:/tmp/pytest-log --gpus all ${{ inputs.JAX_TE_IMAGE }} bash -x -c "$(cat {0})"
         run: |
           pip install pytest pytest-reportlog cuda-python
           pytest --report-log=/tmp/pytest-log/report.jsonl /opt/transformer-engine/tests/jax

--- a/.github/workflows/_test_te.yaml
+++ b/.github/workflows/_test_te.yaml
@@ -33,9 +33,10 @@ jobs:
           docker pull ${{ inputs.JAX_TE_IMAGE }}
 
       - name: Run JAX-TE unit tests w/ docker
-        shell: bash -x {0}
+        shell: docker run -v /tmp/pytest-log:/tmp/pytest-log --gpus all ${{ inputs.JAX_TE_IMAGE }} bash -x {0}
         run: |
-          docker run -v /tmp/pytest-log:/tmp/pytest-log --gpus all ${{ inputs.JAX_TE_IMAGE }} sh -c "pip install pytest pytest-reportlog cuda-python && pytest --report-log=/tmp/pytest-log/report.jsonl /opt/transformer-engine/tests/jax"
+          pip install pytest pytest-reportlog cuda-python
+          pytest --report-log=/tmp/pytest-log/report.jsonl /opt/transformer-engine/tests/jax
 
       - name: Upload test json logs
         uses: actions/upload-artifact@v3

--- a/.github/workflows/_test_te.yaml
+++ b/.github/workflows/_test_te.yaml
@@ -1,8 +1,6 @@
 name: ~test TransformerEngine
 
 on:
-  # Manual trigger
-  workflow_dispatch:
   # Called from another workflow
   workflow_call:
     inputs:

--- a/.github/workflows/_test_te.yaml
+++ b/.github/workflows/_test_te.yaml
@@ -1,0 +1,47 @@
+name: ~test TransformerEngine
+
+on:
+  # Manual trigger
+  workflow_dispatch:
+  # Called from another workflow
+  workflow_call:
+    inputs:
+      JAX_TE_IMAGE:
+        type: string
+        description: 'JAX-TE image build by NVIDIA/JAX-Toolbox'
+        required: true
+        default: 'ghcr.io/nvidia/jax-te:latest'
+
+jobs:
+  te-unit-tests:
+    runs-on: [self-hosted, compute, V100]
+    steps:
+      - name: Print environment variables
+        run: env
+
+      - name: Print GPU information
+        run: nvidia-smi
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Pull JAX-TE image
+        shell: bash -x -e {0}
+        run: |
+          docker pull ${{ inputs.JAX_TE_IMAGE }}
+
+      - name: Run JAX-TE unit tests w/ docker
+        shell: bash -x {0}
+        run: |
+          docker run -v /tmp/pytest-log:/tmp/pytest-log --gpus all ${{ inputs.JAX_TE_IMAGE }} sh -c "pip install pytest pytest-reportlog cuda-python && pytest --report-log=/tmp/pytest-log/report.jsonl /opt/transformer-engine/tests/jax"
+
+      - name: Upload test json logs
+        uses: actions/upload-artifact@v3
+        with:
+          name: test-logs
+          path: /tmp/pytest-log/report.jsonl
+

--- a/.github/workflows/nightly-te-test.yaml
+++ b/.github/workflows/nightly-te-test.yaml
@@ -1,0 +1,105 @@
+name: Nightly Transformer Engine test
+
+on:
+  workflow_run:
+    workflows: [Nightly Transformer Engine build]
+    types: [completed]
+    branches: [main]
+  workflow_dispatch:
+    inputs:
+      JAX_TE_IMAGE:
+        type: string
+        description: 'JAX-TE image build by NVIDIA/JAX-Toolbox'
+        required: true
+        default: 'ghcr.io/nvidia/jax-te:latest'
+
+permissions:
+  contents: read  # to fetch code
+  actions:  write # to cancel previous workflows
+  packages: write # to upload container
+
+jobs:
+
+  metadata:
+    runs-on: ubuntu-22.04
+    outputs:
+      BUILD_DATE: ${{ steps.date.outputs.BUILD_DATE }}
+    steps:
+      - name: Set build date
+        id: date
+        shell: bash -x -e {0}
+        run: |
+          BUILD_DATE=$(TZ='US/Los_Angeles' date '+%Y-%m-%d')
+          echo "BUILD_DATE=${BUILD_DATE}" >> $GITHUB_OUTPUT
+
+  run-jobs:
+    uses: ./.github/workflows/_test_te.yaml
+    if: (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success') || github.event_name == 'workflow_dispatch'
+    with:
+      JAX_TE_IMAGE: ${{ inputs.JAX_TE_IMAGE }}
+    secrets: inherit
+
+  publish:
+    needs: [metadata, run-jobs]
+    if: (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success') || (github.event_name == 'workflow_dispatch' && inputs.PUBLISH)
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Download artifact from the previous job
+        uses: actions/download-artifact@v3
+        with:
+          name: test-logs
+          path: test-logs
+
+      - name: Count the number of failed tests
+        shell: bash -x -e {0}
+        run: |
+          all_outcomes() {
+            jq -r '. | select(.["$report_type"] == "TestReport") | .outcome'
+          }
+          cnt_type() {
+            jq '. | select((.["$report_type"] == "TestReport") and (.outcome | contains("'${1}'"))) | .outcome' | wc -l
+          }
+          SKIPPED_TESTS=$(cat test-logs/report.jsonl | cnt_type skipped)
+          FAILED_TESTS=$(cat test-logs/report.jsonl | cnt_type failed)
+          PASSED_TESTS=$(cat test-logs/report.jsonl | cnt_type passed)
+          TOTAL_TESTS=$(cat test-logs/report.jsonl | all_outcomes | wc -l)
+          echo "Unit test breakdown:"
+          cat test-logs/report.jsonl | all_outcomes | sort | uniq -c
+          if [[ $FAILED_TESTS -eq 0 ]]; then
+            BADGE_COLOR=brightgreen
+          else
+            if [[ $PASSED_TESTS -eq 0 ]]; then
+              BADGE_COLOR=red
+            else
+              BADGE_COLOR=yellow
+            fi
+          fi
+          cat > endpoint.json << EOF
+          {
+            "schemaVersion": 1,
+            "label": "V100 Unit",
+            "message": "${PASSED_TESTS}/${SKIPPED_TESTS}/${FAILED_TESTS} pass/skip/fail",
+            "color": "${BADGE_COLOR}"
+          }
+          EOF
+
+      # TODO: re-enable after secret/gist_id is created for TE badge json
+      #- name: Update status badge endpoint
+      #  uses: exuanbo/actions-deploy-gist@v1
+      #  with:
+      #    token: ${{ secrets.NVJAX_GIST_TOKEN }}
+      #    gist_id: 913c2af68649fe568e9711c2dabb23ae
+      #    file_path: endpoint.json
+      #    file_type: text
+
+      #- name: Upload artifact
+      #  uses: actions/upload-artifact@v3
+      #  with:
+      #    name: endpoint
+      #    path: endpoint.json
+
+  if-upstream-failed:
+    runs-on: ubuntu-latest
+    if: (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'failure') && github.event_name != 'workflow_dispatch'
+    steps:
+      - run: echo 'Upstream workflow failed, aborting run' && exit 1

--- a/.github/workflows/nightly-te-test.yaml
+++ b/.github/workflows/nightly-te-test.yaml
@@ -74,7 +74,7 @@ jobs:
               BADGE_COLOR=yellow
             fi
           fi
-          cat > endpoint.json << EOF
+          cat > te-unit-test-status.json << EOF
           {
             "schemaVersion": 1,
             "label": "V100 Unit",
@@ -83,20 +83,19 @@ jobs:
           }
           EOF
 
-      # TODO: re-enable after secret/gist_id is created for TE badge json
-      #- name: Update status badge endpoint
-      #  uses: exuanbo/actions-deploy-gist@v1
-      #  with:
-      #    token: ${{ secrets.NVJAX_GIST_TOKEN }}
-      #    gist_id: 913c2af68649fe568e9711c2dabb23ae
-      #    file_path: endpoint.json
-      #    file_type: text
+      - name: Update status badge endpoint
+        uses: exuanbo/actions-deploy-gist@v1
+        with:
+          token: ${{ secrets.NVJAX_GIST_TOKEN }}
+          gist_id: 913c2af68649fe568e9711c2dabb23ae
+          file_path: te-unit-test-status.json
+          file_type: text
 
-      #- name: Upload artifact
-      #  uses: actions/upload-artifact@v3
-      #  with:
-      #    name: endpoint
-      #    path: endpoint.json
+      - name: Upload artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: te-unit-test-status
+          path: te-unit-test-status.json
 
   if-upstream-failed:
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 | [![container-badge-jax]][container-link-jax]         | [![build-badge-jax]][workflow-jax]         | [![test-badge-jax]][workflow-jax-unit] |
 | [![container-badge-t5x]][container-link-t5x]         | [![build-badge-t5x]][workflow-t5x]         | [![test-badge-t5x]][workflow-t5x-perf] |
 | [![container-badge-pax]][container-link-pax]         | [![build-badge-pax]][workflow-pax]         |                                        |
-| [![container-badge-te]][container-link-te]           | [![build-badge-te]][workflow-te]           |                                        |
+| [![container-badge-te]][container-link-te]           | [![build-badge-te]][workflow-te]           | [![unit-test-badge-te]][workflow-te-test] |
 | [![container-badge-rosetta]][container-link-rosetta] | [![build-badge-rosetta]][workflow-rosetta] | [![test-badge-rosetta]][workflow-rosetta-test] (dummy) |
 
 [container-badge-base]: https://img.shields.io/static/v1?label=&message=.base&color=gray&logo=docker
@@ -39,10 +39,12 @@
 
 [test-badge-jax]: https://img.shields.io/endpoint?url=https%3A%2F%2Fgist.githubusercontent.com%2Fnvjax%2F913c2af68649fe568e9711c2dabb23ae%2Fraw%2Fendpoint.json&logo=nvidia
 [test-badge-t5x]: https://img.shields.io/github/actions/workflow/status/NVIDIA/JAX-Toolbox/nightly-t5x-test-mgmn.yaml?branch=main&label=A100%20MGMN&logo=nvidia
+[unit-test-badge-te]: https://img.shields.io/endpoint?url=https%3A%2F%2Fgist.githubusercontent.com%2Fnvjax%2F913c2af68649fe568e9711c2dabb23ae%2Fraw%2Fte-unit-test-status.json&logo=nvidia
 [test-badge-rosetta]: https://img.shields.io/github/actions/workflow/status/NVIDIA/JAX-Toolbox/nightly-rosetta-test.yaml?branch=main&label=A100%20MGMN&logo=nvidia
 
 [workflow-jax-unit]: https://github.com/NVIDIA/JAX-Toolbox/actions/workflows/nightly-jax-test-unit.yaml
 [workflow-t5x-perf]: https://github.com/NVIDIA/JAX-Toolbox/actions/workflows/nightly-t5x-test-mgmn.yaml
+[workflow-te-test]: https://github.com/NVIDIA/JAX-Toolbox/actions/workflows/nightly-te-test.yaml
 [workflow-rosetta-test]: https://github.com/NVIDIA/JAX-Toolbox/actions/workflows/nightly-rosetta-test.yaml
 
 


### PR DESCRIPTION
TE has some integration tests that we can run, but first wanted to add unit tests and then will address integration test in follow up PR. Couldn't create a badge like the jax tests do since we need to create a new gist for it. Can address the badge in a follow up PR if preferred