### PR TITLE
Fix pre-submit CI from building full rosetta-t5x multiarch matrix which is not possible yet

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -170,6 +170,7 @@ jobs:
       BUILD_DATE: ${{ needs.metadata.outputs.BUILD_DATE }}
       BASE_IMAGE: ${{ needs.build-t5x.outputs.DOCKER_TAGS }}
       BASE_LIBRARY: t5x
+      PLATFORMS: '["amd64"]'
     secrets: inherit
 
   build-rosetta-pax:


### PR DESCRIPTION
CI would erroneously say arm build failed, but it failued b/c there is no ARM t5x image yet. This change disables ARM builds for rosetta-t5x until https://github.com/NVIDIA/JAX-Toolbox/pull/252 is in