### PR TITLE
update slurm logging on all slurm workflows to tail the log file and print partition and state info

### DIFF
--- a/.github/workflows/_test_pax.yaml
+++ b/.github/workflows/_test_pax.yaml
@@ -96,14 +96,24 @@ jobs:
               $([[ ${{ steps.meta.outputs.TOTAL_TASKS }} > 1 ]] && echo --multiprocess)
           EOF
           )
+          echo "SLURM Partition Status"
+          sshx sinfo
 
           set +x
-          while sshx squeue -j $JOB | grep -q $JOB; do
-            echo "SLURM Job $JOB is still running."
+          while true; do 
+            sshx 'tail -f ${{ steps.meta.outputs.LOG_FILE }} 2>/dev/null || echo "[WARNING]: sbatch_output=${{ steps.meta.outputs.LOG_FILE }} not created yet"'
+            sleep 15
+          done &
+          tail_pid=$!
+
+          STATE=$(sshx "squeue -j $JOB -o '%T' --noheader 2>/dev/null")
+          while [[ -n "$STATE" ]]; do
+            STATE=$(sshx "squeue -j $JOB -o '%T' --noheader 2>/dev/null")
+            echo "$JOB is ${STATE:-n/a}"
             sleep 15
           done
-
-          echo "SLURM Job $JOB finished."
+          echo "SLRUM Job $JOB finished."
+          kill $tail_pid
 
           CKPT_PATH=${{ steps.meta.outputs.MODEL_PATH }}/${{ steps.meta.outputs.TEST_CASE_NAME }}/checkpoints
           if sshx -q [[ -d $CKPT_PATH ]]; then sshx rm -r $CKPT_PATH; fi

--- a/.github/workflows/_test_t5x.yaml
+++ b/.github/workflows/_test_t5x.yaml
@@ -86,13 +86,24 @@ jobs:
               --steps-per-epoch 100
           EOF
           )
+          echo "SLURM Partition Status"
+          sshx sinfo
 
           set +x
-          while sshx squeue -j $JOB | grep -q $JOB; do
-            echo "SLURM Job $JOB is still running."
+          while true; do 
+            sshx 'tail -f ${{ steps.meta.outputs.LOG_FILE }} 2>/dev/null || echo "[WARNING]: sbatch_output=${{ steps.meta.outputs.LOG_FILE }} not created yet"'
+            sleep 15
+          done &
+          tail_pid=$!
+
+          STATE=$(sshx "squeue -j $JOB -o '%T' --noheader 2>/dev/null")
+          while [[ -n "$STATE" ]]; do
+            STATE=$(sshx "squeue -j $JOB -o '%T' --noheader 2>/dev/null")
+            echo "$JOB is ${STATE:-n/a}"
             sleep 15
           done
           echo "SLRUM Job $JOB finished."
+          kill $tail_pid
           set -x
 
       - name: Retrieve training logs and upload to TensorBoard server
@@ -189,13 +200,24 @@ jobs:
               --multiprocess
           EOF
           )
+          echo "SLURM Partition Status"
+          sshx sinfo
 
           set +x
-          while sshx squeue -j $JOB | grep -q $JOB; do
-            echo "SLURM Job $JOB is still running."
+          while true; do 
+            sshx 'tail -f ${{ steps.meta.outputs.LOG_FILE }} 2>/dev/null || echo "[WARNING]: sbatch_output=${{ steps.meta.outputs.LOG_FILE }} not created yet"'
+            sleep 15
+          done &
+          tail_pid=$!
+
+          STATE=$(sshx "squeue -j $JOB -o '%T' --noheader 2>/dev/null")
+          while [[ -n "$STATE" ]]; do
+            STATE=$(sshx "squeue -j $JOB -o '%T' --noheader 2>/dev/null")
+            echo "$JOB is ${STATE:-n/a}"
             sleep 15
           done
           echo "SLRUM Job $JOB finished."
+          kill $tail_pid
           set -x
 
       - name: Retrieve training logs and upload to TensorBoard server

--- a/.github/workflows/_test_te.yaml
+++ b/.github/workflows/_test_te.yaml
@@ -133,13 +133,24 @@ jobs:
                      test_model_parallel_encoder.py'
           EOF
           )
+          echo "SLURM Partition Status"
+          sshx sinfo
 
           set +x
-          while sshx squeue -j $JOB | grep -q $JOB; do
-            echo "SLURM Job $JOB is still running."
+          while true; do 
+            sshx 'tail -f ${{ steps.meta.outputs.SLURM_LOG_FILE }} 2>/dev/null || echo "[WARNING]: sbatch_output=${{ steps.meta.outputs.SLURM_LOG_FILE }} not created yet"'
+            sleep 15
+          done &
+          tail_pid=$!
+
+          STATE=$(sshx "squeue -j $JOB -o '%T' --noheader 2>/dev/null")
+          while [[ -n "$STATE" ]]; do
+            STATE=$(sshx "squeue -j $JOB -o '%T' --noheader 2>/dev/null")
+            echo "$JOB is ${STATE:-n/a}"
             sleep 15
           done
           echo "SLRUM Job $JOB finished."
+          kill $tail_pid
           set -x
 
       - name: Retrieve training logs


### PR DESCRIPTION
Previously the only logging was the slurm state, which made it difficult to tell whether the job was running, but hung, or stuck in the queue.

The change also tails the slurm logs to stdout which should make debugging easier.