### PR TITLE
Fixes badge errors for te and jax

### DIFF
--- a/.github/workflows/_publish_badge.yaml
+++ b/.github/workflows/_publish_badge.yaml
@@ -42,14 +42,16 @@ jobs:
           assert_exists "${{ steps.script.outputs.LABEL }}" LABEL
           assert_exists "${{ steps.script.outputs.MESSAGE }}" MESSAGE
           assert_exists "${{ steps.script.outputs.COLOR }}" COLOR
-
+          LABEL=${{ steps.script.outputs.LABEL }}
+          MESSAGE=${{ steps.script.outputs.MESSAGE }}
+          COLOR=${{ steps.script.outputs.COLOR }}
           (
           cat << EOF
           {
             "schemaVersion": 1,
-            "label": "${{ steps.script.outputs.LABEL }}",
-            "message": "${{ steps.script.outputs.MESSAGE }}",
-            "color": "${{ steps.script.outputs.COLOR }}"
+            "label": "$LABEL",
+            "message": "$MESSAGE",
+            "color": "$COLOR"
           }
           EOF
           ) | tee ${{ inputs.ENDPOINT_FILENAME }}

--- a/.github/workflows/nightly-jax-test-unit.yaml
+++ b/.github/workflows/nightly-jax-test-unit.yaml
@@ -62,7 +62,7 @@ jobs:
     secrets: inherit
     with:
       ENDPOINT_FILENAME: 'jax-unit-test-status.json'
-      PUBLISH: ${{ needs.metadata.outputs.PUBLISH }}
+      PUBLISH: ${{ needs.metadata.outputs.PUBLISH == 'true' }}
       SCRIPT: |
         ARTIFACTS="${{ needs.run-jobs.outputs.ARTIFACT_NAME }}/*"
         FAILED_TESTS=$(cat $ARTIFACTS | grep -c 'FAILED in' || true)

--- a/.github/workflows/nightly-jax-test-unit.yaml
+++ b/.github/workflows/nightly-jax-test-unit.yaml
@@ -62,7 +62,7 @@ jobs:
     secrets: inherit
     with:
       ENDPOINT_FILENAME: 'jax-unit-test-status.json'
-      PUBLISH: ${{ needs.metadata.outputs.PUBLISH == 'true' }}
+      PUBLISH: ${{ github.event_name == 'workflow_run' || needs.metadata.outputs.PUBLISH == 'true' }}
       SCRIPT: |
         ARTIFACTS="${{ needs.run-jobs.outputs.ARTIFACT_NAME }}/*"
         FAILED_TESTS=$(cat $ARTIFACTS | grep -c 'FAILED in' || true)

--- a/.github/workflows/nightly-jax-test-unit.yaml
+++ b/.github/workflows/nightly-jax-test-unit.yaml
@@ -32,10 +32,11 @@ jobs:
   metadata:
     runs-on: ubuntu-22.04
     outputs:
-      JAX_IMAGE: ${{ steps.date.outputs.JAX_IMAGE }}
+      JAX_IMAGE: ${{ steps.meta.outputs.JAX_IMAGE }}
+      PUBLISH: ${{ steps.meta.outputs.PUBLISH }}
     steps:
       - name: Set metadata
-        id: date
+        id: meta
         shell: bash -x -e {0}
         run: |
           if [[ -z "${{ inputs.JAX_IMAGE }}" ]]; then
@@ -44,6 +45,7 @@ jobs:
             JAX_IMAGE=${{ inputs.JAX_IMAGE }}
           fi
           echo "JAX_IMAGE=${JAX_IMAGE}" >> $GITHUB_OUTPUT
+          echo "PUBLISH=${{ inputs.PUBLISH }}" >> $GITHUB_OUTPUT
 
   run-jobs:
     needs: metadata
@@ -60,7 +62,7 @@ jobs:
     secrets: inherit
     with:
       ENDPOINT_FILENAME: 'jax-unit-test-status.json'
-      PUBLISH: ${{ inputs.PUBLISH }}
+      PUBLISH: ${{ needs.metadata.outputs.PUBLISH }}
       SCRIPT: |
         ARTIFACTS="${{ needs.run-jobs.outputs.ARTIFACT_NAME }}/*"
         FAILED_TESTS=$(cat $ARTIFACTS | grep -c 'FAILED in' || true)

--- a/.github/workflows/nightly-te-test.yaml
+++ b/.github/workflows/nightly-te-test.yaml
@@ -31,10 +31,11 @@ jobs:
   metadata:
     runs-on: ubuntu-22.04
     outputs:
