### PR TITLE
Dynamic workflow run names

### DIFF
--- a/.github/workflows/cuda-121-jax-pin.yaml
+++ b/.github/workflows/cuda-121-jax-pin.yaml
@@ -1,4 +1,5 @@
 name: Nightly Containers on CUDA 12.1 (JAX pinned)
+run-name: Nightly Containers on CUDA 12.1 (JAX pinned) (${{ github.event_name == 'workflow_run' && format('nightly {0}', github.event.workflow_run.created_at) || github.event_name }})
 
 on:
   schedule:

--- a/.github/workflows/cuda-122-jax-pin.yaml
+++ b/.github/workflows/cuda-122-jax-pin.yaml
@@ -1,4 +1,5 @@
 name: Nightly Containers on CUDA 12.2 (JAX pinned)
+run-name: Nightly Containers on CUDA 12.2 (JAX pinned) (${{ github.event_name == 'workflow_run' && format('nightly {0}', github.event.workflow_run.created_at) || github.event_name }})
 
 on:
   schedule:

--- a/.github/workflows/nightly-distribution-test.yaml
+++ b/.github/workflows/nightly-distribution-test.yaml
@@ -4,9 +4,9 @@ run-name: Nightly Distribution test (${{ github.event_name == 'workflow_run' && 
 on:
   workflow_dispatch:
   workflow_run:
-    workflows: [~Sandbox]
+    workflows: [Nightly JAX build]
     types: [completed]
-    branches: [dynamic-names]
+    branches: [main]
 
 permissions:
   contents: read  # to fetch code

--- a/.github/workflows/nightly-distribution-test.yaml
+++ b/.github/workflows/nightly-distribution-test.yaml
@@ -1,4 +1,5 @@
 name: Nightly Distribution test
+run-name: Nightly Distribution test (${{ github.event_name == 'workflow_run' && format('nightly {0}', github.event.workflow_run.created_at) || github.event_name }})
 
 on:
   workflow_dispatch:

--- a/.github/workflows/nightly-distribution-test.yaml
+++ b/.github/workflows/nightly-distribution-test.yaml
@@ -4,9 +4,9 @@ run-name: Nightly Distribution test (${{ github.event_name == 'workflow_run' && 
 on:
   workflow_dispatch:
   workflow_run:
-    workflows: [Nightly JAX build]
+    workflows: [~Sandbox]
     types: [completed]
-    branches: [main]
+    branches: [dynamic-names]
 
 permissions:
   contents: read  # to fetch code

--- a/.github/workflows/nightly-distribution-test.yaml
+++ b/.github/workflows/nightly-distribution-test.yaml
@@ -1,5 +1,5 @@
 name: Nightly Distribution test
-run-name: ${{ github.event.workflow.name }} (${{ github.event_name == 'workflow_run' && format('nightly {0}', github.event.workflow_run.created_at) || github.event_name }})
+run-name: Nightly Distribution test (${{ github.event_name == 'workflow_run' && format('nightly {0}', github.event.workflow_run.created_at) || github.event_name }})
 
 on:
   workflow_dispatch:

--- a/.github/workflows/nightly-distribution-test.yaml
+++ b/.github/workflows/nightly-distribution-test.yaml
@@ -1,5 +1,5 @@
 name: Nightly Distribution test
-run-name: Nightly Distribution test (${{ github.event_name == 'workflow_run' && format('nightly {0}', github.event.workflow_run.created_at) || github.event_name }})
+run-name: ${{ github.event.workflow.name }} (${{ github.event_name == 'workflow_run' && format('nightly {0}', github.event.workflow_run.created_at) || github.event_name }})
 
 on:
   workflow_dispatch:

--- a/.github/workflows/nightly-jax-build.yaml
+++ b/.github/workflows/nightly-jax-build.yaml
@@ -1,4 +1,5 @@
 name: Nightly JAX build
+run-name: Nightly JAX build (${{ github.event_name == 'workflow_run' && format('nightly {0}', github.event.workflow_run.created_at) || github.event_name }})
 
 on:
   schedule:

--- a/.github/workflows/nightly-jax-test-unit.yaml
+++ b/.github/workflows/nightly-jax-test-unit.yaml
@@ -1,4 +1,5 @@
 name: Nightly JAX unit test
+run-name: Nightly JAX unit test (${{ github.event_name == 'workflow_run' && format('nightly {0}', github.event.workflow_run.created_at) || github.event_name }})
 
 on:
   workflow_run:

--- a/.github/workflows/nightly-pax-build.yaml
+++ b/.github/workflows/nightly-pax-build.yaml
@@ -1,4 +1,5 @@
 name: Nightly Pax build
+run-name: Nightly Pax build (${{ github.event_name == 'workflow_run' && format('nightly {0}', github.event.workflow_run.created_at) || github.event_name }})
 
 on:
   workflow_run:

--- a/.github/workflows/nightly-pax-test-mgmn.yaml
+++ b/.github/workflows/nightly-pax-test-mgmn.yaml
@@ -1,4 +1,5 @@
 name: Nightly Pax MGMN performance test
+run-name: Nightly Pax MGMN performance test (${{ github.event_name == 'workflow_run' && format('nightly {0}', github.event.workflow_run.created_at) || github.event_name }})
 
 on:
   workflow_run:

--- a/.github/workflows/nightly-rosetta-pax-build.yaml
+++ b/.github/workflows/nightly-rosetta-pax-build.yaml
@@ -1,4 +1,5 @@
 name: Nightly Rosetta Paxml build and test
+run-name: Nightly Rosetta Paxml build and test (${{ github.event_name == 'workflow_run' && format('nightly {0}', github.event.workflow_run.created_at) || github.event_name }})
 
 on:
   workflow_run:

--- a/.github/workflows/nightly-rosetta-t5x-build-test.yaml
+++ b/.github/workflows/nightly-rosetta-t5x-build-test.yaml
@@ -1,4 +1,5 @@
 name: Nightly Rosetta T5x build and test
+run-name: Nightly Rosetta T5x build and test (${{ github.event_name == 'workflow_run' && format('nightly {0}', github.event.workflow_run.created_at) || github.event_name }})
 
 on:
   workflow_run:

--- a/.github/workflows/nightly-t5x-build.yaml
+++ b/.github/workflows/nightly-t5x-build.yaml
@@ -1,4 +1,5 @@
 name: Nightly T5X build
+run-name: Nightly T5X build (${{ github.event_name == 'workflow_run' && format('nightly {0}', github.event.workflow_run.created_at) || github.event_name }})
 
 on:
   workflow_run:

--- a/.github/workflows/nightly-t5x-test-mgmn.yaml
+++ b/.github/workflows/nightly-t5x-test-mgmn.yaml
@@ -1,4 +1,5 @@
 name: Nightly T5X MGMN performance test
+run-name: Nightly T5X MGMN performance test (${{ github.event_name == 'workflow_run' && format('nightly {0}', github.event.workflow_run.created_at) || github.event_name }})
 
 on:
   workflow_run:

--- a/.github/workflows/nightly-te-build.yaml
+++ b/.github/workflows/nightly-te-build.yaml
@@ -1,4 +1,5 @@
 name: Nightly Transformer Engine build
+run-name: Nightly Transformer Engine build (${{ github.event_name == 'workflow_run' && format('nightly {0}', github.event.workflow_run.created_at) || github.event_name }})
 
 on:
   workflow_run:

--- a/.github/workflows/nightly-te-test.yaml
+++ b/.github/workflows/nightly-te-test.yaml
@@ -1,4 +1,5 @@
 name: Nightly Transformer Engine test
+run-name: Nightly Transformer Engine test (${{ github.event_name == 'workflow_run' && format('nightly {0}', github.event.workflow_run.created_at) || github.event_name }})
 
 on:
   workflow_run:

--- a/.github/workflows/pax-cuda-121.yaml
+++ b/.github/workflows/pax-cuda-121.yaml
@@ -1,4 +1,5 @@
 name: Nightly Containers on CUDA 12.1
+run-name: Nightly Containers on CUDA 12.1 (${{ github.event_name == 'workflow_run' && format('nightly {0}', github.event.workflow_run.created_at) || github.event_name }})
 
 on:
   schedule:

--- a/.github/workflows/weekly-base-build.yaml
+++ b/.github/workflows/weekly-base-build.yaml
@@ -1,4 +1,5 @@
 name: Weekly base container build
+run-name: Weekly base container build (${{ github.event_name == 'workflow_run' && format('nightly {0}', github.event.workflow_run.created_at) || github.event_name }})
 
 on:
   schedule:


### PR DESCRIPTION
This change introduces the dynamic [run name field](https://github.blog/changelog/2022-09-26-github-actions-dynamic-names-for-workflow-runs/#:~:text=GitHub%20Actions%20customers%20can%20now,visit%20the%20GitHub%20Actions%20community.) `run-name`.

It's currently difficult on mobile to find the "workflow_run" that corresponds to a particular date, so hopefully this helps identify which builds were nightly vs which builds were manually triggered.

I couldn't find a good way to dynamically look up the `name` field, so for now I copied all of names. I also wasn't able to find a "created_at" for the scheduled workflows, so those don't have timestamps for now.

__Assumptions__:
* "workflow_run" == nightly since "scheduled" events only happen on `main` and `workflow_run` are only run for concrete workflows and not reusable workflows

### TODO
- [x] Test the workflow_run codepath
- [x] Test the scheduled codepath

![image](https://github.com/NVIDIA/JAX-Toolbox/assets/7576060/4b916452-334a-4a73-9220-9fbadc70462f)