### PR TITLE
Do not set the TF_NCCL_VERSION variable when building JAX

### DIFF
--- a/.github/container/build-jax.sh
+++ b/.github/container/build-jax.sh
@@ -154,7 +154,6 @@ export TF_CUDNN_PATHS=/usr/lib/$(uname -p)-linux-gnu
 export TF_CUDA_VERSION=$(ls /usr/local/cuda/lib64/libcudart.so.*.*.* | cut -d . -f 3-4)
 export TF_CUBLAS_VERSION=$(ls /usr/local/cuda/lib64/libcublas.so.*.*.* | cut -d . -f 3)
 export TF_CUDNN_VERSION=$(echo "${NV_CUDNN_VERSION}" | cut -d . -f 1)
-export TF_NCCL_VERSION=$(echo "${NCCL_VERSION}" | cut -d . -f 1)
 
 case "${CPU_ARCH}" in
     "amd64")


### PR DESCRIPTION
Try to see if this fixes the JAX + CUDA 12.1 build error:
```
ERROR: /root/.cache/bazel/_bazel_root/938be0cf9dc59c1b3a9c4bf28d15e057/external/tsl/tsl/platform/default/BUILD:70:11: error loading package '@local_config_nccl//': Label '@tsl//tensorflow/platform/default:cuda_build_defs.bzl' is invalid because 'tensorflow/platform/default' is not a package; perhaps you meant to put the colon here: '@tsl//:tensorflow/platform/default/cuda_build_defs.bzl'? and referenced by '@tsl//tsl/platform/default:dso_loader'
```

Additional test workflow: https://github.com/NVIDIA/JAX-Toolbox/actions/runs/6499748441