### PR TITLE
Remove type hints from PAX ci config script

### DIFF
--- a/.github/container/test-pax.sh
+++ b/.github/container/test-pax.sh
@@ -199,7 +199,7 @@ class GPT126MPP(TransformerLmSpmdPipelineAdam):
   LR_COS_MAX = 1.0
 
   
-  def task(self) -> tasks_lib.SingleTask.HParams:
+  def task(self):
     task_p = super().task()
     task_p = configure_gpt3_task(self, task_p)
 
@@ -239,7 +239,7 @@ if pp > 1:
     FRPOP_DTYPE = dtype
     MAX_STEPS = steps
     
-    def task(self) -> tasks_lib.SingleTask.HParams:
+    def task(self):
       task_p = super().task()
       return task_p
 
@@ -253,7 +253,7 @@ else:
     FRPOP_DTYPE = dtype
     MAX_STEPS = steps
     
-    def task(self) -> tasks_lib.SingleTask.HParams:
+    def task(self):
       task_p = super().task()
       return task_p
 


### PR DESCRIPTION
This fixes an error due to upstream changing the case of the `HParams` variable to `hparams`. Given that the script is short and at the top level, type hints may not be as critical here.