### PR TITLE
Loosen dali benchmark test as it has always been around 155

### DIFF
--- a/rosetta/rosetta/projects/vit/dali_utils_test.py
+++ b/rosetta/rosetta/projects/vit/dali_utils_test.py
@@ -56,7 +56,7 @@ def test_baseline_dali_iteration_stats(
 
     bps = iter_per_sec(dataset, batch_size=dummy_wds_metadata.batch_size, num_iter=500)
 
-    assert bps > 170
+    assert bps > (155 * 0.9)
 
 
 def test_dali_cls_preprocessing(dummy_wds_metadata):


### PR DESCRIPTION
Examples:
* [158](https://github.com/NVIDIA/JAX-Toolbox/actions/runs/6532058705/job/17734663330#step:7:187)
* [154](https://github.com/NVIDIA/JAX-Toolbox/actions/runs/6523380018/job/17714026959#step:7:184)
* [155](https://github.com/NVIDIA/JAX-Toolbox/actions/runs/6516962689/job/17701057693#step:7:184)

The original benchmark was done on a workstation with different specs than the runner here.