### PR TITLE
Use SKIP_HEAD_INSTALLS to prevent pax installation from overwriting jax

### DIFF
--- a/.github/container/Dockerfile.pax
+++ b/.github/container/Dockerfile.pax
@@ -17,7 +17,9 @@ install-flax.sh --defer
 install-te.sh --defer
 
 if [[ -f /opt/requirements-defer.txt ]]; then
-  pip install -r /opt/requirements-defer.txt
+  # SKIP_HEAD_INSTALLS avoids having to install jax from Github source so that
+  # we do not overwrite the jax that was already installed.
+  SKIP_HEAD_INSTALLS=true pip install -r /opt/requirements-defer.txt
 fi
 if [[ -f /opt/cleanup.sh ]]; then
   bash -ex /opt/cleanup.sh


### PR DESCRIPTION
This issue did not show up until recently. Building images with past git-refs/SHAs caused issues since paxml & praxis install the latest jax but if jax was installed with an older commit, we could have conflicts with the API.

`SKIP_HEAD_INSTALLS` was an env var introduced in https://github.com/google/praxis/pull/20 and later mirrored in paxml