### PR TITLE
Create Docker manifest V2 schema 2 images in CI

### DIFF
--- a/.github/workflows/_publish_container.yaml
+++ b/.github/workflows/_publish_container.yaml
@@ -77,10 +77,6 @@ jobs:
 
           echo "manifests=$MANIFESTS" >> $GITHUB_OUTPUT
 
-      - name: Skopeo Login to GitHub Container Registry
-        run: |
-          echo ${{ secrets.GITHUB_TOKEN }} | skopeo login --authfile - ghcr.io
-
       - name: Create multi-arch images
         id: multi-arch
         shell: bash -x -e {0}

--- a/.github/workflows/_publish_container.yaml
+++ b/.github/workflows/_publish_container.yaml
@@ -77,6 +77,10 @@ jobs:
 
           echo "manifests=$MANIFESTS" >> $GITHUB_OUTPUT
 
+      - name: Skopeo Login to GitHub Container Registry
+        run: |
+          echo ${{ secrets.GITHUB_TOKEN }} | skopeo login --authfile - ghcr.io
+
       - name: Create multi-arch images
         id: multi-arch
         shell: bash -x -e {0}
@@ -84,10 +88,6 @@ jobs:
           for tag in $(echo "${{ steps.meta.outputs.tags }}"); do
             docker buildx imagetools create --tag $tag ${{ steps.get-manifests.outputs.manifests }}
           done
-
-      - name: Skopeo Login to GitHub Container Registry
-        run: |
-          echo ${{ secrets.GITHUB_TOKEN }} | skopeo login --authfile - ghcr.io
 
       - name: Create single-arch images
         if: ${{ inputs.EXPOSE_SINGLE_ARCH_IMAGES }}

--- a/.github/workflows/_retrofit_container.yaml
+++ b/.github/workflows/_retrofit_container.yaml
@@ -73,20 +73,15 @@ jobs:
         run: |
           echo ${{ secrets.GITHUB_TOKEN }} | skopeo login --authfile - ghcr.io
 
-      - name: Create Docker v2s2 multi-arch manifest list from extracted manifests
+      - name: Create Docker v2s2 multi-arch manifest list
         id: multi-arch
         shell: bash -x -e {0}
         run: |
-          manifests=""
-          for m in ${{ steps.get-manifests.outputs.manifests }}; do
-            manifests="${manifests} docker://${m}"
-          done
-
           for tag in $(echo "${{ steps.meta.outputs.tags }}"); do
-            skopeo copy --format v2s2 ${manifests} docker://$tag
+            skopeo copy --format v2s2 docker://${{ inputs.SOURCE_IMAGE }} docker://$tag
           done
 
-      - name: Create single-arch images
+      - name: Create Docker v2s2 single-arch manifests
         id: single-arch
         if: ${{ inputs.EXPOSE_SINGLE_ARCH_IMAGES }}
         shell: bash -x -e {0}

--- a/.github/workflows/_retrofit_container.yaml
+++ b/.github/workflows/_retrofit_container.yaml
@@ -17,9 +17,9 @@ on:
         required: false
         default: true
     outputs:
-      MULTIARCH_TAG:
-        description: "Tags of the multi-arch image published"
-        value: ${{ jobs.publish.outputs.MULTIARCH_TAG }}
+      # MULTIARCH_TAG:
+      #   description: "Tags of the multi-arch image published"
+      #   value: ${{ jobs.publish.outputs.MULTIARCH_TAG }}
       SINGLEARCH_TAGS:
         description: "Tags of the single-arch images published"
         value: ${{ jobs.publish.outputs.SINGLEARCH_TAGS }}
@@ -31,7 +31,7 @@ jobs:
   publish:
     runs-on: ubuntu-22.04
     outputs:
-      MULTIARCH_TAG: ${{ steps.meta.outputs.tags }}
+      # MULTIARCH_TAG: ${{ steps.meta.outputs.tags }}
       SINGLEARCH_TAGS: ${{ steps.single-arch.outputs.tags }}
     steps:
       - name: Login to GitHub Container Registry
@@ -69,19 +69,14 @@ jobs:
 
           echo "manifests=$MANIFESTS" >> $GITHUB_OUTPUT
 
-      - name: Skopeo Login to GitHub Container Registry
-        run: |
-          echo ${{ secrets.GITHUB_TOKEN }} | skopeo login --authfile - ghcr.io
-          skopeo --version
-          skopeo copy --help
-
-      - name: Create Docker v2s2 multi-arch manifest list
-        id: multi-arch
-        shell: bash -x -e {0}
-        run: |
-          for tag in $(echo "${{ steps.meta.outputs.tags }}"); do
-            skopeo copy --multi-arch all --format v2s2 docker://${{ inputs.SOURCE_IMAGE }} docker://$tag
-          done
+      ## Requires skopeo >= v1.6.0, but Actions only has v1.4.0
+      # - name: Create Docker v2s2 multi-arch manifest list
+      #   id: multi-arch
+      #   shell: bash -x -e {0}
+      #   run: |
+      #     for tag in $(echo "${{ steps.meta.outputs.tags }}"); do
+      #       skopeo copy --multi-arch all --format v2s2 docker://${{ inputs.SOURCE_IMAGE }} docker://$tag
+      #     done
 
       - name: Create Docker v2s2 single-arch manifests
         id: single-arch

