### PR TITLE
Rename rosetta-t5x, rosetta-pax -> t5x, pax in scripts, workflows, docs

### DIFF
--- a/.github/workflows/_build_pax.yaml
+++ b/.github/workflows/_build_pax.yaml
@@ -75,7 +75,7 @@ jobs:
           flavor: |
             latest=false
           tags: |
-            type=raw,value=${{ github.run_id }}-pax
+            type=raw,value=${{ github.run_id }}-upstream-pax
           labels:
             org.opencontainers.image.created=${{ inputs.BUILD_DATE }}
 

--- a/.github/workflows/_build_rosetta.yaml
+++ b/.github/workflows/_build_rosetta.yaml
@@ -65,7 +65,7 @@ jobs:
         with:
           images: ${{ env.UPLD_IMAGE }}
           flavor: latest=false
-          tags: type=raw,value=${{ github.run_id }}-rosetta-${{ inputs.BASE_LIBRARY }}
+          tags: type=raw,value=${{ github.run_id }}-${{ inputs.BASE_LIBRARY }}
           labels: org.opencontainers.image.created=${{ inputs.BUILD_DATE }}
 
       - name: Set up Docker Buildx

--- a/.github/workflows/_build_t5x.yaml
+++ b/.github/workflows/_build_t5x.yaml
@@ -65,7 +65,7 @@ jobs:
           flavor: |
             latest=false
           tags: |
-            type=raw,value=${{ github.run_id }}-t5x
+            type=raw,value=${{ github.run_id }}-upstream-t5x
           labels:
             org.opencontainers.image.created=${{ inputs.BUILD_DATE }}
 

--- a/.github/workflows/_test_rosetta.yaml
+++ b/.github/workflows/_test_rosetta.yaml
@@ -7,7 +7,7 @@ on:
         type: string
         description: 'Rosetta image build by NVIDIA/JAX-Toolbox'
         required: true
-        default: 'ghcr.io/nvidia/rosetta-t5x:latest'
+        default: 'ghcr.io/nvidia/t5x:latest'
     outputs:
       TEST_ARTIFACT_NAME:
         description: 'Name of the unit test artifact for downstream workflows'

--- a/README.md
+++ b/README.md
@@ -99,8 +99,8 @@
 [container-link-base]: https://github.com/NVIDIA/JAX-Toolbox/pkgs/container/jax-toolbox
 [container-link-jax]: https://github.com/NVIDIA/JAX-Toolbox/pkgs/container/jax
 [container-link-te]: https://github.com/NVIDIA/JAX-Toolbox/pkgs/container/jax-te
-[container-link-rosetta-t5x]: https://github.com/NVIDIA/JAX-Toolbox/pkgs/container/rosetta-t5x
-[container-link-rosetta-pax]: https://github.com/NVIDIA/JAX-Toolbox/pkgs/container/rosetta-pax
+[container-link-rosetta-t5x]: https://github.com/NVIDIA/JAX-Toolbox/pkgs/container/t5x
+[container-link-rosetta-pax]: https://github.com/NVIDIA/JAX-Toolbox/pkgs/container/pax
 
 [build-badge-base]: https://img.shields.io/github/actions/workflow/status/NVIDIA/JAX-Toolbox/weekly-base-build.yaml?branch=main&label=weekly&logo=github-actions&logoColor=dddddd
 [build-badge-jax]: https://img.shields.io/github/actions/workflow/status/NVIDIA/JAX-Toolbox/nightly-jax-build.yaml?branch=main&label=nightly&logo=github-actions&logoColor=dddddd

--- a/rosetta/rosetta/projects/t5x/README.md
+++ b/rosetta/rosetta/projects/t5x/README.md
@@ -12,15 +12,15 @@ The `t5x/contrib/gpu/scripts_gpu` directory contains scripts optimized for GPU u
 ## Prerequisites
 The examples below will reuse these environment variables. Feel free to change them:
 ```bash
-CONTAINER=ghcr.io/nvidia/rosetta-t5x:latest
+CONTAINER=ghcr.io/nvidia/t5x:latest
 DATASET_PATH=<NEED TO SPECIFY>
 WORKSPACE_PATH=""  # Path used for run outputs (unspecified = /t5x_home/workspace)
 ```
 
 ## Container
