### PR TITLE
Updates test-t5x.sh to allow the specification of contrib/gpu configs which enable TE

### DIFF
--- a/.github/container/test-t5x.sh
+++ b/.github/container/test-t5x.sh
@@ -11,19 +11,19 @@ usage() {
     echo ""
     echo "Usage: $0 [OPTIONS]"
     echo ""
-    echo "  OPTIONS                DESCRIPTION"
-    echo "  -a, --additional-args  Additional gin args to pass to t5x/train.py"
-    echo "  -b, --batch-size       Global batch size (REQUIRED)"
-    echo "  -c --use-gpu-configs   If provided uses contrib/gpu configs instead of top-level configs. Notably, gpu configs use adamw instead of adafactor"
-    echo "  -d, --dtype            Data type, defaults to bfloat16."
-    echo "  -e, --epochs           Number of epochs to run, defaults to 7."
-    echo "  --multiprocess         Enable the multiprocess GPU mode."
-    echo "  -o, --output NAME      Name for the output folder, a temporary folder will be created if none specified."
-    echo "  -h, --help             Print usage."
+    echo "  OPTIONS                   DESCRIPTION"
+    echo "  -a, --additional-args     Additional gin args to pass to t5x/train.py"
+    echo "  -b, --batch-size          Global batch size (REQUIRED)"
+    echo "  -c --use-contrib-configs  If provided uses contrib/gpu configs instead of top-level configs. Notably, gpu configs use adamw instead of adafactor"
+    echo "  -d, --dtype               Data type, defaults to bfloat16."
+    echo "  -e, --epochs              Number of epochs to run, defaults to 7."
+    echo "  --multiprocess            Enable the multiprocess GPU mode."
+    echo "  -o, --output NAME         Name for the output folder, a temporary folder will be created if none specified."
+    echo "  -h, --help                Print usage."
     exit $1
 }
 
-args=$(getopt -o a:b:cd:e:o:s:h --long additional-args:,batch-size:,use-gpu-configs,dtype:,epochs:,help,multiprocess,output:,steps-per-epoch: -- "$@")
+args=$(getopt -o a:b:cd:e:o:s:h --long additional-args:,batch-size:,use-contrib-configs,dtype:,epochs:,help,multiprocess,output:,steps-per-epoch: -- "$@")
 if [[ $? -ne 0 ]]; then
     exit 1
 fi


### PR DESCRIPTION
Some code paths in the TE integration were not invoked b/c the configs used in test-t5x.sh were the upstream ones, not the GPU ones in the contrib folder. Adding this flag to switch the configs allows us to use TE layers, which we previously were not.