### PR TITLE
Flax distribution

### DIFF
--- a/.github/container/Dockerfile.pax
+++ b/.github/container/Dockerfile.pax
@@ -8,4 +8,7 @@ FROM ${BASE_IMAGE}
 ADD install-pax.sh /usr/local/bin
 RUN install-pax.sh
 
+ADD install-flax.sh /usr/local/bin
+RUN install-flax.sh
+
 ADD test-pax.sh /usr/local/bin

--- a/.github/container/Dockerfile.t5x
+++ b/.github/container/Dockerfile.t5x
@@ -8,4 +8,8 @@ FROM ${BASE_IMAGE}
 ADD install-t5x.sh /usr/local/bin
 RUN install-t5x.sh
 
+# Note: Install after t5x installation b/c t5x installs flax from source
+ADD install-flax.sh /usr/local/bin
+RUN install-flax.sh
+
 ADD test-t5x.sh /usr/local/bin

--- a/.github/container/install-flax.sh
+++ b/.github/container/install-flax.sh
@@ -1,0 +1,64 @@
+#!/bin/bash
+
+## Parse command-line arguments
+
+usage() {
+    echo "Usage: $0 [OPTION]..."
+    echo "  -d, --dir=PATH         Path to store flax source. Defaults to /opt/flax"
+    echo "  -f, --from=URL         URL of the flax repo. Defaults to https://github.com/google/flax.git"
+    echo "  -h, --help             Print usage."
+    echo "  -r, --ref=REF          Git commit hash or tag name that specifies the version of flax to install. Defaults to HEAD."
+    exit $1
+}
+
+args=$(getopt -o d:f:hr: --long dir:,from:,help,ref: -- "$@")
+if [[ $? -ne 0 ]]; then
+    exit 1
+fi
+
+eval set -- "$args"
+while [ : ]; do
+  case "$1" in
+    -d | --dir)
+        INSTALL_DIR="$2"
+        shift 2
+        ;;
+    -f | --from)
+        FLAX_REPO="$2"
+        shift 2
+        ;;
+    -h | --help)
+        usage
+        ;;
+    -r | --ref)
+        FLAX_REF="$2"
+        shift 2
+        ;;
+    --)
+        shift;
+        break 
+        ;;
+  esac
+done
+
+if [[ $# -ge 1 ]]; then
+    echo "Un-recognized argument: $*" && echo
+    usage 1
+fi
+
+## Set default arguments if not provided via command-line
+
+FLAX_REF="${FLAX_REF:-HEAD}"
+FLAX_REPO="${FLAX_REPO:-https://github.com/google/flax.git}"
+INSTALL_DIR="${INSTALL_DIR:-/opt/flax}"
+
+echo "Installing flax $FLAX_REF from $FLAX_REPO to $INSTALL_DIR"
+
+set -ex
+
+## Install flax
+
+git clone ${FLAX_REPO} ${INSTALL_DIR}
+cd ${INSTALL_DIR}
+git checkout ${FLAX_REF}
+pip install -e .

--- a/.github/workflows/nightly-rosetta-pax-build.yaml
+++ b/.github/workflows/nightly-rosetta-pax-build.yaml
@@ -7,6 +7,11 @@ on:
     branches: [main]
   workflow_dispatch:
     inputs:
+      BASE_IMAGE:
+        type: string
+        description: 'PAX image built by NVIDIA/JAX-Toolbox'
+        default: 'ghcr.io/nvidia/pax:latest'
+        required: true
       PUBLISH:
         type: boolean
         description: Publish dated images and update the 'latest' tag?
@@ -30,16 +35,21 @@ jobs:
     outputs:
       BUILD_DATE: ${{ steps.meta-vars.outputs.BUILD_DATE }}
       BASE_LIBRARY: ${{ steps.meta-vars.outputs.BASE_LIBRARY }}
-      DOCKER_REGISTRY: ${{ steps.meta-vars.outputs.DOCKER_REGISTRY }}
+      BASE_IMAGE: ${{ steps.meta-vars.outputs.BASE_IMAGE }}
     steps:
       - name: Set build metadata
         id: meta-vars
         shell: bash -x -e {0}
         run: |
           BUILD_DATE=$(TZ='US/Los_Angeles' date '+%Y-%m-%d')
+          if [[ -z "${{ inputs.BASE_IMAGE }}" ]]; then
+            BASE_IMAGE=${{ env.DOCKER_REGISTRY }}/${{ env.BASE_LIBRARY }}:latest
+          else
+            BASE_IMAGE=${{ inputs.BASE_IMAGE }}
+          fi
           echo "BUILD_DATE=${BUILD_DATE}" >> $GITHUB_OUTPUT
           echo "BASE_LIBRARY=${{ env.BASE_LIBRARY }}" >> $GITHUB_OUTPUT
-          echo "DOCKER_REGISTRY=${{ env.DOCKER_REGISTRY }}" >> $GITHUB_OUTPUT
+          echo "BASE_IMAGE=${BASE_IMAGE}" >> $GITHUB_OUTPUT
 
   build:
     if: (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success') || github.event_name == 'workflow_dispatch'
@@ -48,7 +58,7 @@ jobs:
     with:
       BUILD_DATE: ${{ needs.metadata.outputs.BUILD_DATE }}
       BASE_LIBRARY: ${{ needs.metadata.outputs.BASE_LIBRARY }}
-      BASE_IMAGE: ${{ needs.metadata.outputs.DOCKER_REGISTRY }}/${{ needs.metadata.outputs.BASE_LIBRARY }}:latest
+      BASE_IMAGE: ${{ needs.metadata.outputs.BASE_IMAGE }}
     secrets: inherit
 
   test:

--- a/.github/workflows/nightly-rosetta-t5x-build.yaml
+++ b/.github/workflows/nightly-rosetta-t5x-build.yaml
@@ -7,6 +7,11 @@ on:
     branches: [main]
   workflow_dispatch:
     inputs:
+      BASE_IMAGE:
+        type: string
+        description: 'T5x image built by NVIDIA/JAX-Toolbox'
+        default: 'ghcr.io/nvidia/t5x:latest'
+        required: true
       PUBLISH:
         type: boolean
         description: Publish dated images and update the 'latest' tag?
@@ -30,16 +35,21 @@ jobs:
     outputs:
       BUILD_DATE: ${{ steps.meta-vars.outputs.BUILD_DATE }}
       BASE_LIBRARY: ${{ steps.meta-vars.outputs.BASE_LIBRARY }}
-      DOCKER_REGISTRY: ${{ steps.meta-vars.outputs.DOCKER_REGISTRY }}
+      BASE_IMAGE: ${{ steps.meta-vars.outputs.BASE_IMAGE }}
     steps:
       - name: Set build metadata
         id: meta-vars
         shell: bash -x -e {0}
         run: |
           BUILD_DATE=$(TZ='US/Los_Angeles' date '+%Y-%m-%d')
+          if [[ -z "${{ inputs.BASE_IMAGE }}" ]]; then
+            BASE_IMAGE=${{ env.DOCKER_REGISTRY }}/${{ env.BASE_LIBRARY }}:latest
+          else
+            BASE_IMAGE=${{ inputs.BASE_IMAGE }}
+          fi
           echo "BUILD_DATE=${BUILD_DATE}" >> $GITHUB_OUTPUT
           echo "BASE_LIBRARY=${{ env.BASE_LIBRARY }}" >> $GITHUB_OUTPUT
-          echo "DOCKER_REGISTRY=${{ env.DOCKER_REGISTRY }}" >> $GITHUB_OUTPUT
+          echo "BASE_IMAGE=${BASE_IMAGE}" >> $GITHUB_OUTPUT
 
   build:
     if: (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success') || github.event_name == 'workflow_dispatch'
@@ -48,7 +58,7 @@ jobs:
     with:
       BUILD_DATE: ${{ needs.metadata.outputs.BUILD_DATE }}
       BASE_LIBRARY: ${{ needs.metadata.outputs.BASE_LIBRARY }}
-      BASE_IMAGE: ${{ needs.metadata.outputs.DOCKER_REGISTRY }}/${{ needs.metadata.outputs.BASE_LIBRARY }}:latest
+      BASE_IMAGE: ${{ needs.metadata.outputs.BASE_IMAGE }}
     secrets: inherit
 
   test:

--- a/rosetta/Dockerfile.pax
+++ b/rosetta/Dockerfile.pax
@@ -12,6 +12,9 @@ ADD --keep-git-dir=true https://github.com/google/paxml.git#main /
 FROM scratch as praxis-mirror-source
 ADD --keep-git-dir=true https://github.com/google/praxis.git#main /
 
+FROM scratch as flax-mirror-source
+ADD --keep-git-dir=true https://github.com/google/flax.git#main /
+
 FROM ${BASE_IMAGE} AS distribution-builder
 
 ARG GIT_USER_EMAIL
@@ -23,7 +26,9 @@ EOF
 
 COPY --from=rosetta-source / /opt/rosetta
 WORKDIR /opt/rosetta
-RUN --mount=target=/opt/pax-mirror,from=pax-mirror-source,readwrite --mount=target=/opt/praxis-mirror,from=praxis-mirror-source,readwrite <<EOF bash -e
+RUN --mount=target=/opt/pax-mirror,from=pax-mirror-source,readwrite \
+    --mount=target=/opt/praxis-mirror,from=praxis-mirror-source,readwrite \
+    --mount=target=/opt/flax-mirror,from=flax-mirror-source,readwrite <<EOF bash -e
 bash create-distribution.sh \
   -p patchlist-paxml.txt \
   -u https://github.com/google/paxml.git \
@@ -34,12 +39,18 @@ bash create-distribution.sh \
   -u https://github.com/google/praxis.git \
   -d $(dirname $(python -c "import praxis; print(*praxis.__path__)")) \
   -e /opt/praxis-mirror
+bash create-distribution.sh \
+  -p patchlist-flax.txt \
+  -u https://github.com/google/flax.git \
+  -d $(dirname $(python -c "import flax; print(*flax.__path__)")) \
+  -e /opt/flax-mirror
 rm -rf $(find /opt -name "__pycache__")
 EOF
   
 FROM ${BASE_IMAGE} AS rosetta
 COPY --link --from=distribution-builder /opt/paxml /opt/paxml
 COPY --link --from=distribution-builder /opt/praxis /opt/praxis
+COPY --link --from=distribution-builder /opt/flax /opt/flax
 COPY --link --from=distribution-builder /opt/rosetta /opt/rosetta
 
 WORKDIR /opt/rosetta

--- a/rosetta/Dockerfile.t5x
+++ b/rosetta/Dockerfile.t5x
@@ -9,6 +9,9 @@ COPY . /
 FROM scratch as t5x-mirror-source
 ADD --keep-git-dir=true https://github.com/google-research/t5x.git#main /
 
+FROM scratch as flax-mirror-source
+ADD --keep-git-dir=true https://github.com/google/flax.git#main /
+
 FROM ${BASE_IMAGE} AS distribution-builder
 
 ARG GIT_USER_EMAIL
@@ -20,16 +23,23 @@ EOF
 
 COPY --from=rosetta-source / /opt/rosetta
 WORKDIR /opt/rosetta
-RUN --mount=target=/opt/t5x-mirror,from=t5x-mirror-source,readwrite <<EOF bash -e
+RUN --mount=target=/opt/t5x-mirror,from=t5x-mirror-source,readwrite \
+    --mount=target=/opt/flax-mirror,from=flax-mirror-source,readwrite <<EOF bash -e
 bash create-distribution.sh \
   -p patchlist-t5x.txt \
   -u https://github.com/google-research/t5x.git \
   -d $(dirname $(python -c "import t5x; print(*t5x.__path__)")) \
   -e /opt/t5x-mirror
+bash create-distribution.sh \
+  -p patchlist-flax.txt \
+  -u https://github.com/google/flax.git \
+  -d $(dirname $(python -c "import flax; print(*flax.__path__)")) \
+  -e /opt/flax-mirror
 EOF
   
 FROM ${BASE_IMAGE} AS rosetta
 COPY --link --from=distribution-builder /opt/t5x /opt/t5x
+COPY --link --from=distribution-builder /opt/flax /opt/flax
 COPY --link --from=distribution-builder /opt/rosetta /opt/rosetta
 
 WORKDIR /opt/rosetta

--- a/rosetta/patchlist-flax.txt
+++ b/rosetta/patchlist-flax.txt
@@ -1,0 +1,7 @@
+##############
+# Patch list #
+##############
+# - Internal patches (These are branches that start with "patch/")
+# - External Pull Requests (These are pull requests with upstream flax and are of the form "pull/$PULLID/head")
+# - Note: Only the first column is used as a git-ref, so anything after is a comment
+


### PR DESCRIPTION
In preparation to support some jax models in rosetta, we also need flax to be a distribution as well. This PR adds it to both the t5x and pax builds so that rosetta can build upon the install.

FWIW, pax builds can install flax in any order b/c it doesn't install flax from source, but t5x installs from source so the flax install has to happen after t5x.