### PR TITLE
Updates t5x readme to account for code being within container

### DIFF
--- a/rosetta/patchlist-t5x.txt
+++ b/rosetta/patchlist-t5x.txt
@@ -5,4 +5,4 @@
 # - External Pull Requests (These are pull requests with upstream t5x and are of the form "pull/$PULLID/head")
 # - Note: Only the first column is used as a git-ref, so anything after is a comment
 
-pull/1320/head
+pull/1320/head  # https://github.com/google-research/t5x/pull/1320: Adds transformer engine support and GPU optimizations to T5x (enables H100)


### PR DESCRIPTION
- Add a comment to the T5X-TE patch in patchlist-t5x.txt with the link to the PR in case someone wants to look it up
- Previously, building the one-off Dockerfile and running interactively relied on scripts within t5x. Now the instructions are self-contained in the readme
- Include a section for how to "Inspecting the source code"