### PR TITLE
Workflow for nightly Pax build on CUDA 12.1

### DIFF
--- a/.github/workflows/_sandbox.yaml
+++ b/.github/workflows/_sandbox.yaml
@@ -2,40 +2,98 @@ name: "~Sandbox"
 
 on:
   workflow_dispatch:
+  push:
+
+permissions:
+  contents: read  # to fetch code
+  actions:  write # to cancel previous workflows
+  packages: write # to upload container
 
 jobs:
-  sandbox:
+
+  metadata:
+    runs-on: ubuntu-22.04
+    outputs:
+      BUILD_DATE: ${{ steps.date.outputs.BUILD_DATE }}
+    steps:
+      - name: Set build date
+        id: date
+        shell: bash -x -e {0}
+        run: |
+          BUILD_DATE=$(TZ='US/Los_Angeles' date '+%Y-%m-%d')
+          echo "BUILD_DATE=${BUILD_DATE}" >> $GITHUB_OUTPUT
+
+  build-base:
+    needs: metadata
+    uses: ./.github/workflows/_build_base.yaml
+    with:
+      BASE_IMAGE: 'nvidia/cuda:12.1.1-devel-ubuntu22.04'
+      BUILD_DATE: ${{ needs.metadata.outputs.BUILD_DATE }}
+    secrets: inherit
+
+  build-jax:
+    needs: [metadata, build-base]
+    uses: ./.github/workflows/_build_jax.yaml
+    with:
+      BUILD_DATE: ${{ needs.metadata.outputs.BUILD_DATE }}
+      BASE_IMAGE: ${{ needs.build-base.outputs.DOCKER_TAGS }}
+    secrets: inherit
+
+  build-pax:
+    needs: [metadata, build-jax]
+    uses: ./.github/workflows/_build_pax.yaml
+    with:
+      BUILD_DATE: ${{ needs.metadata.outputs.BUILD_DATE }}
+      BASE_IMAGE: ${{ needs.build-jax.outputs.DOCKER_TAGS }}
+    secrets: inherit
+
+  build-rosetta-pax:
+    uses: ./.github/workflows/_build_rosetta.yaml
+    needs: [metadata, build-pax]
+    with:
+      BUILD_DATE: ${{ needs.metadata.outputs.BUILD_DATE }}
+      BASE_IMAGE: ${{ needs.build-pax.outputs.DOCKER_TAGS }}
+      BASE_LIBRARY: pax
+    secrets: inherit
+
+  build-summary:
+    needs: [build-base, build-jax, build-pax, build-rosetta-pax]
+    if: always()
     runs-on: ubuntu-22.04
     steps:
