### PR TITLE
Revert "Bump CUDA version to 12.2.0-devel-ubuntu22.04"

### DIFF
--- a/.github/workflows/_build_base.yaml
+++ b/.github/workflows/_build_base.yaml
@@ -7,7 +7,7 @@ on:
         type: string
         description: 'Base CUDA image:'
         required: false
-        default: nvidia/cuda:12.2.0-devel-ubuntu22.04
+        default: nvidia/cuda:12.1.1-devel-ubuntu22.04
       BUILD_DATE:
         type: string
         description: "Build date in YYYY-MM-DD format"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -10,7 +10,7 @@ on:
         type: string
         description: 'Base CUDA image:'
         required: false
-        default: 'nvidia/cuda:12.2.0-devel-ubuntu22.04'
+        default: 'nvidia/cuda:12.1.1-devel-ubuntu22.04'
       SRC_JAX:
         description: 'JAX source: <repo>#<branch|tag|commit>'
         type: string
@@ -103,7 +103,7 @@ jobs:
     needs: metadata
     uses: ./.github/workflows/_build_base.yaml
     with:
-      BASE_IMAGE: ${{ inputs.CUDA_IMAGE || 'nvidia/cuda:12.2.0-devel-ubuntu22.04' }}
+      BASE_IMAGE: ${{ inputs.CUDA_IMAGE || 'nvidia/cuda:12.1.1-devel-ubuntu22.04' }}
       BUILD_DATE: ${{ needs.metadata.outputs.BUILD_DATE }}
     secrets: inherit
 


### PR DESCRIPTION
Reverts NVIDIA/JAX-Toolbox#161

Proposing the reversion of the 12.2 bump. The images produced from the base cuda 12.2.0 image are not functioning and all tests on the CI have been failing for a few days now. I have also seen this fail on my workstation and on selene. It might be better to revert this until we know what's going on. I have attached an image to the issue below to help debug in parallel.

Related: https://github.com/NVIDIA/JAX-Toolbox/issues/165