### PR TITLE
Fix context variable type error in jax nightly workflow

### DIFF
--- a/.github/workflows/nightly-jax-build.yaml
+++ b/.github/workflows/nightly-jax-build.yaml
@@ -61,5 +61,5 @@ jobs:
     needs: [metadata, build]
     uses: ./.github/workflows/_finalize.yaml
     with:
-      PUBLISH_BADGE: '${{ needs.metadata.outputs.PUBLISH }}'
+      PUBLISH_BADGE: ${{ needs.metadata.outputs.PUBLISH == 'true' }}
     secrets: inherit

--- a/.github/workflows/nightly-jax-build.yaml
+++ b/.github/workflows/nightly-jax-build.yaml
@@ -61,5 +61,5 @@ jobs:
     needs: [metadata, build]
     uses: ./.github/workflows/_finalize.yaml
     with:
-      PUBLISH_BADGE: ${{ needs.metadata.outputs.PUBLISH }}
+      PUBLISH_BADGE: '${{ needs.metadata.outputs.PUBLISH }}'
     secrets: inherit

--- a/.github/workflows/nightly-jax-build.yaml
+++ b/.github/workflows/nightly-jax-build.yaml
@@ -22,6 +22,7 @@ jobs:
     runs-on: ubuntu-22.04
     outputs:
       BUILD_DATE: ${{ steps.date.outputs.BUILD_DATE }}
+      PUBLISH: ${{ steps.if-publish.outputs.PUBLISH }}
     steps:
       - name: Set build date
         id: date
@@ -29,6 +30,12 @@ jobs:
         run: |
           BUILD_DATE=$(TZ='US/Los_Angeles' date '+%Y-%m-%d')
           echo "BUILD_DATE=${BUILD_DATE}" >> $GITHUB_OUTPUT
+
+      - name: Determine whether results will be 'published'
+        id: if-publish
+        shell: bash -x -e {0}
+        run: |
+          echo "PUBLISH=${{ github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && inputs.PUBLISH) }}" >> $GITHUB_OUTPUT
 
   build:
     needs: metadata
@@ -51,8 +58,8 @@ jobs:
 
   finalize:
     if: always()
-    needs: [build]
+    needs: [metadata, build]
     uses: ./.github/workflows/_finalize.yaml
     with:
-      PUBLISH_BADGE: ${{ github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && inputs.PUBLISH) }}
+      PUBLISH_BADGE: ${{ needs.metadata.outputs.PUBLISH }}
     secrets: inherit

--- a/.github/workflows/nightly-jax-test-unit.yaml
+++ b/.github/workflows/nightly-jax-test-unit.yaml
@@ -37,11 +37,11 @@ jobs:
   metadata:
     runs-on: ubuntu-22.04
     outputs:
-      JAX_IMAGE: ${{ steps.meta.outputs.JAX_IMAGE }}
-      PUBLISH: ${{ steps.meta.outputs.PUBLISH }}
+      JAX_IMAGE: ${{ steps.image.outputs.JAX_IMAGE }}
+      PUBLISH: ${{ steps.if-publish.outputs.PUBLISH }}
     steps:
-      - name: Set metadata
-        id: meta
+      - name: Determine jax image to use
+        id: image
         shell: bash -x -e {0}
         run: |
           if [[ -z "${{ inputs.JAX_IMAGE }}" ]]; then
@@ -50,6 +50,11 @@ jobs:
             JAX_IMAGE=${{ inputs.JAX_IMAGE }}
           fi
           echo "JAX_IMAGE=${JAX_IMAGE}" >> $GITHUB_OUTPUT
+
+      - name: Determine whether results will be 'published'
+        id: if-publish
+        shell: bash -x -e {0}
+        run: |
           echo "PUBLISH=${{ github.event_name == 'workflow_run' || (github.event_name == 'workflow_dispatch' && inputs.PUBLISH) }}" >> $GITHUB_OUTPUT
 
   run:
@@ -62,7 +67,7 @@ jobs:
 
   finalize:
     if: always()
