### PR TITLE
Fixes rosetta pax build and fixes pycache cleanup for rosetta build

### DIFF
--- a/rosetta/Dockerfile.pax
+++ b/rosetta/Dockerfile.pax
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1-labs
-ARG BASE_IMAGE=ghcr.io/nvidia/paxml:latest
+ARG BASE_IMAGE=ghcr.io/nvidia/pax:latest
 ARG GIT_USER_EMAIL=jax@nvidia.com
 ARG GIT_USER_NAME=NVIDIA
 
@@ -28,7 +28,7 @@ COPY --from=rosetta-source / /opt/rosetta
 WORKDIR /opt/rosetta
 RUN --mount=target=/opt/pax-mirror,from=pax-mirror-source,readwrite \
     --mount=target=/opt/praxis-mirror,from=praxis-mirror-source,readwrite \
-    --mount=target=/opt/flax-mirror,from=flax-mirror-source,readwrite <<EOF bash -e
+    --mount=target=/opt/flax-mirror,from=flax-mirror-source,readwrite <<"EOF" bash -e
 bash create-distribution.sh \
   -p patchlist-paxml.txt \
   -u https://github.com/google/paxml.git \

--- a/rosetta/Dockerfile.t5x
+++ b/rosetta/Dockerfile.t5x
@@ -24,7 +24,7 @@ EOF
 COPY --from=rosetta-source / /opt/rosetta
 WORKDIR /opt/rosetta
 RUN --mount=target=/opt/t5x-mirror,from=t5x-mirror-source,readwrite \
-    --mount=target=/opt/flax-mirror,from=flax-mirror-source,readwrite <<EOF bash -e
+    --mount=target=/opt/flax-mirror,from=flax-mirror-source,readwrite <<"EOF" bash -e
 bash create-distribution.sh \
   -p patchlist-t5x.txt \
   -u https://github.com/google-research/t5x.git \
@@ -35,6 +35,7 @@ bash create-distribution.sh \
   -u https://github.com/google/flax.git \
   -d $(dirname $(python -c "import flax; print(*flax.__path__)")) \
   -e /opt/flax-mirror
+rm -rf $(find /opt -name "__pycache__")
 EOF
   
 FROM ${BASE_IMAGE} AS rosetta


### PR DESCRIPTION
This fixes the failing rosetta-pax build which was erroneously evaluating shell commands in the heredoc