### PR TITLE
Fixes rosetta/tests/extra-only-distribution.sh test failure

### DIFF
--- a/.github/workflows/nightly-distribution-test.yaml
+++ b/.github/workflows/nightly-distribution-test.yaml
@@ -1,6 +1,7 @@
 name: Nightly Distribution test
 
 on:
+  workflow_dispatch:
   workflow_run:
     workflows: [Nightly JAX build]
     types: [completed]

--- a/rosetta/tests/extra-only-distribution.sh
+++ b/rosetta/tests/extra-only-distribution.sh
@@ -17,6 +17,7 @@ DISTRIBUTION_BASE_REF=22117ce5a3606706ba9519ccdd77b532ad8ff7b2
 
 git clone $UPSTREAM_URL $repo_tmp
 git clone $UPSTREAM_URL $extra_tmp
+git -C $extra_tmp checkout $DISTRIBUTION_BASE_REF
 echo "patch/delete-readme" >> $patchlist_tmp
 
 cd $extra_tmp


### PR DESCRIPTION
Test failed due to cherry-picking from a future commit, which may
fail since the distribution was built on a pinned past commit.

The issue was even though the commit to cherry-pick only contained
a file deletion, because there were edits to the file between the
DISTRIBUTION_BASE_REF and TOT main, git cherry-pick errors out
because the file deleted was not the same as the one the patch was based
on

## Additionally
This PR will also allow nightly-distribution-test.yaml to be dispatched thru the UI