### PR TITLE
[rosetta-pax-patchlist] Allows XLA:GPU to detect the MHA pattern more easily to call fused kernels from cublas

### DIFF
--- a/rosetta/patchlist-praxis.txt
+++ b/rosetta/patchlist-praxis.txt
@@ -4,5 +4,5 @@
 # - Internal patches (These are branches that start with "patch/")
 # - External Pull Requests (These are pull requests with upstream praxis and are of the form "pull/$PULLID/head")
 # - Note: Only the first column is used as a git-ref, so anything after is a comment
-pull/18/head # This PR allows XLA:GPU to detect the MHA pattern more easily to call fused kernels from cublas.
+pull/19/head # This PR allows XLA:GPU to detect the MHA pattern more easily to call fused kernels from cublas.
 


### PR DESCRIPTION
@terrykong 