### PR TITLE
Propagate build failures

### DIFF
--- a/.github/workflows/nightly-rosetta-pax-build.yaml
+++ b/.github/workflows/nightly-rosetta-pax-build.yaml
@@ -67,7 +67,7 @@ jobs:
   publish-build:
     needs: [metadata, build]
     uses: ./.github/workflows/_publish_badge.yaml
-    if: ( success() || failure() ) && (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success') || github.event_name == 'workflow_dispatch'
+    if: ( inputs.PUBLISH )
     secrets: inherit
     with:
       ENDPOINT_FILENAME: 'rosetta-pax-build-status.json'
@@ -95,7 +95,7 @@ jobs:
   publish-test:
     needs: [metadata, build, test-pax]
     uses: ./.github/workflows/_publish_badge.yaml
-    if: ( always() )
+    if: (inputs.PUBLISH )
     secrets: inherit
     with:
       ENDPOINT_FILENAME: 'rosetta-pax-overall-test-status.json'

--- a/.github/workflows/nightly-rosetta-pax-build.yaml
+++ b/.github/workflows/nightly-rosetta-pax-build.yaml
@@ -67,7 +67,7 @@ jobs:
   publish-build:
     needs: [metadata, build]
     uses: ./.github/workflows/_publish_badge.yaml
-    if: ( inputs.PUBLISH )
+    if: ( always() )
     secrets: inherit
     with:
       ENDPOINT_FILENAME: 'rosetta-pax-build-status.json'
@@ -95,7 +95,7 @@ jobs:
   publish-test:
     needs: [metadata, build, test-pax]
     uses: ./.github/workflows/_publish_badge.yaml
-    if: (inputs.PUBLISH )
+    if: ( always() )
     secrets: inherit
     with:
       ENDPOINT_FILENAME: 'rosetta-pax-overall-test-status.json'

--- a/.github/workflows/nightly-rosetta-t5x-build-test.yaml
+++ b/.github/workflows/nightly-rosetta-t5x-build-test.yaml
@@ -69,7 +69,7 @@ jobs:
   publish-build:
     needs: [metadata, build]
     uses: ./.github/workflows/_publish_badge.yaml
-    if: ( success() || failure() ) && (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success') || github.event_name == 'workflow_dispatch'
+    if: ( inputs.PUBLISH )
     secrets: inherit
     with:
       ENDPOINT_FILENAME: 'rosetta-t5x-build-status.json'
@@ -122,7 +122,7 @@ jobs:
   publish-test:
     needs: [metadata, build, test-unit, test-t5x, test-vit]
     uses: ./.github/workflows/_publish_badge.yaml
-    if: ( always() )
+    if: ( inputs.PUBLISH )
     secrets: inherit
     with:
       ENDPOINT_FILENAME: 'rosetta-t5x-overall-test-status.json'

--- a/.github/workflows/nightly-rosetta-t5x-build-test.yaml
+++ b/.github/workflows/nightly-rosetta-t5x-build-test.yaml
@@ -69,7 +69,7 @@ jobs:
   publish-build:
     needs: [metadata, build]
     uses: ./.github/workflows/_publish_badge.yaml
-    if: ( inputs.PUBLISH )
+    if: ( always() )
     secrets: inherit
     with:
       ENDPOINT_FILENAME: 'rosetta-t5x-build-status.json'
@@ -122,7 +122,7 @@ jobs:
   publish-test:
     needs: [metadata, build, test-unit, test-t5x, test-vit]
     uses: ./.github/workflows/_publish_badge.yaml
-    if: ( inputs.PUBLISH )
+    if: ( always() )
     secrets: inherit
     with:
       ENDPOINT_FILENAME: 'rosetta-t5x-overall-test-status.json'


### PR DESCRIPTION
Always run the `publish-build` step, regardless of whether the rosetta pax/t5x build was attempted. This ensures that badges correctly reflect build failures due to dependent builds failing.