### PR TITLE
Adds issues:write permission to called triaging workflow

### DIFF
--- a/.github/workflows/_triage.yaml
+++ b/.github/workflows/_triage.yaml
@@ -57,6 +57,7 @@ permissions:
   contents: read  # to fetch code
   actions:  write # to cancel previous workflows
   packages: write # to upload container
+  issues: write   # to create issues
 
 jobs:
   metadata:
@@ -214,8 +215,6 @@ jobs:
     if: (success() || failure()) && needs.metadata.outputs.FRAMEWORK_BASE == 't5x'
     needs: [metadata, test-t5x-ff]
     runs-on: ubuntu-22.04
-    permissions:
-      issues: write
     steps:
       - name: Create table summarizing
         id: summary-table
@@ -373,8 +372,6 @@ jobs:
     if: (success() || failure()) && needs.metadata.outputs.FRAMEWORK_BASE == 'pax'
     needs: [metadata, test-pax-ff]
     runs-on: ubuntu-22.04
-    permissions:
-      issues: write
     steps:
       - name: Create table summarizing
         id: summary-table

--- a/.github/workflows/nightly-pax-test-mgmn.yaml
+++ b/.github/workflows/nightly-pax-test-mgmn.yaml
@@ -22,6 +22,7 @@ permissions:
   contents: read  # to fetch code
   actions:  write # to cancel previous workflows
   packages: write # to upload container
+  issues:   write # to create issues
 
 env:
   DEFAULT_PAX_IMAGE: 'ghcr.io/nvidia/pax:latest'

--- a/.github/workflows/nightly-t5x-test-mgmn.yaml
+++ b/.github/workflows/nightly-t5x-test-mgmn.yaml
@@ -22,6 +22,7 @@ permissions:
   contents: read  # to fetch code
   actions:  write # to cancel previous workflows
   packages: write # to upload container
+  issues: write   # to create issues
 
 env:
   DEFAULT_T5X_IMAGE: 'ghcr.io/nvidia/t5x:latest'


### PR DESCRIPTION
nightly-{t5x,pax}-test-mgmn.yaml fail without adding the issues:write permission globally in the workflow. Specifying it only on a particular step seems to fail.