### PR TITLE
Remove multiple definitions of base CUDA version, revert default to 12.1.1

### DIFF
--- a/.github/container/Dockerfile.base
+++ b/.github/container/Dockerfile.base
@@ -1,4 +1,4 @@
-ARG BASE_IMAGE=nvidia/cuda:12.2.0-devel-ubuntu22.04
+ARG BASE_IMAGE=nvidia/cuda:12.1.1-devel-ubuntu22.04
 FROM ${BASE_IMAGE}
 
 ###############################################################################

--- a/.github/workflows/_build_base.yaml
+++ b/.github/workflows/_build_base.yaml
@@ -5,9 +5,9 @@ on:
     inputs:
       BASE_IMAGE:
         type: string
-        description: 'Base CUDA image:'
+        description: 'Base CUDA image, e.g. nvidia/cuda:X.Y.Z-devel-ubuntu22.04'
         required: false
-        default: nvidia/cuda:12.2.0-devel-ubuntu22.04
+        default: latest
       BUILD_DATE:
         type: string
         description: "Build date in YYYY-MM-DD format"
@@ -77,8 +77,8 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |
-            BASE_IMAGE=${{ inputs.BASE_IMAGE }}
             BUILD_DATE=${{ inputs.BUILD_DATE }}
+            ${{ inputs.BASE_IMAGE != 'latest' && format('BASE_IMAGE: {0}', inputs.BASE_IMAGE) }}
 
       # Temporary workaround until the following issues are solved:
       # https://github.com/orgs/community/discussions/17245

--- a/.github/workflows/_build_base.yaml
+++ b/.github/workflows/_build_base.yaml
@@ -78,7 +78,7 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |
             BUILD_DATE=${{ inputs.BUILD_DATE }}
-            ${{ inputs.BASE_IMAGE != 'latest' && format('BASE_IMAGE: {0}', inputs.BASE_IMAGE) }}
+            ${{ inputs.BASE_IMAGE != 'latest' && format('BASE_IMAGE={0}', inputs.BASE_IMAGE) }}
 
       # Temporary workaround until the following issues are solved:
       # https://github.com/orgs/community/discussions/17245

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -8,9 +8,9 @@ on:
     inputs:
       CUDA_IMAGE:
         type: string
-        description: 'Base CUDA image:'
+        description: 'Base CUDA image, e.g. nvidia/cuda:X.Y.Z-devel-ubuntu22.04'
         required: false
-        default: 'nvidia/cuda:12.2.0-devel-ubuntu22.04'
+        default: 'latest'
       SRC_JAX:
         description: 'JAX source: <repo>#<branch|tag|commit>'
         type: string
@@ -103,8 +103,8 @@ jobs:
     needs: metadata
     uses: ./.github/workflows/_build_base.yaml
     with:
-      BASE_IMAGE: ${{ inputs.CUDA_IMAGE || 'nvidia/cuda:12.2.0-devel-ubuntu22.04' }}
       BUILD_DATE: ${{ needs.metadata.outputs.BUILD_DATE }}
+      ${{ inputs.CUDA_IMAGE != 'latest' && format('BASE_IMAGE: {0}', inputs.CUDA_IMAGE) }}
     secrets: inherit
 
   build-jax:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -103,7 +103,7 @@ jobs:
     needs: metadata
     uses: ./.github/workflows/_build_base.yaml
     with:
-      BASE_IMAGE: ${{ inputs.CUDA_IMAGE }}
+      BASE_IMAGE: ${{ inputs.CUDA_IMAGE || 'latest' }}
       BUILD_DATE: ${{ needs.metadata.outputs.BUILD_DATE }}
     secrets: inherit
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -103,8 +103,8 @@ jobs:
     needs: metadata
     uses: ./.github/workflows/_build_base.yaml
     with:
+      BASE_IMAGE: ${{ inputs.CUDA_IMAGE }}
       BUILD_DATE: ${{ needs.metadata.outputs.BUILD_DATE }}
-      ${{ inputs.CUDA_IMAGE != 'latest' && format('BASE_IMAGE: {0}', inputs.CUDA_IMAGE) }}
     secrets: inherit
 
   build-jax:


### PR DESCRIPTION
This PR addresses #176 and #159 in a single shot.

The default CUDA version will only be encoded in `Dockerfile.base`. A default value of `latest` will be passed between various workflows and eventually being properly resolved into the `BASE_IMAGE` build arg by the `_build_base.yaml` workflow.

Closes #176
Closes #159