### PR TITLE
Loosens t5x loss tests relative tolerances

### DIFF
--- a/.github/workflows/baselines/test_t5x_mgmn_metrics.py
+++ b/.github/workflows/baselines/test_t5x_mgmn_metrics.py
@@ -7,18 +7,18 @@ from statistics import mean
 from numpy.testing import assert_allclose
 
 LOSS_RTOL = {
-    '1G1N': 0.02,
-    '1G2N': 0.03,
-    '1P1G': 0.03,
-    '1P2G': 0.03,
-    '1P4G': 0.035,
-    '1P8G': 0.035,
-    '2G1N': 0.025,
-    '2G2N': 0.015,
-    '4G1N': 0.04,  # orig = 0.03
-    '4G2N': 0.03,
-    '8G1N': 0.03,
-    '8G2N': 0.05
+    '1G1N': 0.10,  # orig = 0.02
+    '1G2N': 0.10,  # orig = 0.03
+    '1P1G': 0.10,  # orig = 0.03
+    '1P2G': 0.10,  # orig = 0.03
+    '1P4G': 0.10,  # orig = 0.035
+    '1P8G': 0.10,  # orig = 0.035
+    '2G1N': 0.10,  # orig = 0.025
+    '2G2N': 0.10,  # orig = 0.015
+    '4G1N': 0.10,  # orig = 0.03
+    '4G2N': 0.10,  # orig = 0.03
+    '8G1N': 0.10,  # orig = 0.03
+    '8G2N': 0.10,  # orig = 0.05
 }
 STEP_TIME_MULT = {
     "1G1N": 0.95,


### PR DESCRIPTION
Relaxing the relative tolerance on the loss tests since it was leading to too many false positives. For reference, deviation in loss for the t5 model can sometimes be up to 15% at the start of training with real data. 