--- a/.github/workflows/_retrofit_container.yaml
+++ b/.github/workflows/_retrofit_container.yaml
@@ -78,7 +78,7 @@ jobs:
         shell: bash -x -e {0}
         run: |
           for tag in $(echo "${{ steps.meta.outputs.tags }}"); do
-            skopeo copy --format v2s2 docker://${{ inputs.SOURCE_IMAGE }} docker://$tag
+            skopeo copy --multi-arch all --format v2s2 docker://${{ inputs.SOURCE_IMAGE }} docker://$tag
           done
 
       - name: Create Docker v2s2 single-arch manifests

--- a/.github/workflows/_retrofit_container.yaml
+++ b/.github/workflows/_retrofit_container.yaml
@@ -32,7 +32,7 @@ jobs:
     runs-on: ubuntu-22.04
     outputs:
       MULTIARCH_TAG: ${{ steps.meta.outputs.tags }}
-      SINGLEARCH_TAGS: ${{ step.create-single-arch.outputs.tags }}
+      SINGLEARCH_TAGS: ${{ steps.single-arch.outputs.tags }}
     steps:
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v2
@@ -78,7 +78,7 @@ jobs:
         shell: bash -x -e {0}
         run: |
           manifests=""
-          for m in ${{ step.get-manifests.outputs.manifests }}; do
+          for m in ${{ steps.get-manifests.outputs.manifests }}; do
             manifests="${manifests} docker://${m}"
           done
 
@@ -87,7 +87,7 @@ jobs:
           done
 
       - name: Create single-arch images
-        id: create-single-arch
+        id: single-arch
         if: ${{ inputs.EXPOSE_SINGLE_ARCH_IMAGES }}
         shell: bash -x -e {0}
         run: |

--- a/.github/workflows/_retrofit_container.yaml
+++ b/.github/workflows/_retrofit_container.yaml
@@ -1,0 +1,106 @@
+name: ~split multi-arch OCI manifests into Docker Image Manifest V2, Schema 2
+
+on:
+  workflow_call:
+    inputs:
+      SOURCE_IMAGE:
+        type: string
+        description: 'Source docker image:'
+        required: true
+      TARGET_TAGS:
+        type: string
+        description: 'Target docker tags in docker/metadata-action format:'
+        required: true
+      EXPOSE_SINGLE_ARCH_IMAGES:
+        type: boolean
+        description: 'Also expose single-arch images:'
+        required: false
+        default: true
+    outputs:
+      MULTIARCH_TAG:
+        description: "Tags of the multi-arch image published"
+        value: ${{ jobs.publish.outputs.MULTIARCH_TAG }}
+      SINGLEARCH_TAGS:
+        description: "Tags of the single-arch images published"
+        value: ${{ jobs.publish.outputs.SINGLEARCH_TAGS }}
+
+env:
+  DOCKER_REPOSITORY: 'ghcr.io/nvidia/jax-toolbox-retrofit'
+
+jobs:
+  publish:
+    runs-on: ubuntu-22.04
+    outputs:
+      MULTIARCH_TAG: ${{ steps.meta.outputs.tags }}
+      SINGLEARCH_TAGS: ${{ step.create-single-arch.outputs.tags }}
+    steps:
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set docker metadata
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: ${{ env.DOCKER_REPOSITORY }}
+          flavor: latest=false
+          tags: ${{ inputs.TARGET_TAGS }}
+
+      - name: Extract manifests from the source manifest list
+        id: get-manifests
+        shell: bash -x -e {0}
+        run: |
+          SOURCE_REPO=$(echo ${{ inputs.SOURCE_IMAGE }} | cut -d: -f1)
+          MEDIA_TYPE=$(docker manifest inspect ${{ inputs.SOURCE_IMAGE }} | jq -r '.mediaType')
+          if [[ ${MEDIA_TYPE} != "application/vnd.oci.image.index.v1+json" ]]; then
+            echo "This workflow only work with OCI manifest lists"
+            exit 1
+          fi
+
+          MANIFESTS=$(
+            docker manifest inspect ${{ inputs.SOURCE_IMAGE }} |\
+            jq -r '.manifests[] | select(.platform.os != "unknown") | .digest' |\
+            xargs -I{} echo ${SOURCE_REPO}@{} |\
+            tr '\n' ' '
+          )
+
+          echo "manifests=$MANIFESTS" >> $GITHUB_OUTPUT
+
+      - name: Skopeo Login to GitHub Container Registry
+        run: |
+          echo ${{ secrets.GITHUB_TOKEN }} | skopeo login --authfile - ghcr.io
+
+      - name: Create Docker v2s2 multi-arch manifest list from extracted manifests
+        id: multi-arch
+        shell: bash -x -e {0}
+        run: |
+          manifests=""
+          for m in ${{ step.get-manifests.outputs.manifests }}; do
+            manifests="${manifests} docker://${m}"
+          done
+
+          for tag in $(echo "${{ steps.meta.outputs.tags }}"); do
+            skopeo copy --format v2s2 ${manifests} docker://$tag
+          done
+
+      - name: Create single-arch images
+        id: create-single-arch
+        if: ${{ inputs.EXPOSE_SINGLE_ARCH_IMAGES }}
+        shell: bash -x -e {0}
+        run: |
+          output_tags=""
+          # Create new manifest list from extracted manifests
+          for manifest in ${{ steps.get-manifests.outputs.manifests }}; do
+            os=$(docker manifest inspect -v $manifest | jq -r '.Descriptor.platform.os')
+            arch=$(docker manifest inspect -v $manifest | jq -r '.Descriptor.platform.architecture')
+            for tag in $(echo "${{ steps.meta.outputs.tags }}"); do
+              single_arch_tag="${tag}-${os}-${arch}"
+              skopeo copy --format v2s2 docker://$manifest docker://${single_arch_tag}
+              output_tags="${output_tags} ${single_arch_tag}"
+            done
+          done
+
+          echo "tags=${output_tags}" >> $GITHUB_OUTPUT