-      - name: Login to GitHub Container Registry
-        uses: docker/login-action@v2
-        with:
-          registry: ghcr.io
-          username: ${{ github.repository_owner }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Print usage
+      - name: Generate job summary for container build
+        shell: bash -x -e {0}
         run: |
-          cat << EOF
-          This is an empty workflow file located in the main branch of your
-          repository. It serves as a testing ground for new GitHub Actions on
-          development branches before merging them to the main branch. By
-          defining and overloading this workflow on your development branch,
-          you can test new actions without affecting your main branch, ensuring
-          a smooth integration process once the changes are ready to be merged.
+          cat > $GITHUB_STEP_SUMMARY << EOF
+          # Images created          
 
-          Usage:
-          
-          1. In your development branch, modify the sandbox.yml workflow file
-             to include the new actions you want to test. Make sure to commit
-             the changes to the development branch.
-          2. Navigate to the 'Actions' tab in your repository, select the
-             '~Sandbox' workflow, and choose your development branch from the
-             branch dropdown menu. Click on 'Run workflow' to trigger the
-             workflow on your development branch.
-          3. Once you have tested and verified the new actions in the Sandbox
-             workflow, you can incorporate them into your main workflow(s) and
-             merge the development branch into the main branch. Remember to
-             revert the changes to the sandbox.yml file in the main branch to
-             keep it empty for future testing.
+          | Image        | Link                                               |
+          | ------------ | -------------------------------------------------- |
+          | Base         | ${{ needs.build-base.outputs.DOCKER_TAGS }}        |
+          | JAX          | ${{ needs.build-jax.outputs.DOCKER_TAGS }}         |
+          | PAX          | ${{ needs.build-pax.outputs.DOCKER_TAGS }}         |
+          | ROSETTA(pax) | ${{ needs.build-rosetta-pax.outputs.DOCKER_TAGS }} |
           EOF
+
+  test-jax:
+    needs: build-jax
+    uses: ./.github/workflows/_test_jax.yaml
+    with:
+      JAX_IMAGE: ${{ needs.build-jax.outputs.DOCKER_TAGS }}
+    secrets: inherit
+
+  test-pax:
+    needs: build-pax
+    uses: ./.github/workflows/_test_pax.yaml
+    with:
+      PAX_IMAGE: ${{ needs.build-pax.outputs.DOCKER_TAGS }}
+    secrets: inherit
+
+  finalize:
+    if: always()
+    # TODO: use dynamic matrix to make dependencies self-updating
+    needs: [build-summary, test-jax, test-pax]
+    uses: ./.github/workflows/_finalize.yaml
+    with:
+      PUBLISH_BADGE: false
+    secrets: inherit

--- a/.github/workflows/_sandbox.yaml
+++ b/.github/workflows/_sandbox.yaml
@@ -2,98 +2,40 @@ name: "~Sandbox"
 
 on:
   workflow_dispatch:
-  push:
-
-permissions:
-  contents: read  # to fetch code
-  actions:  write # to cancel previous workflows
-  packages: write # to upload container
 
 jobs:
-
-  metadata:
-    runs-on: ubuntu-22.04
-    outputs:
-      BUILD_DATE: ${{ steps.date.outputs.BUILD_DATE }}
-    steps:
-      - name: Set build date
-        id: date
-        shell: bash -x -e {0}
-        run: |
-          BUILD_DATE=$(TZ='US/Los_Angeles' date '+%Y-%m-%d')
-          echo "BUILD_DATE=${BUILD_DATE}" >> $GITHUB_OUTPUT
-
-  build-base:
-    needs: metadata
-    uses: ./.github/workflows/_build_base.yaml
-    with:
-      BASE_IMAGE: 'nvidia/cuda:12.1.1-devel-ubuntu22.04'
-      BUILD_DATE: ${{ needs.metadata.outputs.BUILD_DATE }}
-    secrets: inherit
-
-  build-jax:
-    needs: [metadata, build-base]
-    uses: ./.github/workflows/_build_jax.yaml
-    with:
-      BUILD_DATE: ${{ needs.metadata.outputs.BUILD_DATE }}
-      BASE_IMAGE: ${{ needs.build-base.outputs.DOCKER_TAGS }}
-    secrets: inherit
-
-  build-pax:
-    needs: [metadata, build-jax]
-    uses: ./.github/workflows/_build_pax.yaml
-    with:
-      BUILD_DATE: ${{ needs.metadata.outputs.BUILD_DATE }}
-      BASE_IMAGE: ${{ needs.build-jax.outputs.DOCKER_TAGS }}
-    secrets: inherit
-
-  build-rosetta-pax:
-    uses: ./.github/workflows/_build_rosetta.yaml
-    needs: [metadata, build-pax]
-    with:
-      BUILD_DATE: ${{ needs.metadata.outputs.BUILD_DATE }}
-      BASE_IMAGE: ${{ needs.build-pax.outputs.DOCKER_TAGS }}
-      BASE_LIBRARY: pax
-    secrets: inherit
-
-  build-summary:
-    needs: [build-base, build-jax, build-pax, build-rosetta-pax]
-    if: always()
+  sandbox:
     runs-on: ubuntu-22.04
     steps:
-      - name: Generate job summary for container build
-        shell: bash -x -e {0}
-        run: |
-          cat > $GITHUB_STEP_SUMMARY << EOF
-          # Images created          
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
-          | Image        | Link                                               |
-          | ------------ | -------------------------------------------------- |
-          | Base         | ${{ needs.build-base.outputs.DOCKER_TAGS }}        |
-          | JAX          | ${{ needs.build-jax.outputs.DOCKER_TAGS }}         |
-          | PAX          | ${{ needs.build-pax.outputs.DOCKER_TAGS }}         |
-          | ROSETTA(pax) | ${{ needs.build-rosetta-pax.outputs.DOCKER_TAGS }} |
+      - name: Print usage
+        run: |
+          cat << EOF
+          This is an empty workflow file located in the main branch of your
+          repository. It serves as a testing ground for new GitHub Actions on
+          development branches before merging them to the main branch. By
+          defining and overloading this workflow on your development branch,
+          you can test new actions without affecting your main branch, ensuring
+          a smooth integration process once the changes are ready to be merged.
+
+          Usage:
+          
+          1. In your development branch, modify the sandbox.yml workflow file
+             to include the new actions you want to test. Make sure to commit
+             the changes to the development branch.
+          2. Navigate to the 'Actions' tab in your repository, select the
+             '~Sandbox' workflow, and choose your development branch from the
+             branch dropdown menu. Click on 'Run workflow' to trigger the
+             workflow on your development branch.
+          3. Once you have tested and verified the new actions in the Sandbox
+             workflow, you can incorporate them into your main workflow(s) and
+             merge the development branch into the main branch. Remember to
+             revert the changes to the sandbox.yml file in the main branch to
+             keep it empty for future testing.
           EOF
-
-  test-jax:
-    needs: build-jax
-    uses: ./.github/workflows/_test_jax.yaml
-    with:
-      JAX_IMAGE: ${{ needs.build-jax.outputs.DOCKER_TAGS }}
-    secrets: inherit
-
-  test-pax:
-    needs: build-pax
-    uses: ./.github/workflows/_test_pax.yaml
-    with:
-      PAX_IMAGE: ${{ needs.build-pax.outputs.DOCKER_TAGS }}
-    secrets: inherit
-
-  finalize:
-    if: always()
-    # TODO: use dynamic matrix to make dependencies self-updating
-    needs: [build-summary, test-jax, test-pax]
-    uses: ./.github/workflows/_finalize.yaml
-    with:
-      PUBLISH_BADGE: false
-    secrets: inherit

--- a/.github/workflows/pax-cuda-121.yaml
+++ b/.github/workflows/pax-cuda-121.yaml
@@ -1,0 +1,104 @@
+name: CI
+
+on:
+  schedule:
+    - cron: '30 9 * * *'  # Pacific Time 01:30 AM in UTC
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
+permissions:
+  contents: read  # to fetch code
+  actions:  write # to cancel previous workflows
+  packages: write # to upload container
+
+jobs:
+
+  metadata:
+    runs-on: ubuntu-22.04
+    outputs:
+      BUILD_DATE: ${{ steps.date.outputs.BUILD_DATE }}
+    steps:
+      - name: Set build date
+        id: date
+        shell: bash -x -e {0}
+        run: |
+          BUILD_DATE=$(TZ='US/Los_Angeles' date '+%Y-%m-%d')
+          echo "BUILD_DATE=${BUILD_DATE}" >> $GITHUB_OUTPUT
+
+  build-base:
+    needs: metadata
+    uses: ./.github/workflows/_build_base.yaml
+    with:
+      BASE_IMAGE: 'nvidia/cuda:12.1.1-devel-ubuntu22.04'
+      BUILD_DATE: ${{ needs.metadata.outputs.BUILD_DATE }}
+    secrets: inherit
+
+  build-jax:
+    needs: [metadata, build-base]
+    uses: ./.github/workflows/_build_jax.yaml
+    with:
+      BUILD_DATE: ${{ needs.metadata.outputs.BUILD_DATE }}
+      BASE_IMAGE: ${{ needs.build-base.outputs.DOCKER_TAGS }}
+    secrets: inherit
+
+  build-pax:
+    needs: [metadata, build-jax]
+    uses: ./.github/workflows/_build_pax.yaml
+    with:
+      BUILD_DATE: ${{ needs.metadata.outputs.BUILD_DATE }}
+      BASE_IMAGE: ${{ needs.build-jax.outputs.DOCKER_TAGS }}
+    secrets: inherit
+
+  build-rosetta-pax:
+    uses: ./.github/workflows/_build_rosetta.yaml
+    needs: [metadata, build-pax]
+    with:
+      BUILD_DATE: ${{ needs.metadata.outputs.BUILD_DATE }}
+      BASE_IMAGE: ${{ needs.build-pax.outputs.DOCKER_TAGS }}
+      BASE_LIBRARY: pax
+    secrets: inherit
+
+  build-summary:
+    needs: [build-base, build-jax, build-pax, build-rosetta-pax]
+    if: always()
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Generate job summary for container build
+        shell: bash -x -e {0}
+        run: |
+          cat > $GITHUB_STEP_SUMMARY << EOF
+          # Images created          
+
+          | Image        | Link                                               |
+          | ------------ | -------------------------------------------------- |
+          | Base         | ${{ needs.build-base.outputs.DOCKER_TAGS }}        |
+          | JAX          | ${{ needs.build-jax.outputs.DOCKER_TAGS }}         |
+          | PAX          | ${{ needs.build-pax.outputs.DOCKER_TAGS }}         |
+          | ROSETTA(pax) | ${{ needs.build-rosetta-pax.outputs.DOCKER_TAGS }} |
+          EOF
+
+  test-jax:
+    needs: build-jax
+    uses: ./.github/workflows/_test_jax.yaml
+    with:
+      JAX_IMAGE: ${{ needs.build-jax.outputs.DOCKER_TAGS }}
+    secrets: inherit
+
+  test-pax:
+    needs: build-pax
+    uses: ./.github/workflows/_test_pax.yaml
+    with:
+      PAX_IMAGE: ${{ needs.build-pax.outputs.DOCKER_TAGS }}
+    secrets: inherit
+
+  finalize:
+    if: always()
+    # TODO: use dynamic matrix to make dependencies self-updating
+    needs: [build-summary, test-jax, test-pax]
+    uses: ./.github/workflows/_finalize.yaml
+    with:
+      PUBLISH_BADGE: false
+    secrets: inherit

--- a/.github/workflows/pax-cuda-121.yaml
+++ b/.github/workflows/pax-cuda-121.yaml
@@ -1,4 +1,4 @@
-name: CI
+name: Night Pax on CUDA 12.1
 
 on:
   schedule:

--- a/.github/workflows/pax-cuda-121.yaml
+++ b/.github/workflows/pax-cuda-121.yaml
@@ -1,4 +1,4 @@
-name: Night Pax on CUDA 12.1
+name: Nightly Pax on CUDA 12.1
 
 on:
   schedule:


### PR DESCRIPTION
This will add a `Nightly Pax on CUDA 12.1` workflow that will run every day to produce a CUDA 12.1 paxml image for testing on Selene. The image will **not** be made public, but the tags will be printed in the workflow summary for checking out using a PAT.