### PR TITLE
Install cuDNN version that matches CUDA version

### DIFF
--- a/.github/container/install-cudnn.sh
+++ b/.github/container/install-cudnn.sh
@@ -5,10 +5,25 @@ set -ex
 export DEBIAN_FRONTEND=noninteractive
 export TZ=America/Los_Angeles
 
+# Extract CUDA version from `nvcc --version` output line
+# Input: "Cuda compilation tools, release X.Y, VX.Y.Z"
+# Output: X.Y
+cuda_version=$(nvcc --version | sed -n 's/^.*release \([0-9]*\.[0-9]*\).*$/\1/p')
+
+# Find latest cuDNN version compatible with existing CUDA by matching
+# ${cuda_version} in the package version string
+libcudnn_version=$(apt-cache show libcudnn8 | sed -n "s/^Version: \(.*+cuda${cuda_version}\)$/\1/p" | head -n 1)
+libcudnn_dev_version=$(apt-cache show libcudnn8-dev | sed -n "s/^Version: \(.*+cuda${cuda_version}\)$/\1/p" | head -n 1)
+if [[ -z "${libcudnn_version}" || -z "${libcudnn_dev_version}" ]]; then
+    echo "Could not find compatible cuDNN version for CUDA ${cuda_version}"
+    exit 1
+fi
+
+
 apt-get update
 apt-get install -y \
-    libcudnn8 \
-    libcudnn8-dev
+    libcudnn8=${libcudnn_version} \
+    libcudnn8-dev=${libcudnn_dev_version}
 
 apt-get clean
 rm -rf /var/lib/apt/lists/*

--- a/.github/container/install-cudnn.sh
+++ b/.github/container/install-cudnn.sh
@@ -5,6 +5,8 @@ set -ex
 export DEBIAN_FRONTEND=noninteractive
 export TZ=America/Los_Angeles
 
+apt-get update
+
 # Extract CUDA version from `nvcc --version` output line
 # Input: "Cuda compilation tools, release X.Y, VX.Y.Z"
 # Output: X.Y


### PR DESCRIPTION
`apt-get install libcudnn8` will install the latest cuDNN for CUDA 12.2 regardless of the toolkit version in the container. We must manually find the cuDNN version for the currently installed CUDA toolkit and specify it when installing from apt.

Additional test workflow:
~~https://github.com/NVIDIA/JAX-Toolbox/actions/runs/6499767704~~
https://github.com/NVIDIA/JAX-Toolbox/actions/runs/6500577975