### PR TITLE
Avoid skipping triage jobs

### DIFF
--- a/.github/workflows/_triage.yaml
+++ b/.github/workflows/_triage.yaml
@@ -236,7 +236,7 @@ jobs:
           name_conclusion_array=()
           while IFS= read -r line; do
             name_conclusion_array+=("$line")
-          done < <(echo "$json_data" | jq -r '.jobs[] | select(.name | startswith("test-t5x-ff") and contains("outcome")) | "\(.name)\t\(.conclusion)"')
+          done < <(echo "$json_data" | jq -r '.jobs[] | select(.name | contains("test-t5x-ff") and endswith(" / outcome")) | "\(.name)\t\(.conclusion)"')
         
           TABLE_MD=$(
           cat <<EOF
@@ -393,7 +393,7 @@ jobs:
           name_conclusion_array=()
           while IFS= read -r line; do
             name_conclusion_array+=("$line")
-          done < <(echo "$json_data" | jq -r '.jobs[] | select(.name | startswith("test-pax-ff") and contains("outcome")) | "\(.name)\t\(.conclusion)"')
+          done < <(echo "$json_data" | jq -r '.jobs[] | select(.name | contains("test-pax-ff") and endswith(" / outcome")) | "\(.name)\t\(.conclusion)"')
         
           TABLE_MD=$(
           cat <<EOF

--- a/.github/workflows/nightly-pax-test-mgmn.yaml
+++ b/.github/workflows/nightly-pax-test-mgmn.yaml
@@ -154,7 +154,7 @@ jobs:
   triage:
     needs: [metadata, publish-completion]
     uses: ./.github/workflows/_triage.yaml
-    if: needs.publish-completion.outputs.STATUS != 'success' && ((github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success') || github.event_name == 'workflow_dispatch')
+    if: failure() && needs.publish-completion.outputs.STATUS != 'success' && ((github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success') || github.event_name == 'workflow_dispatch')
     secrets: inherit
     with:
       BROKEN_IMAGE: ${{ needs.metadata.outputs.PAX_IMAGE }}

--- a/.github/workflows/nightly-t5x-test-mgmn.yaml
+++ b/.github/workflows/nightly-t5x-test-mgmn.yaml
@@ -116,7 +116,7 @@ jobs:
   triage:
     needs: [metadata, publish-completion]
     uses: ./.github/workflows/_triage.yaml
-    if: needs.publish-completion.outputs.STATUS != 'success' && ((github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success') || github.event_name == 'workflow_dispatch')
+    if: failure() && needs.publish-completion.outputs.STATUS != 'success' && ((github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success') || github.event_name == 'workflow_dispatch')
     secrets: inherit
     with:
       BROKEN_IMAGE: ${{ needs.metadata.outputs.T5X_IMAGE }}


### PR DESCRIPTION
Avoid skipping triage jobs in case of failure. See [here](https://docs.github.com/en/actions/learn-github-actions/expressions#failure-with-conditions) in the docs; without this then I believe the failed status of the earlier `run-jobs.outcome` job step caused the triage job to be skipped.