### PR TITLE
Fix docker tag for nightly vit tests

### DIFF
--- a/.github/workflows/nightly-rosetta-pax-build.yaml
+++ b/.github/workflows/nightly-rosetta-pax-build.yaml
@@ -147,7 +147,7 @@ jobs:
 
         echo "LABEL='Tests'" >> $GITHUB_OUTPUT
 
-        if [[ ${{ needs.build.result }} == "success" ]]; then
+        if [[ ${{ needs.amd64.result }} == "success" && ${{ needs.arm64.result }} == "success" ]]; then
           if [[ $PAX_STATUS == "success" ]]; then
             COLOR=brightgreen
             MESSAGE="MGMN passed"

--- a/.github/workflows/nightly-rosetta-pax-build.yaml
+++ b/.github/workflows/nightly-rosetta-pax-build.yaml
@@ -12,7 +12,7 @@ on:
         type: string
         description: 'PAX image built by NVIDIA/JAX-Toolbox'
         default: ''
-        required: true
+        required: false
       PUBLISH:
         type: boolean
         description: Publish dated images and update the 'latest' tag?

--- a/.github/workflows/nightly-rosetta-t5x-build-test.yaml
+++ b/.github/workflows/nightly-rosetta-t5x-build-test.yaml
@@ -148,7 +148,7 @@ jobs:
     uses: ./.github/workflows/_test_vit.yaml
     if: (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success') || github.event_name == 'workflow_dispatch'
     with:
-      ROSETTA_T5X_IMAGE: ${{ needs.build.outputs.DOCKER_TAG_FINAL }}
+      ROSETTA_T5X_IMAGE: ${{ needs.amd64.outputs.DOCKER_TAG_FINAL }}
     secrets: inherit
 
   publish-t5x:
@@ -161,7 +161,7 @@ jobs:
     secrets: inherit
 
   publish-test:
-    needs: [metadata, test-unit, test-t5x, test-vit]
+    needs: [metadata, amd64, arm64, test-unit, test-t5x, test-vit]
     uses: ./.github/workflows/_publish_badge.yaml
     if: ( always() )
     secrets: inherit
@@ -175,7 +175,7 @@ jobs:
 
         echo "LABEL='Tests'" >> $GITHUB_OUTPUT
 
-        if [[ ${{ needs.build.result }} == "success" ]]; then
+        if [[ ${{ needs.amd64.result }} == "success" && ${{ needs.arm64.result }} == "success" ]]; then
           if [[ $UNIT_STATUS == "success" ]] && [[ $T5X_STATUS == "success" ]] && [[ $VIT_STATUS == "success" ]]; then
             COLOR=brightgreen
             MESSAGE="Unit passed / MGMN passed"

--- a/.github/workflows/nightly-rosetta-t5x-build-test.yaml
+++ b/.github/workflows/nightly-rosetta-t5x-build-test.yaml
@@ -148,7 +148,7 @@ jobs:
     uses: ./.github/workflows/_test_vit.yaml
     if: (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success') || github.event_name == 'workflow_dispatch'
     with:
-      ROSETTA_T5X_IMAGE: ${{ needs.build.outputs.DOCKER_TAGS }}
+      ROSETTA_T5X_IMAGE: ${{ needs.build.outputs.DOCKER_TAG_FINAL }}
     secrets: inherit
 
   publish-t5x:

--- a/.github/workflows/nightly-rosetta-t5x-build-test.yaml
+++ b/.github/workflows/nightly-rosetta-t5x-build-test.yaml
@@ -12,7 +12,7 @@ on:
         type: string
         description: 'T5x image built by NVIDIA/JAX-Toolbox'
         default: ''
-        required: true
+        required: false
       PUBLISH:
         type: boolean
         description: Publish dated images and update the 'latest' tag?


### PR DESCRIPTION
Nightly Rosetta tests: [https://github.com/NVIDIA/JAX-Toolbox/actions/runs/6966611664](https://github.com/NVIDIA/JAX-Toolbox/actions/runs/6966611664)