### PR TITLE
Fix docker tags for nightly upstream pax and t5x tests

### DIFF
--- a/.github/workflows/_test_pax.yaml
+++ b/.github/workflows/_test_pax.yaml
@@ -5,8 +5,8 @@ on:
     inputs:
       PAX_IMAGE:
         type: string
-        description: PAX image from ghcr.io/nvidia/pax
-        default: latest
+        description: PAX image from ghcr.io/nvidia
+        default: ghcr.io/nvidia/upstream-pax:latest
         required: false
       EXTRA_TEST_ARGS:
         type: string

--- a/.github/workflows/_test_pax_rosetta.yaml
+++ b/.github/workflows/_test_pax_rosetta.yaml
@@ -6,7 +6,7 @@ on:
       PAX_IMAGE:
         type: string
         description: PAX image from ghcr.io/nvidia/pax
-        default: latest
+        default: ghcr.io/nvidia/pax:latest
         required: false
       EXTRA_TEST_ARGS:
         type: string

--- a/.github/workflows/_test_t5x.yaml
+++ b/.github/workflows/_test_t5x.yaml
@@ -5,8 +5,8 @@ on:
     inputs:
       T5X_IMAGE:
         type: string
-        description: T5X image from ghcr.io/nvidia/t5x
-        default: 'ghcr.io/nvidia/t5x:latest'
+        description: T5X image from ghcr.io/nvidia
+        default: 'ghcr.io/nvidia/upstream-t5x:latest'
         required: false
       BATCH_SIZE_PER_GPU:
         type: number

--- a/.github/workflows/nightly-pax-test-mgmn.yaml
+++ b/.github/workflows/nightly-pax-test-mgmn.yaml
@@ -10,7 +10,7 @@ on:
       PAX_IMAGE:
         type: string
         description: Pax container
-        default: 'ghcr.io/nvidia/pax:latest'
+        default: 'ghcr.io/nvidia/upstream-pax:latest'
         required: true
       PUBLISH:
         type: boolean
@@ -25,7 +25,7 @@ permissions:
   issues:   write # to create issues
 
 env:
-  DEFAULT_PAX_IMAGE: 'ghcr.io/nvidia/pax:latest'
+  DEFAULT_PAX_IMAGE: 'ghcr.io/nvidia/upstream-pax:latest'
 
 jobs:
 

--- a/.github/workflows/nightly-t5x-test-mgmn.yaml
+++ b/.github/workflows/nightly-t5x-test-mgmn.yaml
@@ -25,7 +25,7 @@ permissions:
   issues: write   # to create issues
 
 env:
-  DEFAULT_T5X_IMAGE: 'ghcr.io/nvidia/t5x:upstream-latest'
+  DEFAULT_T5X_IMAGE: 'ghcr.io/nvidia/upstream-t5x:latest'
 
 jobs:
 

--- a/.github/workflows/nightly-t5x-test-mgmn.yaml
+++ b/.github/workflows/nightly-t5x-test-mgmn.yaml
@@ -10,7 +10,7 @@ on:
       T5X_IMAGE:
         type: string
         description: T5X container
-        default: 'ghcr.io/nvidia/t5x:latest'
+        default: 'ghcr.io/nvidia/upstream-t5x:latest'
         required: true
       PUBLISH:
         type: boolean
@@ -25,7 +25,7 @@ permissions:
   issues: write   # to create issues
 
 env:
-  DEFAULT_T5X_IMAGE: 'ghcr.io/nvidia/t5x:latest'
+  DEFAULT_T5X_IMAGE: 'ghcr.io/nvidia/t5x:upstream-latest'
 
 jobs:
 


### PR DESCRIPTION
The containers used to run nightly Pax and T5X upstream mgmn tests were not updated following the container renaming, so the nightly tests were erroneously using the rosetta-{pax, t5x} containers. This caused a test failure with today's Pax nightly because the upstream tests ran with yesterday's rosetta-pax container, which had an outdated version of `test-pax.sh`.