### PR TITLE
Make pax/praxis editable again

### DIFF
--- a/.github/container/install-flax.sh
+++ b/.github/container/install-flax.sh
@@ -76,4 +76,6 @@ set -ex
 git clone ${FLAX_REPO} ${INSTALL_DIR}
 cd ${INSTALL_DIR}
 git checkout ${FLAX_REF}
+# We currently require installing editable (-e) to build a distribution since
+# we edit the source in place and do not re-install
 maybe_defer_pip_install -e ${INSTALL_DIR}

--- a/.github/container/install-pax.sh
+++ b/.github/container/install-pax.sh
@@ -136,6 +136,8 @@ popd
 # required by both praxis and paxml, and fiddle at head is only required by
 # praxis
 HEAD_PACKAGES="jax fiddle"
+# We currently require installing editable (-e) to build a distribution since
+# we edit the source in place and do not re-install
 SKIP_HEAD_INSTALLS=true maybe_defer_pip_install -e ${PRAXIS_INSTALLED_DIR}
 SKIP_HEAD_INSTALLS=true maybe_defer_pip_install -e ${PAXML_INSTALLED_DIR}[gpu] $HEAD_PACKAGES
 

--- a/.github/container/install-pax.sh
+++ b/.github/container/install-pax.sh
@@ -136,8 +136,8 @@ popd
 # required by both praxis and paxml, and fiddle at head is only required by
 # praxis
 HEAD_PACKAGES="jax fiddle"
-SKIP_HEAD_INSTALLS=true maybe_defer_pip_install ${PRAXIS_INSTALLED_DIR}
-SKIP_HEAD_INSTALLS=true maybe_defer_pip_install ${PAXML_INSTALLED_DIR}[gpu] $HEAD_PACKAGES
+SKIP_HEAD_INSTALLS=true maybe_defer_pip_install -e ${PRAXIS_INSTALLED_DIR}
+SKIP_HEAD_INSTALLS=true maybe_defer_pip_install -e ${PAXML_INSTALLED_DIR}[gpu] $HEAD_PACKAGES
 
 if [[ $(uname -m) == "aarch64" ]]; then
   # array-record pip package is broken on ARM64 right now, we build it from source here.

--- a/.github/container/install-t5x.sh
+++ b/.github/container/install-t5x.sh
@@ -96,6 +96,8 @@ T5X_INSTALLED_DIR=${INSTALL_DIR}/t5x
 git clone ${T5X_REPO} ${T5X_INSTALLED_DIR}
 cd ${T5X_INSTALLED_DIR}
 git checkout ${T5X_REF}
+# We currently require installing editable (-e) to build a distribution since
+# we edit the source in place and do not re-install
 maybe_defer_pip_install -e ${T5X_INSTALLED_DIR}[gpu]
 
 maybe_defer_cleanup apt-get autoremove -y


### PR DESCRIPTION
The rosetta build relies on pax/praxis being installed editable, so this re-enables the editable install in the vanilla pax build