### PR TITLE
Make t5x/pax and all downstream builds depend on jax-te instead of jax

### DIFF
--- a/.github/workflows/_build_pax.yaml
+++ b/.github/workflows/_build_pax.yaml
@@ -7,7 +7,7 @@ on:
         type: string
         description: 'Base docker image that provides JAX'
         required: false
-        default: ghcr.io/nvidia/jax:latest
+        default: ghcr.io/nvidia/jax-te:latest
       BUILD_DATE:
         type: string
         description: "Build date in YYYY-MM-DD format"

--- a/.github/workflows/_build_t5x.yaml
+++ b/.github/workflows/_build_t5x.yaml
@@ -7,7 +7,7 @@ on:
         type: string
         description: 'Base docker image that provides JAX'
         required: false
-        default: ghcr.io/nvidia/jax:latest
+        default: ghcr.io/nvidia/jax-te:latest
       BUILD_DATE:
         type: string
         description: "Build date in YYYY-MM-DD format"

--- a/.github/workflows/nightly-pax-build.yaml
+++ b/.github/workflows/nightly-pax-build.yaml
@@ -2,7 +2,7 @@ name: Nightly Pax build
 
 on:
   workflow_run:
-    workflows: [Nightly JAX build]
+    workflows: [Nightly Transformer Engine build]
     types: [completed]
     branches: [main]
   workflow_dispatch:

--- a/.github/workflows/nightly-t5x-build.yaml
+++ b/.github/workflows/nightly-t5x-build.yaml
@@ -2,7 +2,7 @@ name: Nightly T5X build
 
 on:
   workflow_run:
-    workflows: [Nightly JAX build]
+    workflows: [Nightly Transformer Engine build]
     types: [completed]
     branches: [main]
   workflow_dispatch:


### PR DESCRIPTION
This change switches the default build of t5x, pax, and downstream rosetta builds to depend on jax-te instead of jax as a base build.

This will simplify the number of images we need to maintain since we won't have to maintain a t5x and t5x+te; or rosetta-t5x and rosetta-t5x+te.

@nouiz and @ashors1 