### PR TITLE
Fix rosetta build

### DIFF
--- a/.github/workflows/_build_rosetta.yaml
+++ b/.github/workflows/_build_rosetta.yaml
@@ -81,7 +81,7 @@ jobs:
           if [[ $PYTHON_PACKAGE == "pax" ]]; then
             PYTHON_PACKAGE=paxml
           fi
-          docker run --rm ${{ env.BASE_IMAGE }} python -c "import $PYTHON_PACKAGE"
+          docker run --rm ${{ env.BASE_IMAGE }} python -c "import importlib,sys; sys.exit(importlib.util.find_spec('$PYTHON_PACKAGE') is None)"
 
       - name: Build docker images
         uses: docker/build-push-action@v4

--- a/.github/workflows/_build_rosetta.yaml
+++ b/.github/workflows/_build_rosetta.yaml
@@ -74,15 +74,14 @@ jobs:
           driver-opts: |
             image=moby/buildkit:v0.10.6
 
-      # TODO: Can't run a cuda image yet
-      #- name: Pull and validate BASE_IMAGE=${{ env.BASE_IMAGE }} contains BASE_LIBRARY=${{ inputs.BASE_LIBRARY }}
-      #  shell: bash -x -e {0}
-      #  run: |
-      #    PYTHON_PACKAGE=${{ inputs.BASE_LIBRARY }}
-      #    if [[ $PYTHON_PACKAGE == "pax" ]]; then
-      #      PYTHON_PACKAGE=paxml
-      #    fi
-      #    docker run --rm ${{ env.BASE_IMAGE }} python -c "import $PYTHON_PACKAGE"
+      - name: Pull and validate BASE_IMAGE=${{ env.BASE_IMAGE }} contains BASE_LIBRARY=${{ inputs.BASE_LIBRARY }}
+        shell: bash -x -e {0}
+        run: |
+          PYTHON_PACKAGE=${{ inputs.BASE_LIBRARY }}
+          if [[ $PYTHON_PACKAGE == "pax" ]]; then
+            PYTHON_PACKAGE=paxml
+          fi
+          docker run --rm ${{ env.BASE_IMAGE }} python -c "import $PYTHON_PACKAGE"
 
       - name: Build docker images
         uses: docker/build-push-action@v4

--- a/.github/workflows/_build_rosetta.yaml
+++ b/.github/workflows/_build_rosetta.yaml
@@ -74,15 +74,15 @@ jobs:
           driver-opts: |
             image=moby/buildkit:v0.10.6
 
-      - name: Pull and validate BASE_IMAGE=${{ env.BASE_IMAGE }} contains BASE_LIBRARY=${{ inputs.BASE_LIBRARY }}
-        shell: bash -x -e {0}
-        run: |
-          PYTHON_PACKAGE=${{ inputs.BASE_LIBRARY }}
-          if [[ $PYTHON_PACKAGE == "pax" ]]; then
-            PYTHON_PACKAGE=paxml
-          fi
-          docker run --rm ${{ env.BASE_IMAGE }} python -c "import $PYTHON_PACKAGE"
-
+      # TODO: Can't run a cuda image yet
+      #- name: Pull and validate BASE_IMAGE=${{ env.BASE_IMAGE }} contains BASE_LIBRARY=${{ inputs.BASE_LIBRARY }}
+      #  shell: bash -x -e {0}
+      #  run: |
+      #    PYTHON_PACKAGE=${{ inputs.BASE_LIBRARY }}
+      #    if [[ $PYTHON_PACKAGE == "pax" ]]; then
+      #      PYTHON_PACKAGE=paxml
+      #    fi
+      #    docker run --rm ${{ env.BASE_IMAGE }} python -c "import $PYTHON_PACKAGE"
 
       - name: Build docker images
         uses: docker/build-push-action@v4

