### PR TITLE
Enable TE by default in rosetta pax containers

### DIFF
--- a/rosetta/Dockerfile.pax
+++ b/rosetta/Dockerfile.pax
@@ -13,6 +13,7 @@ FROM scratch as praxis-mirror-source
 ADD --keep-git-dir=true https://github.com/google/praxis.git#main /
 
 FROM ${BASE_IMAGE} AS rosetta
+ENV ENABLE_TE=1
 
 ARG GIT_USER_EMAIL
 ARG GIT_USER_NAME


### PR DESCRIPTION
Note that `test-pax.sh` sets `ENABLE_TE` to 0 when `--enable-te` is not passed in, so we need not make any updates to the pax tests.