--- a/.github/workflows/_retrofit_container.yaml
+++ b/.github/workflows/_retrofit_container.yaml
@@ -72,6 +72,8 @@ jobs:
       - name: Skopeo Login to GitHub Container Registry
         run: |
           echo ${{ secrets.GITHUB_TOKEN }} | skopeo login --authfile - ghcr.io
+          skopeo --version
+          skopeo copy --help
 
       - name: Create Docker v2s2 multi-arch manifest list
         id: multi-arch

--- a/.github/workflows/_sandbox.yaml
+++ b/.github/workflows/_sandbox.yaml
@@ -50,8 +50,8 @@ jobs:
             source_repo=$(echo ${source} | cut -d: -f1)
             media_type=$(docker manifest inspect ${source} | jq -r '.mediaType')
             if [[ ${media_type} != "application/vnd.oci.image.index.v1+json" ]]; then
-              echo "This workflow only work with OCI manifest lists"
-              exit 1
+              echo "Image ${source} is already in Docker format v2s2"
+              continue
             fi
 
             manifests=$(
@@ -64,10 +64,8 @@ jobs:
             for manifest in ${{ steps.get-manifests.outputs.manifests }}; do
               os=$(docker manifest inspect -v $manifest | jq -r '.Descriptor.platform.os')
               arch=$(docker manifest inspect -v $manifest | jq -r '.Descriptor.platform.architecture')
-              for tag in $(echo "${{ steps.meta.outputs.tags }}"); do
-                single_arch_tag="ghcr.io/nvidia/jax-toolbox-retrofit:${{ github.run_id }}-${os}-${arch}"
-                skopeo copy --format v2s2 docker://$manifest docker://${single_arch_tag}
-                echo "${single_arch_tag}" >> $GITHUB_STEP_SUMMARY
-              done
+              single_arch_tag="ghcr.io/nvidia/jax-toolbox-retrofit:${{ github.run_id }}-${os}-${arch}"
+              skopeo copy --format v2s2 docker://$manifest docker://${single_arch_tag}
+              echo "${single_arch_tag}" >> $GITHUB_STEP_SUMMARY
             done
           done

--- a/.github/workflows/_sandbox.yaml
+++ b/.github/workflows/_sandbox.yaml
@@ -9,13 +9,23 @@ permissions:
   packages: write # to upload container
 
 jobs:
+  retrofit:
+    uses: ./.github/workflows/_retrofit_container.yaml
+    with:
+      SOURCE_IMAGE: 'ghcr.io/nvidia/jax:latest'
+      TARGET_TAGS: |
+        type=raw,value=${{ github.run_id }},priority=900
+      EXPOSE_SINGLE_ARCH_IMAGES: true
+    secrets: inherit
+
   retrofit-containers:
     runs-on: ubuntu-22.04
     steps:
       - name: Skopeo Login to GitHub Container Registry
+        shell: bash -x -e {0}
         run: |
           skopeo --version
-          echo ${{ secrets.GITHUB_TOKEN }} | skopeo login --authfile - --password-stdin ghcr.io
+          echo ${{ secrets.GITHUB_TOKEN }} | skopeo login --authfile - ghcr.io
 
       ## Requires skopeo >= v1.6.0, but Actions only has v1.4.0
       # - name: Create Docker v2s2 multi-arch manifest list

--- a/.github/workflows/_sandbox.yaml
+++ b/.github/workflows/_sandbox.yaml
@@ -67,9 +67,7 @@ jobs:
               for tag in $(echo "${{ steps.meta.outputs.tags }}"); do
                 single_arch_tag="ghcr.io/nvidia/jax-toolbox-retrofit:${{ github.run_id }}-${os}-${arch}"
                 skopeo copy --format v2s2 docker://$manifest docker://${single_arch_tag}
-                cat >> $GITHUB_STEP_SUMMARY << EOF
-                ${single_arch_tag}
-                EOF
+                echo "${single_arch_tag}" >> $GITHUB_STEP_SUMMARY
               done
             done
           done

--- a/.github/workflows/_sandbox.yaml
+++ b/.github/workflows/_sandbox.yaml
@@ -21,11 +21,12 @@ jobs:
   retrofit-containers:
     runs-on: ubuntu-22.04
     steps:
-      - name: Skopeo Login to GitHub Container Registry
-        shell: bash -x -e {0}
-        run: |
-          skopeo --version
-          echo ${{ secrets.GITHUB_TOKEN }} | skopeo login --authfile - ghcr.io
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       ## Requires skopeo >= v1.6.0, but Actions only has v1.4.0
       # - name: Create Docker v2s2 multi-arch manifest list

--- a/.github/workflows/_sandbox.yaml
+++ b/.github/workflows/_sandbox.yaml
@@ -61,10 +61,11 @@ jobs:
               tr '\n' ' '
             )
 
