### PR TITLE
Replace TE patch with TE+dropout patch

### DIFF
--- a/rosetta/patchlist-paxml.txt
+++ b/rosetta/patchlist-paxml.txt
@@ -5,4 +5,4 @@
 # - External Pull Requests (These are pull requests with upstream paxml and are of the form "pull/$PULLID/head")
 # - Note: Only the first column is used as a git-ref, so anything after is a comment
 
-pull/46/head # adds Transformer Engine support
+mirror/patch/add_dropout_support_to_te # adds Transformer Engine support (+ dropout support)


### PR DESCRIPTION
Transformer Engine in Pax currently lacks dropout support. This PR updates the TE patch to add support dropout.