### PR TITLE
Propagate script failure

### DIFF
--- a/.github/container/test-pax.sh
+++ b/.github/container/test-pax.sh
@@ -260,7 +260,7 @@ else:
 EOF
 
 ## Launch
-set -x
+set -ex
 python -m paxml.main \
     --exp ci_configs.Synthetic126M \
     --job_log_dir=${OUTPUT} \


### PR DESCRIPTION
`test-pax.sh` should propagate failure of tests to the return value of the script, this can be done with a bash option '-e'.