+            dest_tag=$(echo ${source} | cut -d: -f1 | cut -d/ -f3)-$(echo ${source} | cut -d: -f2)
             for manifest in ${manifests}; do
               os=$(docker manifest inspect -v $manifest | jq -r '.Descriptor.platform.os')
               arch=$(docker manifest inspect -v $manifest | jq -r '.Descriptor.platform.architecture')
-              single_arch_tag="ghcr.io/nvidia/jax-toolbox-retrofit:${{ github.run_id }}-${os}-${arch}"
+              single_arch_tag="ghcr.io/nvidia/jax-toolbox-retrofit:${{ github.run_id }}-${dest_tag}-${os}-${arch}"
               skopeo copy --format v2s2 docker://$manifest docker://${single_arch_tag}
               echo "${single_arch_tag}" >> $GITHUB_STEP_SUMMARY
             done

--- a/.github/workflows/_sandbox.yaml
+++ b/.github/workflows/_sandbox.yaml
@@ -13,9 +13,11 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Skopeo Login to GitHub Container Registry
+        env:
+          PASSWORD: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          echo ${{ secrets.GITHUB_TOKEN }} | skopeo login --authfile - ghcr.io
           skopeo --version
+          echo $PASSWORD | skopeo login --authfile - ghcr.io
 
       ## Requires skopeo >= v1.6.0, but Actions only has v1.4.0
       # - name: Create Docker v2s2 multi-arch manifest list

--- a/.github/workflows/_sandbox.yaml
+++ b/.github/workflows/_sandbox.yaml
@@ -13,11 +13,9 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Skopeo Login to GitHub Container Registry
-        shell: bash -x -e {0}
         run: |
           echo ${{ secrets.GITHUB_TOKEN }} | skopeo login --authfile - ghcr.io
           skopeo --version
-          skopeo copy --help
 
       ## Requires skopeo >= v1.6.0, but Actions only has v1.4.0
       # - name: Create Docker v2s2 multi-arch manifest list

