### PR TITLE
[Rosetta T5x] - create overall badge from each test reusable workflow in rosetta-t5x's nightly workflow

### DIFF
--- a/.github/workflows/_publish_badge.yaml
+++ b/.github/workflows/_publish_badge.yaml
@@ -16,11 +16,17 @@ on:
         description: Upload the endpoint file as GitHub gist?
         default: false
         required: true
+    outputs:
+      STATUS:
+        description: 'Summary pass/fail value indicating if badge results are acceptable overall'
+        value: ${{ jobs.publish.outputs.STATUS }}
 
 
 jobs:
   publish:
     runs-on: ubuntu-22.04
+    outputs:
+      STATUS: ${{ steps.script.outputs.STATUS }}
     steps:
       - name: Download all artifacts from the previous jobs
         uses: actions/download-artifact@v3

--- a/.github/workflows/_test_rosetta.yaml
+++ b/.github/workflows/_test_rosetta.yaml
@@ -86,8 +86,8 @@ jobs:
           FAILED_TESTS=$(cnt_type failed)
           PASSED_TESTS=$(cnt_type passed)
           TOTAL_TESTS=$(all_outcomes | wc -l)
-          echo "Unit/Integration test breakdown:"
-          all_outcomes | sort | uniq -c
+          echo "## Unit/Integration test breakdown" | tee -a $GITHUB_STEP_SUMMARY
+          all_outcomes | sort | uniq -c | tee -a $GITHUB_STEP_SUMMARY
           if [[ $FAILED_TESTS -eq 0 ]] && [[ $TOTAL_TESTS -gt 0 ]]; then
             BADGE_COLOR=brightgreen
             echo "TEST_STATUS=success" >> $GITHUB_OUTPUT

--- a/.github/workflows/_test_rosetta.yaml
+++ b/.github/workflows/_test_rosetta.yaml
@@ -14,7 +14,7 @@ on:
         value: ${{ jobs.rosetta-tests.outputs.TEST_ARTIFACT_NAME }}
       TEST_STATUS:
         description: 'Summary pass/fail value indicating if results from tests are acceptable'
-        value: ${{ jobs.publish-test.outputs.TEST_STATUS }}
+        value: ${{ jobs.publish-test.outputs.STATUS }}
 
 env:
   TEST_ARTIFACT_NAME: test-logs
@@ -90,9 +90,9 @@ jobs:
           all_outcomes | sort | uniq -c | tee -a $GITHUB_STEP_SUMMARY
           if [[ $FAILED_TESTS -eq 0 ]] && [[ $TOTAL_TESTS -gt 0 ]]; then
             BADGE_COLOR=brightgreen
-            echo "TEST_STATUS=success" >> $GITHUB_OUTPUT
+            echo "STATUS=success" >> $GITHUB_OUTPUT
           else
-            echo "TEST_STATUS=failure" >> $GITHUB_OUTPUT
+            echo "STATUS=failure" >> $GITHUB_OUTPUT
             if [[ $PASSED_TESTS -eq 0 ]]; then
               BADGE_COLOR=red
             else

--- a/.github/workflows/_test_t5x.yaml
+++ b/.github/workflows/_test_t5x.yaml
@@ -21,7 +21,7 @@ on:
     outputs:
       TEST_STATUS:
         description: 'Summary pass/fail value indicating if results from tests are acceptable'
-        value: ${{ jobs.publish-test.outputs.TEST_STATUS }}
+        value: ${{ jobs.publish-test.outputs.STATUS }}
 
 jobs:
 
@@ -294,13 +294,13 @@ jobs:
         jq -rc 'input_filename,.' $EXIT_STATUSES
 
         if [[ $FAILED_TESTS -eq 0 ]] && [[ $TOTAL_TESTS -gt 0 ]] || [[ $PASSED_TESTS -eq $TOTAL_TESTS ]]; then
-          echo "TEST_STATUS=success" >> $GITHUB_OUTPUT
+          echo "STATUS=success" >> $GITHUB_OUTPUT
           BADGE_COLOR=brightgreen
         elif [[ $PASSED_TESTS -eq 0 ]]; then
-          echo "TEST_STATUS=failure" >> $GITHUB_OUTPUT
+          echo "STATUS=failure" >> $GITHUB_OUTPUT
           BADGE_COLOR=red
         else
