### PR TITLE
Fixes issue in rosetta dockerfiles where distributions were copied, but deletions weren't being respected. Switched away from multi-stage builder pattern to fix

### DIFF
--- a/rosetta/Dockerfile.pax
+++ b/rosetta/Dockerfile.pax
@@ -15,7 +15,7 @@ ADD --keep-git-dir=true https://github.com/google/praxis.git#main /
 FROM scratch as flax-mirror-source
 ADD --keep-git-dir=true https://github.com/google/flax.git#main /
 
-FROM ${BASE_IMAGE} AS distribution-builder
+FROM ${BASE_IMAGE} AS rosetta
 
 ARG GIT_USER_EMAIL
 ARG GIT_USER_NAME
@@ -47,14 +47,9 @@ bash create-distribution.sh \
 rm -rf $(find /opt -name "__pycache__")
 EOF
   
-FROM ${BASE_IMAGE} AS rosetta
-COPY --link --from=distribution-builder /opt/paxml /opt/paxml
-COPY --link --from=distribution-builder /opt/praxis /opt/praxis
-COPY --link --from=distribution-builder /opt/flax /opt/flax
-COPY --link --from=distribution-builder /opt/rosetta /opt/rosetta
-
 WORKDIR /opt/rosetta
 RUN <<EOF
+rmdir /opt/*-mirror
 pip install -e /opt/rosetta
 rm -rf ~/.cache/pip/
 EOF

--- a/rosetta/Dockerfile.t5x
+++ b/rosetta/Dockerfile.t5x
@@ -12,7 +12,7 @@ ADD --keep-git-dir=true https://github.com/google-research/t5x.git#main /
 FROM scratch as flax-mirror-source
 ADD --keep-git-dir=true https://github.com/google/flax.git#main /
 
-FROM ${BASE_IMAGE} AS distribution-builder
+FROM ${BASE_IMAGE} AS rosetta
 
 ARG GIT_USER_EMAIL
 ARG GIT_USER_NAME
@@ -38,13 +38,9 @@ bash create-distribution.sh \
 rm -rf $(find /opt -name "__pycache__")
 EOF
   
-FROM ${BASE_IMAGE} AS rosetta
-COPY --link --from=distribution-builder /opt/t5x /opt/t5x
-COPY --link --from=distribution-builder /opt/flax /opt/flax
-COPY --link --from=distribution-builder /opt/rosetta /opt/rosetta
-
 WORKDIR /opt/rosetta
 RUN <<EOF bash -e
+rmdir /opt/*-mirror
 pip install -e /opt/rosetta
 rm -rf ~/.cache/pip/
 EOF


### PR DESCRIPTION
@ashors1 reported this issue where distributions had files that were supposed to be deleted in commits in the patchlist. The issue was that `COPY` was used to copy from the builder to the `rosetta` stage, which would be fine for everything except deletions or for files that were renamed. The simple fix is to remove the distribution-builder for now. The image size of building the distribution is still very small (<2MB), so we're not losing much