--- a/.github/workflows/_sandbox.yaml
+++ b/.github/workflows/_sandbox.yaml
@@ -55,7 +55,7 @@ jobs:
             fi
 
             manifests=$(
-              docker manifest inspect ${{ inputs.SOURCE_IMAGE }} |\
+              docker manifest inspect ${source} |\
               jq -r '.manifests[] | select(.platform.os != "unknown") | .digest' |\
               xargs -I{} echo ${source_repo}@{} |\
               tr '\n' ' '

--- a/.github/workflows/_sandbox.yaml
+++ b/.github/workflows/_sandbox.yaml
@@ -48,7 +48,7 @@ jobs:
             ghcr.io/nvidia/t5x:latest         \
           ; do
             source_repo=$(echo ${source} | cut -d: -f1)
-            media_type=$(docker manifest inspect ${{ inputs.SOURCE_IMAGE }} | jq -r '.mediaType')
+            media_type=$(docker manifest inspect ${source} | jq -r '.mediaType')
             if [[ ${media_type} != "application/vnd.oci.image.index.v1+json" ]]; then
               echo "This workflow only work with OCI manifest lists"
               exit 1

--- a/.github/workflows/_sandbox.yaml
+++ b/.github/workflows/_sandbox.yaml
@@ -12,7 +12,7 @@ jobs:
   retrofit:
     uses: ./.github/workflows/_retrofit_container.yaml
     with:
-      SOURCE_IMAGE: 'ghcr.io/nvidia/jax-toolbox:latest'
+      SOURCE_IMAGE: 'ghcr.io/nvidia/jax:latest'
       TARGET_TAGS: |
         type=raw,value=${{ github.run_id }},priority=900
       EXPOSE_SINGLE_ARCH_IMAGES: true

--- a/.github/workflows/_sandbox.yaml
+++ b/.github/workflows/_sandbox.yaml
@@ -13,11 +13,9 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Skopeo Login to GitHub Container Registry
-        env:
-          PASSWORD: ${{ secrets.GITHUB_TOKEN }}
         run: |
           skopeo --version
-          echo $PASSWORD | skopeo login --authfile - ghcr.io
+          echo ${{ secrets.GITHUB_TOKEN }} | skopeo login --authfile - --password-stdin ghcr.io
 
       ## Requires skopeo >= v1.6.0, but Actions only has v1.4.0
       # - name: Create Docker v2s2 multi-arch manifest list

--- a/.github/workflows/_sandbox.yaml
+++ b/.github/workflows/_sandbox.yaml
@@ -9,11 +9,58 @@ permissions:
   packages: write # to upload container
 
 jobs:
-  retrofit:
-    uses: ./.github/workflows/_retrofit_container.yaml
-    with:
-      SOURCE_IMAGE: 'ghcr.io/nvidia/jax:latest'
-      TARGET_TAGS: |
-        type=raw,value=${{ github.run_id }},priority=900
-      EXPOSE_SINGLE_ARCH_IMAGES: true
-    secrets: inherit
+  retrofit-containers:
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Skopeo Login to GitHub Container Registry
+        shell: bash -x -e {0}
+        run: |
+          echo ${{ secrets.GITHUB_TOKEN }} | skopeo login --authfile - ghcr.io
+          skopeo --version
+          skopeo copy --help
+
+      ## Requires skopeo >= v1.6.0, but Actions only has v1.4.0
+      # - name: Create Docker v2s2 multi-arch manifest list
+      #   id: multi-arch
+      #   shell: bash -x -e {0}
+      #   run: |
+      #     for tag in $(echo "${{ steps.meta.outputs.tags }}"); do
+      #       skopeo copy --multi-arch all --format v2s2 docker://${{ inputs.SOURCE_IMAGE }} docker://$tag
+      #     done
+
+      - name: Create Docker v2s2 single-arch manifests
+        id: single-arch
+        shell: bash -x -e {0}
+        run: |
+
+          for source in \
+            ghcr.io/nvidia/jax-toolbox:base   \
+            ghcr.io/nvidia/jax:latest         \
+            ghcr.io/nvidia/t5x:latest         \
+          ; do
+            source_repo=$(echo ${source} | cut -d: -f1)
+            media_type=$(docker manifest inspect ${{ inputs.SOURCE_IMAGE }} | jq -r '.mediaType')
+            if [[ ${media_type} != "application/vnd.oci.image.index.v1+json" ]]; then
+              echo "This workflow only work with OCI manifest lists"
+              exit 1
+            fi
+
+            manifests=$(
+              docker manifest inspect ${{ inputs.SOURCE_IMAGE }} |\
+              jq -r '.manifests[] | select(.platform.os != "unknown") | .digest' |\
+              xargs -I{} echo ${source_repo}@{} |\
+              tr '\n' ' '
+            )
+
+            for manifest in ${{ steps.get-manifests.outputs.manifests }}; do
+              os=$(docker manifest inspect -v $manifest | jq -r '.Descriptor.platform.os')
+              arch=$(docker manifest inspect -v $manifest | jq -r '.Descriptor.platform.architecture')
+              for tag in $(echo "${{ steps.meta.outputs.tags }}"); do
+                single_arch_tag="ghcr.io/nvidia/jax-toolbox-retrofit:${{ github.run_id }}-${os}-${arch}"
+                skopeo copy --format v2s2 docker://$manifest docker://${single_arch_tag}
+                cat >> $GITHUB_STEP_SUMMARY << EOF
+                ${single_arch_tag}
+                EOF
+              done
+            done
+          done

--- a/.github/workflows/_sandbox.yaml
+++ b/.github/workflows/_sandbox.yaml
@@ -1,24 +1,10 @@
 name: "~Sandbox"
 
 on:
-  push:
-
-permissions:
-  contents: read  # to fetch code
-  actions:  write # to cancel previous workflows
-  packages: write # to upload container
+  workflow_dispatch:
 
 jobs:
-  retrofit:
-    uses: ./.github/workflows/_retrofit_container.yaml
-    with:
-      SOURCE_IMAGE: 'ghcr.io/nvidia/jax:latest'
-      TARGET_TAGS: |
-        type=raw,value=${{ github.run_id }},priority=900
-      EXPOSE_SINGLE_ARCH_IMAGES: true
-    secrets: inherit
-
-  retrofit-containers:
+  sandbox:
     runs-on: ubuntu-22.04
     steps:
       - name: Login to GitHub Container Registry
@@ -28,45 +14,28 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      ## Requires skopeo >= v1.6.0, but Actions only has v1.4.0
-      # - name: Create Docker v2s2 multi-arch manifest list
-      #   id: multi-arch
-      #   shell: bash -x -e {0}
-      #   run: |
-      #     for tag in $(echo "${{ steps.meta.outputs.tags }}"); do
-      #       skopeo copy --multi-arch all --format v2s2 docker://${{ inputs.SOURCE_IMAGE }} docker://$tag
-      #     done
-
-      - name: Create Docker v2s2 single-arch manifests
-        id: single-arch
-        shell: bash -x -e {0}
+      - name: Print usage
         run: |
+          cat << EOF
+          This is an empty workflow file located in the main branch of your
+          repository. It serves as a testing ground for new GitHub Actions on
+          development branches before merging them to the main branch. By
+          defining and overloading this workflow on your development branch,
+          you can test new actions without affecting your main branch, ensuring
+          a smooth integration process once the changes are ready to be merged.
 
-          for source in \
-            ghcr.io/nvidia/jax-toolbox:base   \
-            ghcr.io/nvidia/jax:latest         \
-            ghcr.io/nvidia/t5x:latest         \
-          ; do
-            source_repo=$(echo ${source} | cut -d: -f1)
-            media_type=$(docker manifest inspect ${source} | jq -r '.mediaType')
-            if [[ ${media_type} != "application/vnd.oci.image.index.v1+json" ]]; then
-              echo "Image ${source} is already in Docker format v2s2"
-              continue
-            fi
-
-            manifests=$(
-              docker manifest inspect ${source} |\
-              jq -r '.manifests[] | select(.platform.os != "unknown") | .digest' |\
-              xargs -I{} echo ${source_repo}@{} |\
-              tr '\n' ' '
-            )
-
-            dest_tag=$(echo ${source} | cut -d: -f1 | cut -d/ -f3)-$(echo ${source} | cut -d: -f2)
-            for manifest in ${manifests}; do
-              os=$(docker manifest inspect -v $manifest | jq -r '.Descriptor.platform.os')
-              arch=$(docker manifest inspect -v $manifest | jq -r '.Descriptor.platform.architecture')
-              single_arch_tag="ghcr.io/nvidia/jax-toolbox-retrofit:${{ github.run_id }}-${dest_tag}-${os}-${arch}"
-              skopeo copy --format v2s2 docker://$manifest docker://${single_arch_tag}
-              echo "${single_arch_tag}" >> $GITHUB_STEP_SUMMARY
-            done
-          done
+          Usage:
+          
+          1. In your development branch, modify the sandbox.yml workflow file
+             to include the new actions you want to test. Make sure to commit
+             the changes to the development branch.
+          2. Navigate to the 'Actions' tab in your repository, select the
+             '~Sandbox' workflow, and choose your development branch from the
+             branch dropdown menu. Click on 'Run workflow' to trigger the
+             workflow on your development branch.
+          3. Once you have tested and verified the new actions in the Sandbox
+             workflow, you can incorporate them into your main workflow(s) and
+             merge the development branch into the main branch. Remember to
+             revert the changes to the sandbox.yml file in the main branch to
+             keep it empty for future testing.
+          EOF

--- a/.github/workflows/_sandbox.yaml
+++ b/.github/workflows/_sandbox.yaml
@@ -61,7 +61,7 @@ jobs:
               tr '\n' ' '
             )
 