-We provide the latest fully built, ready-to-use, and verified container here: `ghcr.io/nvidia/rosetta-t5x:latest-verified`. The verified containers will be updated
-periodically, but if you wish to use the bleeding edge (which may come have unexpected behavior), please use `ghcr.io/nvidia/rosetta-t5x:latest`.
-We also provide nightly dated images with the naming pattern [ghcr.io/nvidia/rosetta-t5x:nightly-YYYY-MM-DD](https://github.com/NVIDIA/JAX-Toolbox/pkgs/container/rosetta-t5x), but we encourage
+We provide the latest fully built, ready-to-use, and verified container here: `ghcr.io/nvidia/t5x:latest-verified`. The verified containers will be updated
+periodically, but if you wish to use the bleeding edge (which may come have unexpected behavior), please use `ghcr.io/nvidia/t5x:latest`.
+We also provide nightly dated images with the naming pattern [ghcr.io/nvidia/t5x:nightly-YYYY-MM-DD](https://github.com/NVIDIA/JAX-Toolbox/pkgs/container/t5x), but we encourage
 you to use the latest ones to get the best performance.
 
 We **highly** recommend using the pre-built container, but if you'd like to build your own container, you can follow the instructions here: [Building rosetta manually](../../../README.md#building-rosetta-with-a-specific-base)

--- a/rosetta/rosetta/projects/t5x/scripts/example_slurm_ft_frompile.sub
+++ b/rosetta/rosetta/projects/t5x/scripts/example_slurm_ft_frompile.sub
@@ -15,7 +15,7 @@ set -eoux
 #-------------------------------------------------------------------------------
 
 # << CHANGE ! >>
-CONTAINER="${CONTAINER:-ghcr.io/nvidia/rosetta-t5x:latest-verified}" # Add link to your built container
+CONTAINER="${CONTAINER:-ghcr.io/nvidia/t5x:latest-verified}" # Add link to your built container
 
 # << CHANGE ! >>
 # BASE_TFDS_DATA_DIR and DATASET_MAP are mutually exclusive

--- a/rosetta/rosetta/projects/t5x/scripts/example_slurm_pretrain_pile.sub
+++ b/rosetta/rosetta/projects/t5x/scripts/example_slurm_pretrain_pile.sub
@@ -15,7 +15,7 @@ set -eoux
 #-------------------------------------------------------------------------------
 
 # << CHANGE ! >>
-CONTAINER="${CONTAINER:-ghcr.io/nvidia/rosetta-t5x:latest-verified}" # Add link to your built container
+CONTAINER="${CONTAINER:-ghcr.io/nvidia/t5x:latest-verified}" # Add link to your built container
 
 # << CHANGE ! >>
 # BASE_TFDS_DATA_DIR and DATASET_MAP are mutually exclusive

--- a/rosetta/rosetta/projects/vit/README.md
+++ b/rosetta/rosetta/projects/vit/README.md
@@ -6,11 +6,11 @@ This directory provides an implementation of the [Vision Transformer (ViT)](http
 Convergence and performance has been validated on NVIDIA DGX A100 (8x A100 80G) nodes. Pretraining and fine-tuning of ViT/B-16 can be performed on a single DGX A100 80G node. We provide both singlenode and multinode support for pre-training and fine-tuning. If running on a machine with less than 80G memory, some of the default configurations may run out of memory; if you run out of memory and have more GPUs available, increase your GPU count and decrease your batch size per GPU. You may also use gradient accumulation to reduce the microbatch size while keeping the global batch size and GPU count constant, but note that gradient accumulation with ViT works only with scale-invariant optimizers such as Adam and Adafactor. See the [known issues](#Known-issues) section below for more information.
 
 ## Building a Container
-We provide and fully built and ready-to-use container here: `ghcr.io/nvidia/rosetta-t5x:vit-2023-07-21`
+We provide and fully built and ready-to-use container here: `ghcr.io/nvidia/t5x:vit-2023-07-21`
 
 If you do not plan on making changes to the Rosetta source code and would simply like to run experiments on top of Rosetta, we strongly recommend using the pre-built container. Run the following command to launch a container interactively: 
 ```
-export CONTAINER=ghcr.io/nvidia/rosetta-t5x:vit-2023-07-21
+export CONTAINER=ghcr.io/nvidia/t5x:vit-2023-07-21
 docker run -ti --gpus=all --net=host --ipc=host -v <IMAGENET_PATH>:/opt/rosetta/datasets/imagenet -v <WORKSPACE_PATH>:/opt/rosetta/workspace -v <TRAIN_INDEX_PATH>:/opt/rosetta/train_idxs -v <EVAL_INDEX_PATH>:/opt/rosetta/eval_idxs --privileged $CONTAINER /bin/bash
 ```
 where  `<IMAGENET_PATH>` is the path to the ImageNet-1k dataset (see the [downloading the dataset](#Downloading-the-dataset) section below for details) and ``<TRAIN_INDEX_PATH>`` and ``<EVAL_INDEX_PATH>`` refer to the paths to the train and eval indices for the ImageNet tar files (see the [before launching a run](#before-launching-a-run) section below for more information about these paths). ``<WORKSPACE_PATH>`` refers to the directory where you would like to store any persistent files. Any custom configurations or run scripts needed for your experiments should reside here.

--- a/rosetta/rosetta/projects/vit/scripts/example_slurm_finetune.sub
+++ b/rosetta/rosetta/projects/vit/scripts/example_slurm_finetune.sub
@@ -30,7 +30,7 @@ set -x
 # File system and volume glue code
 #-------------------------------------------------------------------------------
 
-CONTAINER="${CONTAINER:=ghcr.io/nvidia/rosetta-t5x:vit-2023-07-21}"
+CONTAINER="${CONTAINER:=ghcr.io/nvidia/t5x:vit-2023-07-21}"
 
 # << CHANGE ! >>
 BASE_WORKSPACE_DIR=${BASE_WORKSPACE_DIR} # path to workspace directory where outputs will reside

--- a/rosetta/rosetta/projects/vit/scripts/example_slurm_pretrain.sub
+++ b/rosetta/rosetta/projects/vit/scripts/example_slurm_pretrain.sub
@@ -30,7 +30,7 @@ set -x
 # File system and volume glue code
 #-------------------------------------------------------------------------------
 
-CONTAINER="${CONTAINER:=ghcr.io/nvidia/rosetta-t5x:vit-2023-07-21}"
+CONTAINER="${CONTAINER:=ghcr.io/nvidia/t5x:vit-2023-07-21}"
 
 # << CHANGE ! >>
 BASE_WORKSPACE_DIR=${BASE_WORKSPACE_DIR} # path to workspace directory where outputs will reside


### PR DESCRIPTION
There were a couple of other places rosetta-t5x and rosetta-pax were mentioned.

Merging into @yhtang 's branch 