-          echo "TEST_STATUS=failure" >> $GITHUB_OUTPUT
+          echo "STATUS=failure" >> $GITHUB_OUTPUT
           BADGE_COLOR=yellow
         fi
         echo "LABEL='Completion'" >> $GITHUB_OUTPUT

--- a/.github/workflows/_test_t5x.yaml
+++ b/.github/workflows/_test_t5x.yaml
@@ -282,6 +282,14 @@ jobs:
         FAILED_TESTS=$(jq -r '. | select ((.state != "COMPLETED") or (.exitcode != "0")) | .state' $EXIT_STATUSES | wc -l)
         TOTAL_TESTS=$(ls $EXIT_STATUSES | wc -l)
 
+        echo '## T5x MGMN+SPMD Test Status' >> $GITHUB_STEP_SUMMARY
+        for i in $EXIT_STATUSES; do
+          echo $i | cut -d'.' -f1
+          echo '```json'
+          jq . $i
+          echo '```'
+        done | tee -a $GITHUB_STEP_SUMMARY
+
         echo "Test statuses:"
         jq -rc 'input_filename,.' $EXIT_STATUSES
 

--- a/.github/workflows/nightly-rosetta-t5x-build-test.yaml
+++ b/.github/workflows/nightly-rosetta-t5x-build-test.yaml
@@ -116,7 +116,7 @@ jobs:
     if: ( always() )
     secrets: inherit
     with:
-      ENDPOINT_FILENAME: 'rosetta-t5x-test-status.json'
+      ENDPOINT_FILENAME: 'rosetta-t5x-overall-test-status.json'
       PUBLISH: ${{ github.event_name == 'workflow_run' || needs.metadata.outputs.PUBLISH == 'true' }}
       SCRIPT: |
         UNIT_STATUS=${{ needs.test-unit.outputs.TEST_STATUS }}

--- a/.github/workflows/nightly-rosetta-t5x-build-test.yaml
+++ b/.github/workflows/nightly-rosetta-t5x-build-test.yaml
@@ -91,46 +91,6 @@ jobs:
       ROSETTA_IMAGE: ${{ needs.build.outputs.DOCKER_TAGS }}
     secrets: inherit
 
