### PR TITLE
Fix pytest baselines path for PAX MGMN metrics

### DIFF
--- a/.github/workflows/baselines/test_pax_mgmn_metrics.py
+++ b/.github/workflows/baselines/test_pax_mgmn_metrics.py
@@ -22,7 +22,7 @@ E2E_TIME_MULT = {
     "2DP2TP4PP":  0.95,
 }
 test_dir = os.path.dirname(os.path.abspath(__file__))
-baselines_dir = os.path.join(test_dir, "../PAX_MGMN")
+baselines_dir = os.path.join(test_dir, "PAX_MGMN")
 results_dir = os.environ.get("RESULTS_DIR")
 loss_summary_name = "loss"
 step_time_summary_name = "Steps/sec"


### PR DESCRIPTION
I must have forgotten to correct this when I restructured the files.