### PR TITLE
Uses SLURM output variables instead of input variables in t5x sbatch scripts

### DIFF
--- a/rosetta/rosetta/projects/t5x/scripts/example_slurm_ft_frompile.sub
+++ b/rosetta/rosetta/projects/t5x/scripts/example_slurm_ft_frompile.sub
@@ -70,7 +70,7 @@ export GPUS_PER_NODE=${1:-8}
 export BASE_SCRIPT=${2:-"${T5X_DIR}/t5x/contrib/gpu/scripts_gpu/multiprocess_ft_frompile.sh"}
 export WITH_MP=1
 
-NUM_GPUS=$(( GPUS_PER_NODE * SLURM_JOB_NUM_NODES ))
+NUM_GPUS=$(( GPUS_PER_NODE * SLURM_STEP_NUM_NODES ))
 
 # << CHANGE ! >>
 # You can add binding to the command below with the following line (after nvidia-smi). Remove the '&&' on the next bash line.
@@ -84,7 +84,7 @@ EOF
 )"
 
 # create run specific output directory for ease of analysis
-FOLDER="${BASE_T5X_OUTPUTS_DIR}/multinode/${FT_TASK}-${T5_SIZE}-${PREC}-N${SLURM_JOB_NUM_NODES}-n${NUM_GPUS}-BS${BSIZE_PER_GPU}-MBS${NUM_MICROBATCHES}-SL${ENC_SL}_${DEC_SL}-TP${TP_SIZE}-FP8${ENABLE_FP8}"
+FOLDER="${BASE_T5X_OUTPUTS_DIR}/multinode/${FT_TASK}-${T5_SIZE}-${PREC}-N${SLURM_STEP_NUM_NODES}-n${NUM_GPUS}-BS${BSIZE_PER_GPU}-MBS${NUM_MICROBATCHES}-SL${ENC_SL}_${DEC_SL}-TP${TP_SIZE}-FP8${ENABLE_FP8}"
 mkdir -p ${FOLDER}
 
 # redirect both stdout and stderr in the same file for ease of analysis

--- a/rosetta/rosetta/projects/t5x/scripts/example_slurm_pretrain_pile.sub
+++ b/rosetta/rosetta/projects/t5x/scripts/example_slurm_pretrain_pile.sub
@@ -68,7 +68,7 @@ export GPUS_PER_NODE=${1:-8}
 export BASE_SCRIPT=${2:-"${T5X_DIR}/t5x/contrib/gpu/scripts_gpu/multiprocess_pretrain_pile.sh"}
 export WITH_MP=1
 
-NUM_GPUS=$(( GPUS_PER_NODE * SLURM_JOB_NUM_NODES ))
+NUM_GPUS=$(( GPUS_PER_NODE * SLURM_STEP_NUM_NODES ))
 
 # << CHANGE ! >>
 # You can add binding to the command below with the following line (after nvidia-smi). Remove the '&&' on the next bash line.
@@ -82,7 +82,7 @@ EOF
 )"
 
 # create run specific output directory for ease of analysis
-FOLDER="${BASE_T5X_OUTPUTS_DIR}/multinode/PRETRAIN-${T5_SIZE}-${PREC}-N${SLURM_JOB_NUM_NODES}-n${NUM_GPUS}-Step${TRAIN_STEPS}-BS${BSIZE_PER_GPU}-MBS${NUM_MICROBATCHES}-SL${ENC_SL}_${DEC_SL}-TP${TP_SIZE}-FP8${ENABLE_FP8}"
+FOLDER="${BASE_T5X_OUTPUTS_DIR}/multinode/PRETRAIN-${T5_SIZE}-${PREC}-N${SLURM_STEP_NUM_NODES}-n${NUM_GPUS}-Step${TRAIN_STEPS}-BS${BSIZE_PER_GPU}-MBS${NUM_MICROBATCHES}-SL${ENC_SL}_${DEC_SL}-TP${TP_SIZE}-FP8${ENABLE_FP8}"
 mkdir -p ${FOLDER}
 
 # redirect both stdout and stderr in the same file for ease of analysis


### PR DESCRIPTION
It is better practice to use the [output variables ](https://slurm.schedmd.com/srun.html#SECTION_OUTPUT-ENVIRONMENT-VARIABLES)instead of [input variables](https://slurm.schedmd.com/srun.html#SECTION_INPUT-ENVIRONMENT-VARIABLES) since input variables should not be relied upon. In some cases, it has been observed that the input variable has not been set when using salloc.