-      JAX_TE_IMAGE: ${{ steps.date.outputs.JAX_TE_IMAGE }}
+      JAX_TE_IMAGE: ${{ steps.meta.outputs.JAX_TE_IMAGE }}
+      PUBLISH: ${{ steps.meta.outputs.PUBLISH }}
     steps:
       - name: Set metadata
-        id: date
+        id: meta
         shell: bash -x -e {0}
         run: |
           if [[ -z "${{ inputs.JAX_TE_IMAGE }}" ]]; then
@@ -43,6 +44,7 @@ jobs:
             JAX_TE_IMAGE=${{ inputs.JAX_TE_IMAGE }}
           fi
           echo "JAX_TE_IMAGE=${JAX_TE_IMAGE}" >> $GITHUB_OUTPUT
+          echo "PUBLISH=${{ inputs.PUBLISH }}" >> $GITHUB_OUTPUT
 
   run-jobs:
     needs: metadata
@@ -59,7 +61,7 @@ jobs:
     secrets: inherit
     with:
       ENDPOINT_FILENAME: 'te-unit-test-status.json'
-      PUBLISH: ${{ inputs.PUBLISH }}
+      PUBLISH: ${{ needs.metadata.outputs.PUBLISH }}
       SCRIPT: |
         ARTIFACTS="${{ needs.run-jobs.outputs.UNIT_TEST_ARTIFACT_NAME }}/*.jsonl"
         all_outcomes() {
@@ -94,7 +96,7 @@ jobs:
     secrets: inherit
     with:
       ENDPOINT_FILENAME: 'te-integration-test-status.json'
-      PUBLISH: ${{ inputs.PUBLISH }}
+      PUBLISH: ${{ needs.metadata.outputs.PUBLISH }}
       SCRIPT: |
         ARTIFACTS="${{ needs.run-jobs.outputs.INTEGRATION_TEST_ARTIFACT_NAME }}/*.jsonl"
         all_outcomes() {

--- a/.github/workflows/nightly-te-test.yaml
+++ b/.github/workflows/nightly-te-test.yaml
@@ -61,7 +61,7 @@ jobs:
     secrets: inherit
     with:
       ENDPOINT_FILENAME: 'te-unit-test-status.json'
-      PUBLISH: ${{ needs.metadata.outputs.PUBLISH }}
+      PUBLISH: ${{ needs.metadata.outputs.PUBLISH == 'true' }}
       SCRIPT: |
         ARTIFACTS="${{ needs.run-jobs.outputs.UNIT_TEST_ARTIFACT_NAME }}/*.jsonl"
         all_outcomes() {
@@ -96,7 +96,7 @@ jobs:
     secrets: inherit
     with:
       ENDPOINT_FILENAME: 'te-integration-test-status.json'
-      PUBLISH: ${{ needs.metadata.outputs.PUBLISH }}
+      PUBLISH: ${{ needs.metadata.outputs.PUBLISH == 'true' }}
       SCRIPT: |
         ARTIFACTS="${{ needs.run-jobs.outputs.INTEGRATION_TEST_ARTIFACT_NAME }}/*.jsonl"
         all_outcomes() {

--- a/.github/workflows/nightly-te-test.yaml
+++ b/.github/workflows/nightly-te-test.yaml
@@ -61,7 +61,7 @@ jobs:
     secrets: inherit
     with:
       ENDPOINT_FILENAME: 'te-unit-test-status.json'
-      PUBLISH: ${{ needs.metadata.outputs.PUBLISH == 'true' }}
+      PUBLISH: ${{ github.event_name == 'workflow_run' || needs.metadata.outputs.PUBLISH == 'true' }}
       SCRIPT: |
         ARTIFACTS="${{ needs.run-jobs.outputs.UNIT_TEST_ARTIFACT_NAME }}/*.jsonl"
         all_outcomes() {
@@ -96,7 +96,7 @@ jobs:
     secrets: inherit
     with:
       ENDPOINT_FILENAME: 'te-integration-test-status.json'
-      PUBLISH: ${{ needs.metadata.outputs.PUBLISH == 'true' }}
+      PUBLISH: ${{ github.event_name == 'workflow_run' || needs.metadata.outputs.PUBLISH == 'true' }}
       SCRIPT: |
         ARTIFACTS="${{ needs.run-jobs.outputs.INTEGRATION_TEST_ARTIFACT_NAME }}/*.jsonl"
         all_outcomes() {


### PR DESCRIPTION
Few things this PR fixes:
- the `inputs` context isn't allowed in the `with` context for reusable workflows
- the PUBLISH input was boolean, but b/c it was passed thru the concrete workflow, it was converted to a string and caused errors when calling the reusable workflow
- `_publish_badge.yml` inserted step outputs inline which added an extra single quote and messed with the badge color parsing. Using shell variables works around the insertion of the extra single quotes