### PR TITLE
Fix Multiprocessing in Pax Tests

### DIFF
--- a/.github/workflows/_test_pax.yaml
+++ b/.github/workflows/_test_pax.yaml
@@ -89,7 +89,7 @@ jobs:
               --tensor-parallel ${{ matrix.PARALLEL_CONFIG[1] }} \
               --pipeline-parallel ${{ matrix.PARALLEL_CONFIG[2] }} \
               --nodes ${{ steps.meta.outputs.NODES }} \
-              $([[ $TOTAL_TASKS > 1 ]] && echo --multiprocess)
+              $([[ $steps.meta.outputs.TOTAL_TASKS > 1 ]] && echo --multiprocess)
           EOF
           )
 

--- a/.github/workflows/_test_pax.yaml
+++ b/.github/workflows/_test_pax.yaml
@@ -89,7 +89,7 @@ jobs:
               --tensor-parallel ${{ matrix.PARALLEL_CONFIG[1] }} \
               --pipeline-parallel ${{ matrix.PARALLEL_CONFIG[2] }} \
               --nodes ${{ steps.meta.outputs.NODES }} \
-              $([[ $steps.meta.outputs.TOTAL_TASKS > 1 ]] && echo --multiprocess)
+              $([[ ${{ steps.meta.outputs.TOTAL_TASKS }} > 1 ]] && echo --multiprocess)
           EOF
           )
 


### PR DESCRIPTION
Fixes the `TOTAL_TASKS` variable substitution to allow Pax tests to run with multiprocessing.