### PR TITLE
Skip PR CI if only files change are readme markdown

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -2,6 +2,8 @@ name: CI
 
 on:
   pull_request:
+    paths-ignore:
+      - '**.md'
   workflow_dispatch:
     inputs:
       CUDA_IMAGE:


### PR DESCRIPTION
CI doesn't need to run if the only change is to the markdown.