### PR TITLE
Updates test-t5x.sh by removing t5 installation and support --additional-args

### DIFF
--- a/.github/workflows/_test_t5x.yaml
+++ b/.github/workflows/_test_t5x.yaml
@@ -92,7 +92,7 @@ jobs:
               --dtype bfloat16 \
               --batch-size ${{ steps.meta.outputs.BATCH_SIZE }} \
               --epochs 7 \
-              --steps-per-epoch 100 ${{ inputs.EXTRA_GIN_ARGS != '' && format('--additional-args \"{}\"', inputs.EXTRA_GIN_ARGS) || '' }}
+              --steps-per-epoch 100 ${{ inputs.EXTRA_GIN_ARGS != '' && format('--additional-args "{0}"', inputs.EXTRA_GIN_ARGS) || '' }}
           EOF
           )
 
@@ -214,7 +214,7 @@ jobs:
               --batch-size ${{ steps.meta.outputs.BATCH_SIZE }} \
               --epochs 7 \
               --steps-per-epoch 100 \
-              --multiprocess ${{ inputs.EXTRA_GIN_ARGS != '' && format('--additional-args \"{}\"', inputs.EXTRA_GIN_ARGS) || '' }}
+              --multiprocess ${{ inputs.EXTRA_GIN_ARGS != '' && format('--additional-args "{0}"', inputs.EXTRA_GIN_ARGS) || '' }}
           EOF
           )
 

--- a/.github/workflows/_test_t5x.yaml
+++ b/.github/workflows/_test_t5x.yaml
@@ -92,7 +92,8 @@ jobs:
               --dtype bfloat16 \
               --batch-size ${{ steps.meta.outputs.BATCH_SIZE }} \
               --epochs 7 \
-              --steps-per-epoch 100 ${{ inputs.EXTRA_GIN_ARGS != '' && format('--additional-args "{0}"', inputs.EXTRA_GIN_ARGS) || '' }}
+              --steps-per-epoch 100 \
+              ${{ inputs.EXTRA_GIN_ARGS != '' && format('--additional-args "{0}"', inputs.EXTRA_GIN_ARGS) || '' }}
           EOF
           )
 
@@ -214,7 +215,8 @@ jobs:
               --batch-size ${{ steps.meta.outputs.BATCH_SIZE }} \
               --epochs 7 \
               --steps-per-epoch 100 \
-              --multiprocess ${{ inputs.EXTRA_GIN_ARGS != '' && format('--additional-args "{0}"', inputs.EXTRA_GIN_ARGS) || '' }}
+              --multiprocess \
+              ${{ inputs.EXTRA_GIN_ARGS != '' && format('--additional-args "{0}"', inputs.EXTRA_GIN_ARGS) || '' }}
           EOF
           )
 

--- a/.github/workflows/_test_t5x.yaml
+++ b/.github/workflows/_test_t5x.yaml
@@ -13,6 +13,11 @@ on:
         description: Batch size per GPU
         default: 32
         required: false
+      EXTRA_GIN_ARGS:
+        type: string
+        description: Extra gin args to pass to test-t5x.sh
+        default: ""
+        required: false
     outputs:
       TEST_STATUS:
         description: 'Summary pass/fail value indicating if results from tests are acceptable'
@@ -87,7 +92,7 @@ jobs:
               --dtype bfloat16 \
               --batch-size ${{ steps.meta.outputs.BATCH_SIZE }} \
               --epochs 7 \
-              --steps-per-epoch 100
+              --steps-per-epoch 100 ${{ inputs.EXTRA_GIN_ARGS != '' && format('--additional-args \"{}\"', inputs.EXTRA_GIN_ARGS) || '' }}
           EOF
           )
 
@@ -209,7 +214,7 @@ jobs:
               --batch-size ${{ steps.meta.outputs.BATCH_SIZE }} \
               --epochs 7 \
               --steps-per-epoch 100 \
-              --multiprocess
+              --multiprocess ${{ inputs.EXTRA_GIN_ARGS != '' && format('--additional-args \"{}\"', inputs.EXTRA_GIN_ARGS) || '' }}
           EOF
           )
 

--- a/.github/workflows/nightly-rosetta-t5x-build-test.yaml
+++ b/.github/workflows/nightly-rosetta-t5x-build-test.yaml
@@ -137,6 +137,8 @@ jobs:
     if: (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success') || github.event_name == 'workflow_dispatch'
     with:
       T5X_IMAGE: ${{ needs.build.outputs.DOCKER_TAGS }}
+      # Disable packing b/c rosetta-t5x images run with TE by default, and TE does not currently support packing
+      EXTRA_GIN_ARGS: "--gin.train/utils.DatasetConfig.pack=False --gin.train_eval/utils.DatasetConfig.pack=False"
     secrets: inherit
 
   publish-t5x:

--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@
 [workflow-jax]: https://github.com/NVIDIA/JAX-Toolbox/actions/workflows/nightly-jax-build.yaml
 [workflow-t5x]: https://github.com/NVIDIA/JAX-Toolbox/actions/workflows/nightly-t5x-build.yaml
 [workflow-pax]: https://github.com/NVIDIA/JAX-Toolbox/actions/workflows/nightly-pax-build.yaml
-[workflow-rosetta-t5x]: https://github.com/NVIDIA/JAX-Toolbox/actions/workflows/nightly-rosetta-t5x-build.yaml
+[workflow-rosetta-t5x]: https://github.com/NVIDIA/JAX-Toolbox/actions/workflows/nightly-rosetta-t5x-build-test.yaml
 [workflow-rosetta-pax]: https://github.com/NVIDIA/JAX-Toolbox/actions/workflows/nightly-rosetta-pax-build.yaml
 [workflow-te]: https://github.com/NVIDIA/JAX-Toolbox/actions/workflows/nightly-te-build.yaml
 


### PR DESCRIPTION
This change removes `t5` installation as that is no longer needed as of this commit that adds t5 back into the gpu extra in t5x: https://github.com/google-research/t5x/commit/f3a18e96cbc923d0fa36f4666796cc3510416a3c

The other change this introduces is `--additional-args` to test-t5x.sh. This will allow us to test with additional flags not present in the script to test experimental configurations without making a code change. Here is an example of how you can use it to turn off packing, which is not yet supported by TE:

### Before
```bash
test-t5x.sh \
  --output /tmp \
  --dtype bfloat16 \
  --batch-size 32 \
  --epochs 7 \
  --steps-per-epoch 100
```
### After
```bash
test-t5x.sh \
  --output /tmp \
  --dtype bfloat16 \
  --batch-size 32 \
  --epochs 7 \
  --steps-per-epoch 100 \
  --additional-args "--gin.train/utils.DatasetConfig.pack=False --gin.train_eval/utils.DatasetConfig.pack=False"
```

To pass these new flags to test-t5x.sh, the reusable workflow `_test_t5x.yaml` has a new input `EXTRA_GIN_ARGS` that forwards these flags to the script.