-  publish-test-unit:
-    needs: [metadata, build, test-unit]
-    uses: ./.github/workflows/_publish_badge.yaml
-    if: ( success() || failure() ) && (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success') || github.event_name == 'workflow_dispatch'
-    secrets: inherit
-    with:
-      ENDPOINT_FILENAME: 'rosetta-t5x-test-status.json'
-      PUBLISH: ${{ github.event_name == 'workflow_run' || needs.metadata.outputs.PUBLISH == 'true' }}
-      SCRIPT: |
-        ARTIFACTS="${{ needs.test-unit.outputs.TEST_ARTIFACT_NAME }}/*.jsonl"
-        all_outcomes() {
-          cat $ARTIFACTS | jq -r '. | select((.["$report_type"] == "TestReport") and (.when == "call")) | .outcome'
-        }
-        cnt_type() {
-          cat $ARTIFACTS | jq '. | select((.["$report_type"] == "TestReport") and (.when == "call") and (.outcome | contains("'${1}'"))) | .outcome' | wc -l
-        }
-        SKIPPED_TESTS=$(cnt_type skipped)
-        FAILED_TESTS=$(cnt_type failed)
-        PASSED_TESTS=$(cnt_type passed)
-        TOTAL_TESTS=$(all_outcomes | wc -l)
-        echo "Unit/Integration test breakdown:"
-        all_outcomes | sort | uniq -c
-        if [[ $FAILED_TESTS -eq 0 ]] && [[ $TOTAL_TESTS -gt 0 ]]; then
-          BADGE_COLOR=brightgreen
-        else
-          if [[ $PASSED_TESTS -eq 0 ]]; then
-            BADGE_COLOR=red
-          else
-            BADGE_COLOR=yellow
-          fi
-        fi
-        echo "LABEL='V100'" >> $GITHUB_OUTPUT
-        if [[ ${{ needs.build.result }} == "success" ]]; then
-          echo "MESSAGE='${PASSED_TESTS}/${SKIPPED_TESTS}/${FAILED_TESTS} pass/skip/fail'" >> $GITHUB_OUTPUT
-          echo "COLOR='${BADGE_COLOR}'" >> $GITHUB_OUTPUT
-        else
-          echo "MESSAGE='n/a'" >> $GITHUB_OUTPUT
-          echo "COLOR='red'" >> $GITHUB_OUTPUT
-        fi
-
   test-t5x:
     needs: build
     uses: ./.github/workflows/_test_t5x.yaml
@@ -149,6 +109,42 @@ jobs:
       BUILD_DATE: ${{ needs.metadata.outputs.BUILD_DATE }}
       EXPERIMENT_SUBDIR: ROSETTA_T5X
     secrets: inherit
+
+  publish-test:
+    needs: [metadata, build, test-unit, test-t5x]
+    uses: ./.github/workflows/_publish_badge.yaml
+    if: ( always() )
+    secrets: inherit
+    with:
+      ENDPOINT_FILENAME: 'rosetta-t5x-test-status.json'
+      PUBLISH: ${{ github.event_name == 'workflow_run' || needs.metadata.outputs.PUBLISH == 'true' }}
+      SCRIPT: |
+        UNIT_STATUS=${{ needs.test-unit.outputs.TEST_STATUS }}
+        T5X_STATUS=${{ needs.test-t5x.outputs.TEST_STATUS }}
+
+        echo "LABEL='Tests'" >> $GITHUB_OUTPUT
+
+        if [[ ${{ needs.build.result }} == "success" ]]; then
+          if [[ $UNIT_STATUS == "success" ]] && [[ $T5X_STATUS == "success" ]]; then
+            COLOR=brightgreen
+            MESSAGE="Unit passed / MGMN passed"
+          elif [[ $UNIT_STATUS == "success" ]]; then 
+            COLOR=yellow
+            MESSAGE="Unit passed / MGMN failed"
+          elif [[ $T5X_STATUS == "success" ]]; then
+            COLOR=yellow
+            MESSAGE="Unit failed / MGMN passed"
+          else
+            COLOR=red
+            MESSAGE="Unit failed / MGMN failed"
+          fi
+        else
+          MESSAGE="n/a"
+          COLOR="red"
+        fi
+
+        echo "MESSAGE='${MESSAGE}'" >> $GITHUB_OUTPUT
+        echo "COLOR='${COLOR}'" >> $GITHUB_OUTPUT
 
   publish-latest-container:
     needs: [metadata, build, test-t5x, test-unit]

--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@
 [test-badge-pax]: https://img.shields.io/endpoint?url=https%3A%2F%2Fgist.githubusercontent.com%2Fnvjax%2F913c2af68649fe568e9711c2dabb23ae%2Fraw%2Fpax-test-completion-status.json&logo=nvidia
 [unit-test-badge-te]: https://img.shields.io/endpoint?url=https%3A%2F%2Fgist.githubusercontent.com%2Fnvjax%2F913c2af68649fe568e9711c2dabb23ae%2Fraw%2Fte-unit-test-status.json&logo=nvidia
 [integration-test-badge-te]: https://img.shields.io/endpoint?url=https%3A%2F%2Fgist.githubusercontent.com%2Fnvjax%2F913c2af68649fe568e9711c2dabb23ae%2Fraw%2Fte-integration-test-status.json&logo=nvidia
-[test-badge-rosetta-t5x]: https://img.shields.io/endpoint?url=https%3A%2F%2Fgist.githubusercontent.com%2Fnvjax%2F913c2af68649fe568e9711c2dabb23ae%2Fraw%2Frosetta-t5x-test-status.json&logo=nvidia
+[test-badge-rosetta-t5x]: https://img.shields.io/endpoint?url=https%3A%2F%2Fgist.githubusercontent.com%2Fnvjax%2F913c2af68649fe568e9711c2dabb23ae%2Fraw%2Frosetta-t5x-overall-test-status.json&logo=nvidia
 [test-badge-rosetta-pax]: https://img.shields.io/endpoint?url=https%3A%2F%2Fgist.githubusercontent.com%2Fnvjax%2F913c2af68649fe568e9711c2dabb23ae%2Fraw%2Frosetta-pax-test-status.json&logo=nvidia
 
 [workflow-jax-unit]: https://github.com/NVIDIA/JAX-Toolbox/actions/workflows/nightly-jax-test-unit.yaml


### PR DESCRIPTION
- Also adds outputs.STATUS to _publish_badge.yaml to allow the status from the badge logic to be read by downstream jobs and an overall badge job
- Updates the rosetta-t5x test badge on the front page readme