--- a/.github/workflows/nightly-rosetta-pax-build.yaml
+++ b/.github/workflows/nightly-rosetta-pax-build.yaml
@@ -62,7 +62,7 @@ jobs:
   publish:
     if: (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success') || (github.event_name == 'workflow_dispatch' && inputs.PUBLISH)
     needs: [metadata, build]
-    uses: ./.github/workflows/_publish_nightly.yaml
+    uses: ./.github/workflows/_publish_container.yaml
     secrets: inherit
     with:
       SOURCE_IMAGE: ${{ needs.build.outputs.DOCKER_TAGS }}

--- a/.github/workflows/nightly-rosetta-pax-build.yaml
+++ b/.github/workflows/nightly-rosetta-pax-build.yaml
@@ -14,7 +14,7 @@ on:
         required: false
 
 env:
-  TARGET: rosetta
+  BASE_LIBRARY: pax
   DOCKER_REGISTRY: ghcr.io/nvidia
 
 permissions:
@@ -36,6 +36,8 @@ jobs:
         run: |
           BUILD_DATE=$(TZ='US/Los_Angeles' date '+%Y-%m-%d')
           echo "BUILD_DATE=${BUILD_DATE}" >> $GITHUB_OUTPUT
+          echo "BASE_LIBRARY=${{ env.BASE_LIBRARY }}" >> $GITHUB_OUTPUT
+          echo "DOCKER_REGISTRY=${{ env.DOCKER_REGISTRY }}" >> $GITHUB_OUTPUT
 
   build:
     if: (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success') || github.event_name == 'workflow_dispatch'
@@ -43,8 +45,8 @@ jobs:
     uses: ./.github/workflows/_build_rosetta.yaml
     with:
       BUILD_DATE: ${{ needs.metadata.outputs.BUILD_DATE }}
-      BASE_LIBRARY: pax
-      BASE_IMAGE: ${{ env.DOCKER_REGISTRY }}/pax:latest
+      BASE_LIBRARY: ${{ needs.metadata.outputs.BASE_LIBRARY }}
+      BASE_IMAGE: ${{ needs.metadata.outputs.DOCKER_REGISTRY }}/${{ needs.metadata.outputs.BASE_LIBRARY }}:latest
     secrets: inherit
 
   test:
@@ -62,7 +64,7 @@ jobs:
     secrets: inherit
     with:
       SOURCE_IMAGE: ${{ needs.build.outputs.DOCKER_TAGS }}
-      TARGET_IMAGE: rosetta-pax
+      TARGET_IMAGE: rosetta-${{ needs.metadata.outputs.BASE_LIBRARY }}
       TARGET_TAGS: |
         type=raw,value=latest,priority=1000
         type=raw,value=nightly-${{ needs.metadata.outputs.BUILD_DATE }},priority=900

--- a/.github/workflows/nightly-rosetta-pax-build.yaml
+++ b/.github/workflows/nightly-rosetta-pax-build.yaml
@@ -28,10 +28,12 @@ jobs:
     if: (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success') || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-22.04
     outputs:
-      BUILD_DATE: ${{ steps.date.outputs.BUILD_DATE }}
+      BUILD_DATE: ${{ steps.meta-vars.outputs.BUILD_DATE }}
+      BASE_LIBRARY: ${{ steps.meta-vars.outputs.BASE_LIBRARY }}
+      DOCKER_REGISTRY: ${{ steps.meta-vars.outputs.DOCKER_REGISTRY }}
     steps:
-      - name: Set build date
-        id: date
+      - name: Set build metadata
+        id: meta-vars
         shell: bash -x -e {0}
         run: |
           BUILD_DATE=$(TZ='US/Los_Angeles' date '+%Y-%m-%d')

--- a/.github/workflows/nightly-rosetta-t5x-build.yaml
+++ b/.github/workflows/nightly-rosetta-t5x-build.yaml
@@ -14,7 +14,7 @@ on:
         required: false
 
 env:
-  TARGET: rosetta
+  BASE_LIBRARY: t5x
   DOCKER_REGISTRY: ghcr.io/nvidia
 
 permissions:
@@ -36,6 +36,8 @@ jobs:
         run: |
           BUILD_DATE=$(TZ='US/Los_Angeles' date '+%Y-%m-%d')
           echo "BUILD_DATE=${BUILD_DATE}" >> $GITHUB_OUTPUT
+          echo "BASE_LIBRARY=${{ env.BASE_LIBRARY }}" >> $GITHUB_OUTPUT
+          echo "DOCKER_REGISTRY=${{ env.DOCKER_REGISTRY }}" >> $GITHUB_OUTPUT
 
   build:
     if: (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success') || github.event_name == 'workflow_dispatch'
@@ -43,8 +45,8 @@ jobs:
     uses: ./.github/workflows/_build_rosetta.yaml
     with:
       BUILD_DATE: ${{ needs.metadata.outputs.BUILD_DATE }}
-      BASE_LIBRARY: t5x
-      BASE_IMAGE: ${{ env.DOCKER_REGISTRY }}/t5x:latest
+      BASE_LIBRARY: ${{ needs.metadata.outputs.BASE_LIBRARY }}
+      BASE_IMAGE: ${{ needs.metadata.outputs.DOCKER_REGISTRY }}/${{ needs.metadata.outputs.BASE_LIBRARY }}:latest
     secrets: inherit
 
   test:
@@ -62,7 +64,7 @@ jobs:
     secrets: inherit
     with:
       SOURCE_IMAGE: ${{ needs.build.outputs.DOCKER_TAGS }}
-      TARGET_IMAGE: rosetta-t5x
+      TARGET_IMAGE: rosetta-${{ needs.metadata.outputs.BASE_LIBRARY }}
       TARGET_TAGS: |
         type=raw,value=latest,priority=1000
         type=raw,value=nightly-${{ needs.metadata.outputs.BUILD_DATE }},priority=900

--- a/.github/workflows/nightly-rosetta-t5x-build.yaml
+++ b/.github/workflows/nightly-rosetta-t5x-build.yaml
@@ -28,10 +28,12 @@ jobs:
     if: (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success') || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-22.04
     outputs:
-      BUILD_DATE: ${{ steps.date.outputs.BUILD_DATE }}
+      BUILD_DATE: ${{ steps.meta-vars.outputs.BUILD_DATE }}
+      BASE_LIBRARY: ${{ steps.meta-vars.outputs.BASE_LIBRARY }}
+      DOCKER_REGISTRY: ${{ steps.meta-vars.outputs.DOCKER_REGISTRY }}
     steps:
-      - name: Set build date
-        id: date
+      - name: Set build metadata
+        id: meta-vars
         shell: bash -x -e {0}
         run: |
           BUILD_DATE=$(TZ='US/Los_Angeles' date '+%Y-%m-%d')

--- a/README.md
+++ b/README.md
@@ -7,13 +7,15 @@
 | [![container-badge-t5x]][container-link-t5x]         | [![build-badge-t5x]][workflow-t5x]         | [![test-badge-t5x]][workflow-t5x-perf] |
 | [![container-badge-pax]][container-link-pax]         | [![build-badge-pax]][workflow-pax]         | [![test-badge-pax]][workflow-pax-perf] |
 | [![container-badge-te]][container-link-te]           | [![build-badge-te]][workflow-te]           | [![unit-test-badge-te]][workflow-te-test] <br> [![integration-test-badge-te]][workflow-te-test] |
-| [![container-badge-rosetta]][container-link-rosetta] | [![build-badge-rosetta]][workflow-rosetta] | [![test-badge-rosetta]][workflow-rosetta-test] (dummy) |
+| [![container-badge-rosetta-t5x]][container-link-rosetta-t5x] | [![build-badge-rosetta-t5x]][workflow-rosetta-t5x] | [![test-badge-rosetta-t5x]][workflow-rosetta-t5x] (dummy) |
+| [![container-badge-rosetta-pax]][container-link-rosetta-pax] | [![build-badge-rosetta-pax]][workflow-rosetta-pax] | [![test-badge-rosetta-pax]][workflow-rosetta-pax] (dummy) |
 
 [container-badge-base]: https://img.shields.io/static/v1?label=&message=.base&color=gray&logo=docker
 [container-badge-jax]: https://img.shields.io/static/v1?label=&message=JAX&color=gray&logo=docker
 [container-badge-t5x]: https://img.shields.io/static/v1?label=&message=T5X&color=gray&logo=docker
 [container-badge-pax]: https://img.shields.io/static/v1?label=&message=PAX&color=gray&logo=docker
-[container-badge-rosetta]: https://img.shields.io/static/v1?label=&message=ROSETTA&color=gray&logo=docker
+[container-badge-rosetta-t5x]: https://img.shields.io/static/v1?label=&message=ROSETTA(T5X)&color=gray&logo=docker
+[container-badge-rosetta-pax]: https://img.shields.io/static/v1?label=&message=ROSETTA(PAX)&color=gray&logo=docker
 [container-badge-te]: https://img.shields.io/static/v1?label=&message=TE&color=gray&logo=docker
 
 [container-link-base]: https://github.com/NVIDIA/JAX-Toolbox/pkgs/container/jax-toolbox
@@ -21,20 +23,23 @@
 [container-link-t5x]: https://github.com/NVIDIA/JAX-Toolbox/pkgs/container/t5x
 [container-link-pax]: https://github.com/NVIDIA/JAX-Toolbox/pkgs/container/pax
 [container-link-te]: https://github.com/NVIDIA/JAX-Toolbox/pkgs/container/jax-te
-[container-link-rosetta]: https://github.com/NVIDIA/JAX-Toolbox/pkgs/container/rosetta
+[container-link-rosetta-t5x]: https://github.com/NVIDIA/JAX-Toolbox/pkgs/container/rosetta-t5x
+[container-link-rosetta-pax]: https://github.com/NVIDIA/JAX-Toolbox/pkgs/container/rosetta-pax
 
 [build-badge-base]: https://img.shields.io/github/actions/workflow/status/NVIDIA/JAX-Toolbox/weekly-base-build.yaml?branch=main&label=weekly&logo=github-actions&logoColor=dddddd
 [build-badge-jax]: https://img.shields.io/github/actions/workflow/status/NVIDIA/JAX-Toolbox/nightly-jax-build.yaml?branch=main&label=nightly&logo=github-actions&logoColor=dddddd
 [build-badge-t5x]: https://img.shields.io/github/actions/workflow/status/NVIDIA/JAX-Toolbox/nightly-t5x-build.yaml?branch=main&label=nightly&logo=github-actions&logoColor=dddddd
 [build-badge-pax]: https://img.shields.io/github/actions/workflow/status/NVIDIA/JAX-Toolbox/nightly-pax-build.yaml?branch=main&label=nightly&logo=github-actions&logoColor=dddddd
-[build-badge-rosetta]: https://img.shields.io/github/actions/workflow/status/NVIDIA/JAX-Toolbox/nightly-rosetta-build.yaml?branch=main&label=nightly&logo=github-actions&logoColor=dddddd
+[build-badge-rosetta-t5x]: https://img.shields.io/github/actions/workflow/status/NVIDIA/JAX-Toolbox/nightly-rosetta-t5x-build.yaml?branch=main&label=nightly&logo=github-actions&logoColor=dddddd
+[build-badge-rosetta-pax]: https://img.shields.io/github/actions/workflow/status/NVIDIA/JAX-Toolbox/nightly-rosetta-pax-build.yaml?branch=main&label=nightly&logo=github-actions&logoColor=dddddd
 [build-badge-te]: https://img.shields.io/github/actions/workflow/status/NVIDIA/JAX-Toolbox/nightly-te-build.yaml?branch=main&label=nightly&logo=github-actions&logoColor=dddddd
 
 [workflow-base]: https://github.com/NVIDIA/JAX-Toolbox/actions/workflows/weekly-base-build.yaml
 [workflow-jax]: https://github.com/NVIDIA/JAX-Toolbox/actions/workflows/nightly-jax-build.yaml
 [workflow-t5x]: https://github.com/NVIDIA/JAX-Toolbox/actions/workflows/nightly-t5x-build.yaml
 [workflow-pax]: https://github.com/NVIDIA/JAX-Toolbox/actions/workflows/nightly-pax-build.yaml
-[workflow-rosetta]: https://github.com/NVIDIA/JAX-Toolbox/actions/workflows/nightly-rosetta-build.yaml
+[workflow-rosetta-t5x]: https://github.com/NVIDIA/JAX-Toolbox/actions/workflows/nightly-rosetta-t5x-build.yaml
+[workflow-rosetta-pax]: https://github.com/NVIDIA/JAX-Toolbox/actions/workflows/nightly-rosetta-pax-build.yaml
 [workflow-te]: https://github.com/NVIDIA/JAX-Toolbox/actions/workflows/nightly-te-build.yaml
 
 [test-badge-jax]: https://img.shields.io/endpoint?url=https%3A%2F%2Fgist.githubusercontent.com%2Fnvjax%2F913c2af68649fe568e9711c2dabb23ae%2Fraw%2Fjax-unit-test-status.json&logo=nvidia
@@ -42,13 +47,13 @@
 [test-badge-pax]: https://img.shields.io/github/actions/workflow/status/NVIDIA/JAX-Toolbox/nightly-pax-test-mgmn.yaml?branch=main&label=A100%20MGMN&logo=nvidia
 [unit-test-badge-te]: https://img.shields.io/endpoint?url=https%3A%2F%2Fgist.githubusercontent.com%2Fnvjax%2F913c2af68649fe568e9711c2dabb23ae%2Fraw%2Fte-unit-test-status.json&logo=nvidia
 [integration-test-badge-te]: https://img.shields.io/endpoint?url=https%3A%2F%2Fgist.githubusercontent.com%2Fnvjax%2F913c2af68649fe568e9711c2dabb23ae%2Fraw%2Fte-integration-test-status.json&logo=nvidia
-[test-badge-rosetta]: https://img.shields.io/github/actions/workflow/status/NVIDIA/JAX-Toolbox/nightly-rosetta-test.yaml?branch=main&label=A100%20MGMN&logo=nvidia
+[test-badge-rosetta-t5x]: https://img.shields.io/github/actions/workflow/status/NVIDIA/JAX-Toolbox/nightly-rosetta-t5x-build.yaml?branch=main&label=A100%20MGMN&logo=nvidia
+[test-badge-rosetta-pax]: https://img.shields.io/github/actions/workflow/status/NVIDIA/JAX-Toolbox/nightly-rosetta-pax-build.yaml?branch=main&label=A100%20MGMN&logo=nvidia
 
 [workflow-jax-unit]: https://github.com/NVIDIA/JAX-Toolbox/actions/workflows/nightly-jax-test-unit.yaml
 [workflow-t5x-perf]: https://github.com/NVIDIA/JAX-Toolbox/actions/workflows/nightly-t5x-test-mgmn.yaml
 [workflow-pax-perf]: https://github.com/NVIDIA/JAX-Toolbox/actions/workflows/nightly-pax-test-mgmn.yaml
 [workflow-te-test]: https://github.com/NVIDIA/JAX-Toolbox/actions/workflows/nightly-te-test.yaml
-[workflow-rosetta-test]: https://github.com/NVIDIA/JAX-Toolbox/actions/workflows/nightly-rosetta-test.yaml
 
 
 ## Note

--- a/rosetta/Dockerfile.pax
+++ b/rosetta/Dockerfile.pax
@@ -16,12 +16,14 @@ FROM ${BASE_IMAGE} AS distribution-builder
 
 ARG GIT_USER_EMAIL
 ARG GIT_USER_NAME
-RUN git config --global user.email "${GIT_USER_EMAIL}" && \
-    git config --global user.name "${GIT_USER_NAME}"
+RUN <<EOF bash -e
+git config --global user.email "${GIT_USER_EMAIL}"
+git config --global user.name "${GIT_USER_NAME}"
+EOF
 
 COPY --from=rosetta-source / /opt/rosetta
 WORKDIR /opt/rosetta
-RUN --mount=target=/opt/pax-mirror,from=pax-mirror-source,readwrite --mount=target=/opt/praxis-mirror,from=praxis-mirror-source,readwrite <<EOF
+RUN --mount=target=/opt/pax-mirror,from=pax-mirror-source,readwrite --mount=target=/opt/praxis-mirror,from=praxis-mirror-source,readwrite <<EOF bash -e
 bash create-distribution.sh \
   -p patchlist-paxml.txt \
   -u https://github.com/google/paxml.git \

--- a/rosetta/Dockerfile.pax
+++ b/rosetta/Dockerfile.pax
@@ -32,7 +32,7 @@ bash create-distribution.sh \
 bash create-distribution.sh \
   -p patchlist-praxis.txt \
   -u https://github.com/google/praxis.git \
-  -d $(dirname $(python -c "import praxis; print(*praxis.__path__)"))
+  -d $(dirname $(python -c "import praxis; print(*praxis.__path__)")) \
   -e /opt/praxis-mirror
 rm -rf $(find /opt -name "__pycache__")
 EOF

--- a/rosetta/Dockerfile.t5x
+++ b/rosetta/Dockerfile.t5x
@@ -13,12 +13,14 @@ FROM ${BASE_IMAGE} AS distribution-builder
 
 ARG GIT_USER_EMAIL
 ARG GIT_USER_NAME
-RUN git config --global user.email "${GIT_USER_EMAIL}" && \
-    git config --global user.name "${GIT_USER_NAME}"
+RUN <<EOF bash -e
+git config --global user.email "${GIT_USER_EMAIL}"
+git config --global user.name "${GIT_USER_NAME}"
+EOF
 
 COPY --from=rosetta-source / /opt/rosetta
 WORKDIR /opt/rosetta
-RUN --mount=target=/opt/t5x-mirror,from=t5x-mirror-source,readwrite <<EOF
+RUN --mount=target=/opt/t5x-mirror,from=t5x-mirror-source,readwrite <<EOF bash -e
 bash create-distribution.sh \
   -p patchlist-t5x.txt \
   -u https://github.com/google-research/t5x.git \
@@ -31,7 +33,7 @@ COPY --link --from=distribution-builder /opt/t5x /opt/t5x
 COPY --link --from=distribution-builder /opt/rosetta /opt/rosetta
 
 WORKDIR /opt/rosetta
-RUN <<EOF
+RUN <<EOF bash -e
 pip install -e /opt/rosetta
 rm -rf ~/.cache/pip/
 EOF
@@ -39,7 +41,7 @@ EOF
 FROM rosetta AS rosetta-devel
 
 WORKDIR /opt/rosetta
-RUN <<EOF
+RUN <<EOF bash -e
 pip install -e '/opt/rosetta[test,lint]'
 rm -rf ~/.cache/pip/
 EOF


### PR DESCRIPTION
Fixes issues not caught in first #65 :

* heredocs in Dockerfile need `bash -e` to exit if failure
* disable library validation b/c nvidia-container-toolkit not available in builder runner
* refactored env context usage since it is not available in under with context
* updated badges in frontpage readme  for rosetta t5x/pax