### PR TITLE
build-jax.sh: update default source dir

### DIFF
--- a/.github/container/build-jax.sh
+++ b/.github/container/build-jax.sh
@@ -66,7 +66,7 @@ DEBUG=0
 DRY=0
 EDITABLE=0
 JAXLIB_ONLY=0
-SRC_PATH_JAX="/opt/jax-source"
+SRC_PATH_JAX="/opt/jax"
 SRC_PATH_XLA="/opt/xla-source"
 XLA_ARM64_PATCH_LIST=""
 


### PR DESCRIPTION
This changed in https://github.com/NVIDIA/JAX-Toolbox/pull/371.