-    needs: [run]
+    needs: [metadata, run]
     uses: ./.github/workflows/_finalize.yaml
     with:
       PUBLISH_BADGE: ${{ needs.metadata.outputs.PUBLISH }}

--- a/.github/workflows/nightly-jax-test-unit.yaml
+++ b/.github/workflows/nightly-jax-test-unit.yaml
@@ -57,18 +57,17 @@ jobs:
         run: |
           echo "PUBLISH=${{ github.event_name == 'workflow_run' || (github.event_name == 'workflow_dispatch' && inputs.PUBLISH) }}" >> $GITHUB_OUTPUT
 
-  # run:
-  #   needs: metadata
-  #   uses: ./.github/workflows/_test_jax.yaml
-  #   if: (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success') || github.event_name == 'workflow_dispatch'
-  #   with:
-  #     JAX_IMAGE: ${{ needs.metadata.outputs.JAX_IMAGE }}
-  #   secrets: inherit
+  run:
+    needs: metadata
+    uses: ./.github/workflows/_test_jax.yaml
+    if: (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success') || github.event_name == 'workflow_dispatch'
+    with:
+      JAX_IMAGE: ${{ needs.metadata.outputs.JAX_IMAGE }}
+    secrets: inherit
 
   finalize:
     if: always()
-    # needs: [metadata, run]
-    needs: [metadata]
+    needs: [metadata, run]
     uses: ./.github/workflows/_finalize.yaml
     with:
       PUBLISH_BADGE: ${{ needs.metadata.outputs.PUBLISH == 'true' }}

--- a/.github/workflows/nightly-jax-test-unit.yaml
+++ b/.github/workflows/nightly-jax-test-unit.yaml
@@ -71,5 +71,5 @@ jobs:
     needs: [metadata]
     uses: ./.github/workflows/_finalize.yaml
     with:
-      PUBLISH_BADGE: '${{ needs.metadata.outputs.PUBLISH }}'
+      PUBLISH_BADGE: ${{ needs.metadata.outputs.PUBLISH == 'true' }}
     secrets: inherit

--- a/.github/workflows/nightly-jax-test-unit.yaml
+++ b/.github/workflows/nightly-jax-test-unit.yaml
@@ -70,5 +70,5 @@ jobs:
     needs: [metadata, run]
     uses: ./.github/workflows/_finalize.yaml
     with:
-      PUBLISH_BADGE: ${{ needs.metadata.outputs.PUBLISH }}
+      PUBLISH_BADGE: '${{ needs.metadata.outputs.PUBLISH }}'
     secrets: inherit

--- a/.github/workflows/nightly-jax-test-unit.yaml
+++ b/.github/workflows/nightly-jax-test-unit.yaml
@@ -57,17 +57,18 @@ jobs:
         run: |
           echo "PUBLISH=${{ github.event_name == 'workflow_run' || (github.event_name == 'workflow_dispatch' && inputs.PUBLISH) }}" >> $GITHUB_OUTPUT
 
-  run:
-    needs: metadata
-    uses: ./.github/workflows/_test_jax.yaml
-    if: (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success') || github.event_name == 'workflow_dispatch'
-    with:
-      JAX_IMAGE: ${{ needs.metadata.outputs.JAX_IMAGE }}
-    secrets: inherit
+  # run:
+  #   needs: metadata
+  #   uses: ./.github/workflows/_test_jax.yaml
+  #   if: (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success') || github.event_name == 'workflow_dispatch'
+  #   with:
+  #     JAX_IMAGE: ${{ needs.metadata.outputs.JAX_IMAGE }}
+  #   secrets: inherit
 
   finalize:
     if: always()
-    needs: [metadata, run]
+    # needs: [metadata, run]
+    needs: [metadata]
     uses: ./.github/workflows/_finalize.yaml
     with:
       PUBLISH_BADGE: '${{ needs.metadata.outputs.PUBLISH }}'


### PR DESCRIPTION
Fixed a type error between string/Boolean values in the 'publish' job.