### PR TITLE
Use nvcr.io private registry to stage CI internal containers

### DIFF
--- a/.github/workflows/_build_base.yaml
+++ b/.github/workflows/_build_base.yaml
@@ -19,7 +19,7 @@ on:
         value: ${{ jobs.build.outputs.DOCKER_TAGS }}
 
 env:
-  UPLD_IMAGE: ghcr.io/nvidia/jax-toolbox-internal
+  UPLD_IMAGE: nvcr.io/nvidian/jax-toolbox-internal
 
 permissions:
   contents: read  # to fetch code
@@ -42,9 +42,9 @@ jobs:
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v2
         with:
-          registry: ghcr.io
-          username: ${{ github.repository_owner }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          registry: nvcr.io
+          username: '$oauthtoken'
+          password: ${{ secrets.NVCR_TOKEN }}
 
       - name: Set docker metadata
         id: meta

--- a/.github/workflows/_build_base.yaml
+++ b/.github/workflows/_build_base.yaml
@@ -39,7 +39,7 @@ jobs:
       - name: Check out the repository under ${GITHUB_WORKSPACE}
         uses: actions/checkout@v3
 
-      - name: Login to GitHub Container Registry
+      - name: Login to NVIDIA Container Registry
         uses: docker/login-action@v2
         with:
           registry: nvcr.io

--- a/.github/workflows/_build_jax.yaml
+++ b/.github/workflows/_build_jax.yaml
@@ -39,7 +39,7 @@ on:
         value: ${{ jobs.build.outputs.DOCKER_TAGS }}
 
 env:
-  UPLD_IMAGE: ghcr.io/nvidia/jax-toolbox-internal
+  UPLD_IMAGE: nvcr.io/nvidian/jax-toolbox-internal
 
 permissions:
   contents: read  # to fetch code
@@ -62,9 +62,9 @@ jobs:
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v2
         with:
-          registry: ghcr.io
-          username: ${{ github.repository_owner }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          registry: nvcr.io
+          username: '$oauthtoken'
+          password: ${{ secrets.NVCR_TOKEN }}
 
       - name: Set docker metadata
         id: meta

--- a/.github/workflows/_build_jax.yaml
+++ b/.github/workflows/_build_jax.yaml
@@ -59,7 +59,7 @@ jobs:
       - name: Check out the repository under ${GITHUB_WORKSPACE}
         uses: actions/checkout@v3
 
-      - name: Login to GitHub Container Registry
+      - name: Login to NVIDIA Container Registry
         uses: docker/login-action@v2
         with:
           registry: nvcr.io

--- a/.github/workflows/_build_pax.yaml
+++ b/.github/workflows/_build_pax.yaml
@@ -39,7 +39,7 @@ on:
         value: ${{ jobs.build.outputs.DOCKER_TAGS }}
 
 env:
-  UPLD_IMAGE: ghcr.io/nvidia/jax-toolbox-internal
+  UPLD_IMAGE: nvcr.io/nvidian/jax-toolbox-internal
 
 permissions:
   contents: read  # to fetch code
@@ -62,9 +62,9 @@ jobs:
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v2
         with:
-          registry: ghcr.io
-          username: ${{ github.repository_owner }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          registry: nvcr.io
+          username: '$oauthtoken'
+          password: ${{ secrets.NVCR_TOKEN }}
 
       - name: Set docker metadata
         id: meta

--- a/.github/workflows/_build_pax.yaml
+++ b/.github/workflows/_build_pax.yaml
@@ -59,7 +59,7 @@ jobs:
       - name: Check out the repository under ${GITHUB_WORKSPACE}
         uses: actions/checkout@v3
 
-      - name: Login to GitHub Container Registry
+      - name: Login to NVIDIA Container Registry
         uses: docker/login-action@v2
         with:
           registry: nvcr.io

--- a/.github/workflows/_build_rosetta.yaml
+++ b/.github/workflows/_build_rosetta.yaml
@@ -23,7 +23,7 @@ on:
         value: ${{ jobs.build.outputs.DOCKER_TAGS }}
 
 env:
-  UPLD_IMAGE: ghcr.io/nvidia/jax-toolbox-internal
+  UPLD_IMAGE: nvcr.io/nvidian/jax-toolbox-internal
   DOCKER_REGISTRY: ghcr.io/nvidia
 
 permissions:
@@ -55,9 +55,9 @@ jobs:
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v2
         with:
-          registry: ghcr.io
-          username: ${{ github.repository_owner }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          registry: nvcr.io
+          username: '$oauthtoken'
+          password: ${{ secrets.NVCR_TOKEN }}
 
       - name: Set docker metadata
         id: meta

--- a/.github/workflows/_build_rosetta.yaml
+++ b/.github/workflows/_build_rosetta.yaml
@@ -52,7 +52,7 @@ jobs:
       - name: Check out the repository under ${GITHUB_WORKSPACE}
         uses: actions/checkout@v3
 
-      - name: Login to GitHub Container Registry
+      - name: Login to NVIDIA Container Registry
         uses: docker/login-action@v2
         with:
           registry: nvcr.io

--- a/.github/workflows/_build_t5x.yaml
+++ b/.github/workflows/_build_t5x.yaml
@@ -29,7 +29,7 @@ on:
         value: ${{ jobs.build.outputs.DOCKER_TAGS }}
 
 env:
-  UPLD_IMAGE: ghcr.io/nvidia/jax-toolbox-internal
+  UPLD_IMAGE: nvcr.io/nvidian/jax-toolbox-internal
 
 permissions:
   contents: read  # to fetch code
@@ -52,9 +52,9 @@ jobs:
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v2
         with:
-          registry: ghcr.io
-          username: ${{ github.repository_owner }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          registry: nvcr.io
+          username: '$oauthtoken'
+          password: ${{ secrets.NVCR_TOKEN }}
 
       - name: Set docker metadata
         id: meta

--- a/.github/workflows/_build_t5x.yaml
+++ b/.github/workflows/_build_t5x.yaml
@@ -49,7 +49,7 @@ jobs:
       - name: Check out the repository under ${GITHUB_WORKSPACE}
         uses: actions/checkout@v3
 
-      - name: Login to GitHub Container Registry
+      - name: Login to NVIDIA Container Registry
         uses: docker/login-action@v2
         with:
           registry: nvcr.io

--- a/.github/workflows/_build_te.yaml
+++ b/.github/workflows/_build_te.yaml
@@ -29,7 +29,7 @@ on:
         value: ${{ jobs.build.outputs.DOCKER_TAGS }}
 
 env:
-  UPLD_IMAGE: ghcr.io/nvidia/jax-toolbox-internal
+  UPLD_IMAGE: nvcr.io/nvidian/jax-toolbox-internal
 
 permissions:
   contents: read  # to fetch code
@@ -52,9 +52,9 @@ jobs:
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v2
         with:
-          registry: ghcr.io
-          username: ${{ github.repository_owner }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          registry: nvcr.io
+          username: '$oauthtoken'
+          password: ${{ secrets.NVCR_TOKEN }}
 
       - name: Set docker metadata
         id: meta

--- a/.github/workflows/_build_te.yaml
+++ b/.github/workflows/_build_te.yaml
@@ -49,7 +49,7 @@ jobs:
       - name: Check out the repository under ${GITHUB_WORKSPACE}
         uses: actions/checkout@v3
 
-      - name: Login to GitHub Container Registry
+      - name: Login to NVIDIA Container Registry
         uses: docker/login-action@v2
         with:
           registry: nvcr.io

--- a/.github/workflows/_publish_nightly.yaml
+++ b/.github/workflows/_publish_nightly.yaml
@@ -36,6 +36,13 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v2
+        with:
+          registry: nvcr.io
+          username: '$oauthtoken'
+          password: ${{ secrets.NVCR_TOKEN }}
+
       - name: Set docker metadata
         id: meta
         uses: docker/metadata-action@v4
@@ -48,8 +55,9 @@ jobs:
         shell: bash -x -e {0}
         run: |
           for tag in $(echo "${{ steps.meta.outputs.tags }}"); do
-            docker manifest create $tag ${{ inputs.SOURCE_IMAGE }}
-            docker manifest push $tag
+            docker pull ${{ inputs.SOURCE_IMAGE }}
+            docker tag ${{ inputs.SOURCE_IMAGE }} $tag
+            docker push $tag
           done
 
       - name: Generate outputs and artifacts

--- a/.github/workflows/_publish_nightly.yaml
+++ b/.github/workflows/_publish_nightly.yaml
@@ -36,7 +36,7 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Login to GitHub Container Registry
+      - name: Login to NVIDIA Container Registry
         uses: docker/login-action@v2
         with:
           registry: nvcr.io

--- a/.github/workflows/_sandbox.yaml
+++ b/.github/workflows/_sandbox.yaml
@@ -10,7 +10,7 @@ jobs:
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v2
         with:
-          registry: ghcr.io
+          registry: nvcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/_sandbox.yaml
+++ b/.github/workflows/_sandbox.yaml
@@ -10,9 +10,16 @@ jobs:
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v2
         with:
-          registry: nvcr.io
+          registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Login to NVIDIA Container Registry
+        uses: docker/login-action@v2
+        with:
+          registry: nvcr.io
+          username: $oauthtoken
+          password: ${{ secrets.NVCR_TOKEN }}
 
       - name: Print usage
         run: |

--- a/.github/workflows/_test_jax.yaml
+++ b/.github/workflows/_test_jax.yaml
@@ -20,7 +20,7 @@ jobs:
       - name: Print GPU information
         run: nvidia-smi  
 
-      - name: Login to GitHub Container Registry
+      - name: Login to NVIDIA Container Registry
         uses: docker/login-action@v2
         with:
           registry: nvcr.io

--- a/.github/workflows/_test_jax.yaml
+++ b/.github/workflows/_test_jax.yaml
@@ -23,9 +23,9 @@ jobs:
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v2
         with:
-          registry: ghcr.io
-          username: ${{ github.repository_owner }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          registry: nvcr.io
+          username: '$oauthtoken'
+          password: ${{ secrets.NVCR_TOKEN }}
 
       - name: Pull JAX image
         shell: bash -x -e {0}

--- a/.github/workflows/_test_rosetta.yaml
+++ b/.github/workflows/_test_rosetta.yaml
@@ -27,9 +27,9 @@ jobs:
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v2
         with:
-          registry: ghcr.io
-          username: ${{ github.repository_owner }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          registry: nvcr.io
+          username: '$oauthtoken'
+          password: ${{ secrets.NVCR_TOKEN }}
 
       - name: Pull Rosetta image
         shell: bash -x -e {0}

--- a/.github/workflows/_test_te.yaml
+++ b/.github/workflows/_test_te.yaml
@@ -23,9 +23,9 @@ jobs:
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v2
         with:
-          registry: ghcr.io
-          username: ${{ github.repository_owner }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          registry: nvcr.io
+          username: '$oauthtoken'
+          password: ${{ secrets.NVCR_TOKEN }}
 
       - name: Pull JAX-TE image
         shell: bash -x -e {0}

--- a/.github/workflows/_test_te.yaml
+++ b/.github/workflows/_test_te.yaml
@@ -20,7 +20,7 @@ jobs:
       - name: Print GPU information
         run: nvidia-smi
 
-      - name: Login to GitHub Container Registry
+      - name: Login to NVIDIA Container Registry
         uses: docker/login-action@v2
         with:
           registry: nvcr.io


### PR DESCRIPTION
Pros:
- No longer need to pay for private container storage on ghcr.io
- Potentially better confidentiality if builds contain NVIDIA IP not authorized for release yet.
- Potentially more reliable pulling to/from dlcluster/selene
Cons:
- (ironically) more difficult to grant access, users need to apply to internal portal first.
- docker push/pull slightly slower than ghcr.io for CI jobs. Assumed due to better colocation of ghcr.io and Actions servers.

This PR is for preview purposes and may not represent the final work to be merged.

A good compromise may be to use ghcr.io for instantaneous access in jobs, but use a periodically scheduled Actions workflow to archive containers older than a certain time to nvcr.io.