### PR TITLE
Add soft link for `nsys`. Fixes #170

### DIFF
--- a/.github/container/Dockerfile.base
+++ b/.github/container/Dockerfile.base
@@ -36,3 +36,9 @@ RUN install-cudnn.sh
 
 ADD install-ofed.sh /usr/local/bin
 RUN install-ofed.sh
+
+###############################################################################
+## Emergency fix: nsys not in PATH
+###############################################################################
+
+RUN ln -s /opt/nvidia/nsight-compute/*/host/target-linux-x64/nsys /usr/local/cuda/bin


### PR DESCRIPTION
`nsys` is inherited from `nvidia/cuda`. While it is not clear why it was not added to PATH there, we will add a link for it in `/usr/local/cuda/bin`, which is a path in `PATH`, in `jax-toolbox:base` as an emergency fix.