-            for manifest in ${{ steps.get-manifests.outputs.manifests }}; do
+            for manifest in ${manifests}; do
               os=$(docker manifest inspect -v $manifest | jq -r '.Descriptor.platform.os')
               arch=$(docker manifest inspect -v $manifest | jq -r '.Descriptor.platform.architecture')
               single_arch_tag="ghcr.io/nvidia/jax-toolbox-retrofit:${{ github.run_id }}-${os}-${arch}"

--- a/.github/workflows/_sandbox.yaml
+++ b/.github/workflows/_sandbox.yaml
@@ -1,41 +1,19 @@
 name: "~Sandbox"
 
 on:
-  workflow_dispatch:
+  push:
+
+permissions:
+  contents: read  # to fetch code
+  actions:  write # to cancel previous workflows
+  packages: write # to upload container
 
 jobs:
-  sandbox:
-    runs-on: ubuntu-22.04
-    steps:
-      - name: Login to GitHub Container Registry
-        uses: docker/login-action@v2
-        with:
-          registry: ghcr.io
-          username: ${{ github.repository_owner }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Print usage
-        run: |
-          cat << EOF
-          This is an empty workflow file located in the main branch of your
-          repository. It serves as a testing ground for new GitHub Actions on
-          development branches before merging them to the main branch. By
-          defining and overloading this workflow on your development branch,
-          you can test new actions without affecting your main branch, ensuring
-          a smooth integration process once the changes are ready to be merged.
-
-          Usage:
-          
-          1. In your development branch, modify the sandbox.yml workflow file
-             to include the new actions you want to test. Make sure to commit
-             the changes to the development branch.
-          2. Navigate to the 'Actions' tab in your repository, select the
-             '~Sandbox' workflow, and choose your development branch from the
-             branch dropdown menu. Click on 'Run workflow' to trigger the
-             workflow on your development branch.
-          3. Once you have tested and verified the new actions in the Sandbox
-             workflow, you can incorporate them into your main workflow(s) and
-             merge the development branch into the main branch. Remember to
-             revert the changes to the sandbox.yml file in the main branch to
-             keep it empty for future testing.
-          EOF
+  retrofit:
+    uses: ./.github/workflows/_retrofit_container.yaml
+    with:
+      SOURCE_IMAGE: 'ghcr.io/nvidia/jax-toolbox:latest'
+      TARGET_TAGS: |
+        type=raw,value=${{ github.run_id }},priority=900
+      EXPOSE_SINGLE_ARCH_IMAGES: true
+    secrets: inherit

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -192,6 +192,65 @@ jobs:
           | ROSETTA(pax) | ${{ needs.build-rosetta-pax.outputs.DOCKER_TAGS }} |
           EOF
 
+  retrofit-containers:
+    needs: [build-base, build-jax, build-te, build-t5x, build-pax, build-rosetta-t5x, build-rosetta-pax]
+    if: always()
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      ## Requires skopeo >= v1.6.0, but Actions only has v1.4.0
+      # - name: Create Docker v2s2 multi-arch manifest list
+      #   id: multi-arch
+      #   shell: bash -x -e {0}
+      #   run: |
+      #     for tag in $(echo "${{ steps.meta.outputs.tags }}"); do
+      #       skopeo copy --multi-arch all --format v2s2 docker://${{ inputs.SOURCE_IMAGE }} docker://$tag
+      #     done
+
+      - name: Create Docker v2s2 single-arch manifests
+        id: single-arch
+        shell: bash -x -e {0}
+        run: |
+
+          for source in \
+            ${{ needs.build-base.outputs.DOCKER_TAGS }}        \
+            ${{ needs.build-jax.outputs.DOCKER_TAGS }}         \
+            ${{ needs.build-te.outputs.DOCKER_TAGS }}          \
+            ${{ needs.build-t5x.outputs.DOCKER_TAGS }}         \
+            ${{ needs.build-pax.outputs.DOCKER_TAGS }}         \
+            ${{ needs.build-rosetta-t5x.outputs.DOCKER_TAGS }} \
+            ${{ needs.build-rosetta-pax.outputs.DOCKER_TAGS }} \
+          ; do
+            source_repo=$(echo ${source} | cut -d: -f1)
+            media_type=$(docker manifest inspect ${source} | jq -r '.mediaType')
+            if [[ ${media_type} != "application/vnd.oci.image.index.v1+json" ]]; then
+              echo "Image ${source} is already in Docker format v2s2"
+              continue
+            fi
+
+            manifests=$(
+              docker manifest inspect ${source} |\
+              jq -r '.manifests[] | select(.platform.os != "unknown") | .digest' |\
+              xargs -I{} echo ${source_repo}@{} |\
+              tr '\n' ' '
+            )
+
+            dest_tag=$(echo ${source} | cut -d: -f1 | cut -d/ -f3)-$(echo ${source} | cut -d: -f2)
+            for manifest in ${manifests}; do
+              os=$(docker manifest inspect -v $manifest | jq -r '.Descriptor.platform.os')
+              arch=$(docker manifest inspect -v $manifest | jq -r '.Descriptor.platform.architecture')
+              single_arch_tag="ghcr.io/nvidia/jax-toolbox-retrofit:${{ github.run_id }}-${dest_tag}-${os}-${arch}"
+              skopeo copy --format v2s2 docker://$manifest docker://${single_arch_tag}
+              echo "${single_arch_tag}" >> $GITHUB_STEP_SUMMARY
+            done
+          done
+
   test-distribution:
     needs: metadata
     uses: ./.github/workflows/_test_distribution.yaml

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -196,6 +196,8 @@ jobs:
     needs: [build-base, build-jax, build-te, build-t5x, build-pax, build-rosetta-t5x, build-rosetta-pax]
     if: always()
     runs-on: ubuntu-22.04
+    env:
+      DOCKER_REPO: 'ghcr.io/nvidia/jax-toolbox-retrofit'
     steps:
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v2
@@ -231,24 +233,31 @@ jobs:
             media_type=$(docker manifest inspect ${source} | jq -r '.mediaType')
             if [[ ${media_type} != "application/vnd.oci.image.index.v1+json" ]]; then
               echo "Image ${source} is already in Docker format v2s2"
-              continue
+              dest=${DOCKER_REPO}:$(echo ${source} | cut -d: -f2)
+              skopeo copy --format v2s2 docker://${source} docker://${dest}
+              echo "${dest}" >> $GITHUB_STEP_SUMMARY
+            else
+              manifests=$(
+                docker manifest inspect ${source} |\
+                jq -r '.manifests[] | select(.platform.os != "unknown") | .digest' |\
+                xargs -I{} echo ${source_repo}@{} |\
+                tr '\n' ' '
+              )
+
+              ## registry/org/repo:tag -> repo-tag
+              # dest_tag=$(echo ${source} | cut -d: -f1 | cut -d/ -f3)-$(echo ${source} | cut -d: -f2)
+              ## registry/org/repo:tag -> tag
+              dest_tag=$(echo ${source} | cut -d: -f2)
+
+              for manifest in ${manifests}; do
+                os=$(docker manifest inspect -v $manifest | jq -r '.Descriptor.platform.os')
+                arch=$(docker manifest inspect -v $manifest | jq -r '.Descriptor.platform.architecture')
+                # single_arch_tag="ghcr.io/nvidia/jax-toolbox-retrofit:${{ github.run_id }}-${dest_tag}-${os}-${arch}"
+                single_arch_tag="${DOCKER_REPO}:${dest_tag}-${os}-${arch}"
+                skopeo copy --format v2s2 docker://$manifest docker://${single_arch_tag}
+                echo "${single_arch_tag}" >> $GITHUB_STEP_SUMMARY
+              done
             fi
-
-            manifests=$(
-              docker manifest inspect ${source} |\
-              jq -r '.manifests[] | select(.platform.os != "unknown") | .digest' |\
-              xargs -I{} echo ${source_repo}@{} |\
-              tr '\n' ' '
-            )
-
-            dest_tag=$(echo ${source} | cut -d: -f1 | cut -d/ -f3)-$(echo ${source} | cut -d: -f2)
-            for manifest in ${manifests}; do
-              os=$(docker manifest inspect -v $manifest | jq -r '.Descriptor.platform.os')
-              arch=$(docker manifest inspect -v $manifest | jq -r '.Descriptor.platform.architecture')
-              single_arch_tag="ghcr.io/nvidia/jax-toolbox-retrofit:${{ github.run_id }}-${dest_tag}-${os}-${arch}"
-              skopeo copy --format v2s2 docker://$manifest docker://${single_arch_tag}
-              echo "${single_arch_tag}" >> $GITHUB_STEP_SUMMARY
-            done
           done
 
   test-distribution:


### PR DESCRIPTION
These images will be located in the `ghcr.io/nvidia/jax-toolbox-retrofit` repo.

Example images created:
- [6584312905-jax-toolbox-internal-6584312905-pax-multiarch-linux-amd64](https://github.com/orgs/NVIDIA/packages/container/jax-toolbox-retrofit/139560350?tag=6584312905-jax-toolbox-internal-6584312905-pax-multiarch-linux-amd64)
- [6584312905-jax-toolbox-internal-6584312905-pax-multiarch-linux-arm64](https://github.com/orgs/NVIDIA/packages/container/jax-toolbox-retrofit/139560297?tag=6584312905-jax-toolbox-internal-6584312905-pax-multiarch-linux-arm64)
- [6584312905-jax-toolbox-internal-6584312905-upstream-pax-multiarch-linux-arm64](https://github.com/orgs/NVIDIA/packages/container/jax-toolbox-retrofit/139560221?tag=6584312905-jax-toolbox-internal-6584312905-upstream-pax-multiarch-linux-arm64)
- [6584312905-jax-toolbox-internal-6584312905-upstream-pax-multiarch-linux-amd64](https://github.com/orgs/NVIDIA/packages/container/jax-toolbox-retrofit/139560133?tag=6584312905-jax-toolbox-internal-6584312905-upstream-pax-multiarch-linux-amd64)
- [6584312905-jax-toolbox-internal-6584312905-jax-multiarch-linux-amd64](https://github.com/orgs/NVIDIA/packages/container/jax-toolbox-retrofit/139560018?tag=6584312905-jax-toolbox-internal-6584312905-jax-multiarch-linux-amd64)
- [6584312905-jax-toolbox-internal-6584312905-jax-multiarch-linux-arm64](https://github.com/orgs/NVIDIA/packages/container/jax-toolbox-retrofit/139559937?tag=6584312905-jax-toolbox-internal-6584312905-jax-multiarch-linux-arm64)
- [6584312905-jax-toolbox-internal-6584312905-base-multiarch-linux-amd64](https://github.com/orgs/NVIDIA/packages/container/jax-toolbox-retrofit/139559812?tag=6584312905-jax-toolbox-internal-6584312905-base-multiarch-linux-amd64)
- [6584312905-jax-toolbox-internal-6584312905-base-multiarch-linux-arm64](https://github.com/orgs/NVIDIA/packages/container/jax-toolbox-retrofit/139559652?tag=6584312905-jax-toolbox-internal-6584312905-base-multiarch-linux-arm64)
