### PR TITLE
Adds a new synchronization workflow at the end of the nightly run

### DIFF
--- a/.github/workflows/nightly-distribution-test.yaml
+++ b/.github/workflows/nightly-distribution-test.yaml
@@ -13,6 +13,15 @@ permissions:
   actions:  write # to cancel previous workflows
 
 jobs:
+  save_parent:
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Save Parent workflow_id ${{ github.event.workflow_run.id }}
+        run: echo ${{ github.event.workflow_run.id }} | tee parent-run-id.txt
+      - uses: actions/upload-artifact@v3
+        with:
+          name: parent-run-id
+          path: parent-run-id.txt
 
   test-distribution:
     uses: ./.github/workflows/_test_distribution.yaml

--- a/.github/workflows/nightly-jax-build.yaml
+++ b/.github/workflows/nightly-jax-build.yaml
@@ -18,6 +18,15 @@ permissions:
   packages: write # to upload container
 
 jobs:
+  save_parent:
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Save Parent workflow_id ${{ github.event.workflow_run.id }}
+        run: echo ${{ github.event.workflow_run.id }} | tee parent-run-id.txt
+      - uses: actions/upload-artifact@v3
+        with:
+          name: parent-run-id
+          path: parent-run-id.txt
 
   metadata:
     runs-on: ubuntu-22.04

--- a/.github/workflows/nightly-jax-test-unit.yaml
+++ b/.github/workflows/nightly-jax-test-unit.yaml
@@ -28,6 +28,15 @@ env:
   DEFAULT_JAX_IMAGE: 'ghcr.io/nvidia/jax:latest'
 
 jobs:
+  save_parent:
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Save Parent workflow_id ${{ github.event.workflow_run.id }}
+        run: echo ${{ github.event.workflow_run.id }} | tee parent-run-id.txt
+      - uses: actions/upload-artifact@v3
+        with:
+          name: parent-run-id
+          path: parent-run-id.txt
 
   if-upstream-failed:
     if: (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'failure') && github.event_name != 'workflow_dispatch'

--- a/.github/workflows/nightly-manifest-update.yaml
+++ b/.github/workflows/nightly-manifest-update.yaml
@@ -1,0 +1,68 @@
+name: Nightly Manifest Update
+run-name: Nightly Manifest Update (${{ github.event_name == 'workflow_run' && format('nightly {0}', github.event.workflow_run.created_at) || github.event_name }}) parent_id=${{ github.event.workflow_run.id }}
+
+on:
+  workflow_run:
+    workflows:
+      - Nightly JAX unit test
+      - Nightly Transformer Engine test
+      - Nightly Distribution test
+      - Nightly Pax MGMN performance test
+      - Nightly T5X MGMN performance test
+      - Nightly Rosetta Paxml build and test
+      - Nightly Rosetta T5x build and test
+    types: [completed]
+    branches: [main]
+
+permissions:
+  contents: write # to fetch code, and create commits
+  actions:  write # to cancel previous workflows
+  packages: write # to upload container
+
+jobs:
+  save_parent:
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Save Parent workflow_id ${{ github.event.workflow_run.id }}
+        run: echo ${{ github.event.workflow_run.id }} | tee parent-run-id.txt
+      - uses: actions/upload-artifact@v3
+        with:
+          name: parent-run-id
+          path: parent-run-id.txt
+  check-concurrent:
+    runs-on: ubuntu-22.04
+    timeout-minutes: 360  # This is the max time we expect between runs of this workflow 
+    outputs:
+      # Outcome is before continue-on-error is appled and conclusion is after
+      status: ${{ steps.k_step.outcome }}
+    steps:
+      - name: Check out the repository under ${GITHUB_WORKSPACE}
+        uses: actions/checkout@v3
+      - name: Check if not latest
+        id: k_step
+        continue-on-error: true
+        run: |
+          export THIS_WORKFLOW_PARENT_RUN_ID=${{ github.event.workflow_run.id }}
+          source ./.github/workflows/scripts/block_and_check_if_largest.sh
+          echo block_and_check_if_largest ${{ secrets.GITHUB_TOKEN }} ${{ github.repository }} ${{ github.sha }} ${{ github.run_id }} 120
+          block_and_check_if_largest ${{ secrets.GITHUB_TOKEN }} ${{ github.repository }} ${{ github.sha }} ${{ github.run_id }} 120
+  
+  afterWait:
+    name: after-wait
+    needs: [check-concurrent]
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Print kill status
+        run: echo ${{ needs.check-concurrent.outputs.status }}
+      - name: Cancel workflow if this is not the most recent instance of this workflow
+        if: needs.check-concurrent.outputs.status != 'success'
+        uses: octokit/request-action@v2.x
+        with:
+          route: POST /repos/{repository}/actions/runs/{run_id}/cancel
+          repository: ${{ github.repository }}
+          run_id: ${{ github.run_id }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Dummy wait if things were not successful
+        if: needs.check-concurrent.outputs.status != 'success'
+        run: sleep 60

--- a/.github/workflows/nightly-manifest-update.yaml
+++ b/.github/workflows/nightly-manifest-update.yaml
@@ -66,3 +66,11 @@ jobs:
       - name: Dummy wait if things were not successful
         if: needs.check-concurrent.outputs.status != 'success'
         run: sleep 60
+      - name: Check out the repository under ${GITHUB_WORKSPACE}
+        uses: actions/checkout@v3
+      - name: Check parent statuses
+        run: |
+          export THIS_WORKFLOW_PARENT_RUN_ID=${{ github.event.workflow_run.id }}
+          source ./.github/workflows/scripts/check_workflow_status.sh
+          echo check_workflow_status ${{ secrets.GITHUB_TOKEN }} ${{ github.repository }} ${{ github.sha }} ${{ github.run_id }}
+          check_workflow_status ${{ secrets.GITHUB_TOKEN }} ${{ github.repository }} ${{ github.sha }} ${{ github.run_id }}

--- a/.github/workflows/nightly-manifest-update.yaml
+++ b/.github/workflows/nightly-manifest-update.yaml
@@ -44,8 +44,8 @@ jobs:
         run: |
           export THIS_WORKFLOW_PARENT_RUN_ID=${{ github.event.workflow_run.id }}
           source ./.github/workflows/scripts/block_and_check_if_largest.sh
-          echo block_and_check_if_largest ${{ secrets.GITHUB_TOKEN }} ${{ github.repository }} ${{ github.sha }} ${{ github.run_id }} 120
-          block_and_check_if_largest ${{ secrets.GITHUB_TOKEN }} ${{ github.repository }} ${{ github.sha }} ${{ github.run_id }} 120
+          echo block_and_check_if_largest ${{ secrets.GITHUB_TOKEN }} ${{ github.repository }} ${{ github.sha }} ${{ github.run_id }} 300
+          block_and_check_if_largest ${{ secrets.GITHUB_TOKEN }} ${{ github.repository }} ${{ github.sha }} ${{ github.run_id }} 300
   
   afterWait:
     name: after-wait

--- a/.github/workflows/nightly-pax-build.yaml
+++ b/.github/workflows/nightly-pax-build.yaml
@@ -20,6 +20,15 @@ permissions:
   packages: write # to upload container
 
 jobs:
+  save_parent:
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Save Parent workflow_id ${{ github.event.workflow_run.id }}
+        run: echo ${{ github.event.workflow_run.id }} | tee parent-run-id.txt
+      - uses: actions/upload-artifact@v3
+        with:
+          name: parent-run-id
+          path: parent-run-id.txt
 
   metadata:
     runs-on: ubuntu-22.04

--- a/.github/workflows/nightly-pax-test-mgmn.yaml
+++ b/.github/workflows/nightly-pax-test-mgmn.yaml
@@ -29,6 +29,15 @@ env:
   DEFAULT_PAX_IMAGE: 'ghcr.io/nvidia/upstream-pax:latest'
 
 jobs:
+  save_parent:
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Save Parent workflow_id ${{ github.event.workflow_run.id }}
+        run: echo ${{ github.event.workflow_run.id }} | tee parent-run-id.txt
+      - uses: actions/upload-artifact@v3
+        with:
+          name: parent-run-id
+          path: parent-run-id.txt
 
   metadata:
     runs-on: ubuntu-22.04

--- a/.github/workflows/nightly-rosetta-pax-build.yaml
+++ b/.github/workflows/nightly-rosetta-pax-build.yaml
@@ -29,6 +29,15 @@ permissions:
   packages: write # to upload container
 
 jobs:
+  save_parent:
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Save Parent workflow_id ${{ github.event.workflow_run.id }}
+        run: echo ${{ github.event.workflow_run.id }} | tee parent-run-id.txt
+      - uses: actions/upload-artifact@v3
+        with:
+          name: parent-run-id
+          path: parent-run-id.txt
 
   metadata:
     runs-on: ubuntu-22.04

--- a/.github/workflows/nightly-rosetta-t5x-build-test.yaml
+++ b/.github/workflows/nightly-rosetta-t5x-build-test.yaml
@@ -29,6 +29,15 @@ permissions:
   packages: write # to upload container
 
 jobs:
+  save_parent:
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Save Parent workflow_id ${{ github.event.workflow_run.id }}
+        run: echo ${{ github.event.workflow_run.id }} | tee parent-run-id.txt
+      - uses: actions/upload-artifact@v3
+        with:
+          name: parent-run-id
+          path: parent-run-id.txt
 
   metadata:
     runs-on: ubuntu-22.04

--- a/.github/workflows/nightly-t5x-build.yaml
+++ b/.github/workflows/nightly-t5x-build.yaml
@@ -20,6 +20,15 @@ permissions:
   packages: write # to upload container
 
 jobs:
+  save_parent:
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Save Parent workflow_id ${{ github.event.workflow_run.id }}
+        run: echo ${{ github.event.workflow_run.id }} | tee parent-run-id.txt
+      - uses: actions/upload-artifact@v3
+        with:
+          name: parent-run-id
+          path: parent-run-id.txt
 
   metadata:
     runs-on: ubuntu-22.04

--- a/.github/workflows/nightly-t5x-test-mgmn.yaml
+++ b/.github/workflows/nightly-t5x-test-mgmn.yaml
@@ -29,6 +29,15 @@ env:
   DEFAULT_T5X_IMAGE: 'ghcr.io/nvidia/upstream-t5x:latest'
 
 jobs:
+  save_parent:
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Save Parent workflow_id ${{ github.event.workflow_run.id }}
+        run: echo ${{ github.event.workflow_run.id }} | tee parent-run-id.txt
+      - uses: actions/upload-artifact@v3
+        with:
+          name: parent-run-id
+          path: parent-run-id.txt
 
   metadata:
     runs-on: ubuntu-22.04

--- a/.github/workflows/nightly-te-test.yaml
+++ b/.github/workflows/nightly-te-test.yaml
@@ -28,6 +28,15 @@ env:
   DEFAULT_JAX_TE_IMAGE: 'ghcr.io/nvidia/upstream-pax:latest'
 
 jobs:
+  save_parent:
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Save Parent workflow_id ${{ github.event.workflow_run.id }}
+        run: echo ${{ github.event.workflow_run.id }} | tee parent-run-id.txt
+      - uses: actions/upload-artifact@v3
+        with:
+          name: parent-run-id
+          path: parent-run-id.txt
 
   metadata:
     runs-on: ubuntu-22.04

--- a/.github/workflows/scripts/block_and_check_if_largest.sh
+++ b/.github/workflows/scripts/block_and_check_if_largest.sh
@@ -1,0 +1,123 @@
+#!/bin/bash
+set -u
+
+_get_workflow_id() {
+  WORKFLOW_RUN_ID=$1
+  curl -s -L -H "Authorization: Bearer $GH_TOKEN" -H "X-GitHub-Api-Version: 2022-11-28" "https://api.github.com/repos/$REPOSITORY/actions/runs/$WORKFLOW_RUN_ID" | jq -r '.workflow_id'
+}
+
+_get_parent_run_id() {
+  # This gets the parent run id in two ways:
+  #  1. If the input run id is the current run id, inspect the parent run id from an environment variable named THIS_WORKFLOW_PARENT_RUN_ID. It should be set with ${{ github.event.workflow_run.id }}
+  #  2. Otherwise, get parent id by downloading the artifact named "parent-run-id" which should be uploaded for all workflows
+  WORKFLOW_RUN_ID=$1
+  if [[ $WORKFLOW_RUN_ID -eq $THIS_WORKFLOW_RUN_ID ]]; then
+    # Should be set outside of this script: export THIS_WORKFLOW_PARENT_RUN_ID=${{ github.event.workflow_run.id }}
+    # This covers a special case where you cannot inspect the artifacts of the current ongoing run
+    echo $THIS_WORKFLOW_PARENT_RUN_ID
+    return
+  fi
+  
+  download_url=$(curl -s -L -H "Authorization: Bearer $GH_TOKEN" -H "X-GitHub-Api-Version: 2022-11-28" "https://api.github.com/repos/$REPOSITORY/actions/runs/$WORKFLOW_RUN_ID/artifacts" | jq -r '.artifacts[] | select(.name == "parent-run-id") | .archive_download_url // ""')
+  if [[ -z $download_url ]]; then
+    echo ""
+  else
+    # Download the zipped artifact to a temporary file
+    temp_zip=$(mktemp)
+    curl -s -L -H "Authorization: Bearer $GH_TOKEN" -H "X-GitHub-Api-Version: 2022-11-28" $download_url -o "$temp_zip"
+    # Unzip the content to another temporary file
+    temp_unzipped=$(mktemp)
+    unzip -p "$temp_zip" > "$temp_unzipped"
+    # Read the content of the unzipped file
+    cat "$temp_unzipped"
+    rm "$temp_zip" "$temp_unzipped"
+  fi
+}
+
+_get_root_run_id() {
+  # Recursively search for the root run id. If the worfklow run name has the parent id,
+  #  then no API request is needed. The workflow run name is used in cases where other
+  #  instances of the workflow run have not completed, so their artifacts are not
+  #  available yet
+  WORKFLOW_RUN_ID=$1
+  WORKFLOW_RUN_NAME=${2:-}
+  ID_IN_NAME=$(echo "$WORKFLOW_RUN_NAME" | egrep -o 'parent_id=[0-9]+' | cut -d= -f2)
+  if [[ -n $ID_IN_NAME ]]; then
+    PARENT_ID=$ID_IN_NAME
+  else
+    PARENT_ID=$(_get_parent_run_id $WORKFLOW_RUN_ID)
+  fi
+  while [[ -n $PARENT_ID ]]; do
+    WORKFLOW_RUN_ID=$PARENT_ID
+    PARENT_ID=$(_get_parent_run_id $PARENT_ID)
+  done
+  echo $WORKFLOW_RUN_ID
+}
+
+_get_workflow_tree() {
+  # This will return all workflows that 
+  GH_TOKEN=$1
+  REPOSITORY=$2
+  GITHUB_SHA=$3
+  THIS_WORKFLOW_RUN_ID=$4
+
+  THIS_ROOT_ID=$(_get_root_run_id $THIS_WORKFLOW_RUN_ID)
+  THIS_WORKFLOW_ID=$(_get_workflow_id $THIS_WORKFLOW_RUN_ID)
+
+  # Print all workflows
+  ALL_WORKFLOWS=$(curl -s -L -H "Authorization: Bearer $GH_TOKEN" -H "X-GitHub-Api-Version: 2022-11-28" "https://api.github.com/repos/$REPOSITORY/actions/runs?head_sha=$GITHUB_SHA&per_page=100" | jq -r '.workflow_runs[] | "\(.id)\t\(.workflow_id)\t\(.name)"' | sort -k1,1nr)
+  echo "[DEBUG]: START all workflows:" >&2
+  echo "$ALL_WORKFLOWS" >&2
+  echo "[DEBUG]: END all workflows:" >&2
+  # TODO: Max is 100, but may need to use jq to combine
+  echo "$ALL_WORKFLOWS" | while IFS=$'\t' read -r run_id workflow_id workflow_name; do
+    if [[ $workflow_id != $THIS_WORKFLOW_ID ]]; then
+      continue
+    fi
+
+    root_id=$(_get_root_run_id "$run_id" "$workflow_name")
+    if [[ $root_id != $THIS_ROOT_ID ]]; then
+      continue
+    fi
+
+    printf "%s\t%s\t%s\t%s\n" "$run_id" "$root_id" "$workflow_id" "$workflow_name"
+  done | sort -k1,1nr
+}
+
+block_and_check_if_largest() {
+  if [[ $# -lt 4 || $# -gt 5 ]]; then
+    echo $#
+    echo 'block_and_check_if_largest $GH_TOKEN $REPOSITORY $GITHUB_SHA $WORKFLOW_RUN_ID ${DELAY:-60}'
+    echo 'Example: block_and_check_if_largest ${{ secrets.GITHUB_TOKEN }} ${{ github.repository }} ${{ github.sha }} ${{ github.run_id }} 60'
+    echo 'Requires you to set the following outside this script: export THIS_WORKFLOW_PARENT_RUN_ID=${{ github.event.workflow_run.id }}'
+    echo 'Exits 0 if it is the largest run_id'
+    return 1
+  fi
+  GH_TOKEN=$1
+  REPOSITORY=$2
+  GITHUB_SHA=$3
+  THIS_WORKFLOW_RUN_ID=$4
+  DELAY=${5:-60}
+
+  RAW_WORKFLOW_PATH=$(curl -s -L -H "Authorization: Bearer $GH_TOKEN" -H "X-GitHub-Api-Version: 2022-11-28" "https://api.github.com/repos/$REPOSITORY/actions/runs/$THIS_WORKFLOW_RUN_ID" | jq -r '. | "\(.head_sha)/\(.path)"')
+  RAW_WORKFLOW_URL=https://raw.githubusercontent.com/$REPOSITORY/$RAW_WORKFLOW_PATH
+  NUM_DEPENDENCIES=$(curl -s $RAW_WORKFLOW_URL | yq '.on.workflow_run.workflows | length')
+
+  while true; do
+    echo Sleeping for $DELAY sec
+    sleep $DELAY
+    workflows=$(_get_workflow_tree $GH_TOKEN $REPOSITORY $GITHUB_SHA $THIS_WORKFLOW_RUN_ID)
+    num_workflows=$(echo "$workflows" | wc -l)
+    largest_id=$(echo "$workflows" | cut -f1 | sort -nr | head -n1)
+    echo "========== $(date)"
+    echo "$workflows"
+    if [[ $largest_id -eq $THIS_WORKFLOW_RUN_ID && $num_workflows -eq $NUM_DEPENDENCIES ]]; then
+      echo "This workflow run id is the largest: $THIS_WORKFLOW_RUN_ID"
+      break
+    elif [[ $largest_id -ne $THIS_WORKFLOW_RUN_ID ]]; then
+      echo "This workflow run id is NOT the largest: $THIS_WORKFLOW_RUN_ID"
+      exit 1
+    fi
+  done
+}
+

--- a/.github/workflows/scripts/check_workflow_status.sh
+++ b/.github/workflows/scripts/check_workflow_status.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+
+source $( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )/block_and_check_if_largest.sh
+
+check_workflow_status() {
+  if [[ $# -ne 4 ]]; then
+    echo 'check_workflow_status $GH_TOKEN $REPOSITORY $GITHUB_SHA $WORKFLOW_RUN_ID'
+    echo 'Example: check_workflow_status ${{ secrets.GITHUB_TOKEN }} ${{ github.repository }} ${{ github.sha }} ${{ github.run_id }}'
+    echo 'Requires you to set the following outside this script: export THIS_WORKFLOW_PARENT_RUN_ID=${{ github.event.workflow_run.id }}'
+    echo 'Prints all dependent workflow statuses of instances of the current workflow. Exits 1 if there are any failures'
+    return 1
+  fi
+  GH_TOKEN=$1
+  REPOSITORY=$2
+  GITHUB_SHA=$3
+  THIS_WORKFLOW_RUN_ID=$4
+
+  workflows=$(_get_workflow_tree $GH_TOKEN $REPOSITORY $GITHUB_SHA $THIS_WORKFLOW_RUN_ID)
+  table=$(
+  echo -e "run_id\tparent_id\tparent_conclusion\tparent_workflow_name"
+  echo "$workflows" | while IFS=$'\t' read -r run_id root_id workflow_id workflow_name; do
+    parent_id=$(_get_parent_run_id $run_id)
+    parent_workflow_json=$(_get_workflow_json $parent_id)
+    parent_conclusion=$(echo "$parent_workflow_json" | jq -r '.conclusion')
+    parent_workflow_name=$(echo "$parent_workflow_json" | jq -r '.name')
+    printf "%s\t%s\t%s\t%s\n" "$run_id" "$parent_id" "$parent_conclusion" "$parent_workflow_name"
+  done
+  )
+  if [[ -z "${GITHUB_STEP_SUMMARY:-}" ]]; then
+    echo "$table"
+  else
+    echo "$table" \
+      | sed 's/^/| /; s/$/ |/; s/\t/ | /g' \
+      | awk 'NR==1 {n=split($0, a, "|"); header="|"; for (i=2; i<n; i++) header=header" --- |"; print; print header} NR!=1' \
+      | tee $GITHUB_STEP_SUMMARY
+  fi
+  
+  # Overall success only if all parent runs were success
+  overall_conclusion=$(echo "$table" | tail -n+2 | awk -F'\t' '{
+      if ($3 != "success") {
+          print "failure";
+          exit;
+      }
+  } END {
+      if (NR > 0) {
+          print "success";
+      }
+  } ')
+  echo "Overall conclusion: $overall_conclusion"
+  if [[ $overall_conclusion == failure ]]; then
+    exit 1
+  fi
+}


### PR DESCRIPTION
This PR introduces a new workflow that runs at the end of all nightly workflow leaves, that can be used to update a manifest file.

## The Idea
We want to have a single workflow run if all the test workflows pass, i.e.:
```
on:
  workflow_run:
    workflows:
      - Nightly JAX unit test
      - Nightly Transformer Engine test
      - Nightly Distribution test
      - Nightly Pax MGMN performance test
      - Nightly T5X MGMN performance test
      - Nightly Rosetta Paxml build and test
      - Nightly Rosetta T5x build and test
    types: [completed]
    branches: [main]
```

After all the tests finish, we will update the manifest. The PR to update the manifest will come after this change, so as of now this PR introduces `nightly-manifest-update.yaml`, but it doesn't update anything

## The problem
As of now, there is no good way to trigger a workflow if several dependent workflows succeed. There are several issues open about this matter and there does not seem to be a plan to support this anytime in the future. 

The issue with the above `on.workflow_run.workflows[]` syntax is a nightly-manifest-update.yaml run will be started for each entry in that list, regardless of if it fails or not. This is an issue because:

1. The workflow is started even if the parent workflow failed
2. There's no builtin way to inspect the test status of the other parent workflows, only the one that triggered the current workflow
3. With several of these workflows started, we can run into a race condition if we try to `git merge` from several independent workflows
4. There's not a good way to know which one of these workflows will be the "last" to finish, since that might be a function of the workload

## The solution 
The solution this PR implements is to let `N` `nightly-manifest-update.yaml` runs get created and cancel all but the last one that was started; `N` here is determined by `on.workflow_runs.workflows[] | length`. This works because each workflow run will be given a unique workflow run id, and we can just query all the workflow runs for the current nightly and kill all workflows that have ids less than the max id.

Roughly the algorithm in pseudocode is:
```python
# Each instance of nightly-manifest-update.yaml runs this
THIS_RUN_ID=12345
while True:
  ALL_MANIFEST_UPDATE_RUNS = (
    get_nightly_workflows() # all nightly workflows
      .filter(lambda w: w is 'nightly-manifest-update.yaml')  # just the nightly manifest ones
  )
  max_id = max(run.id for run in ALL_MANIFEST_UPDATE_RUNS)
  if len(ALL_MANIFEST_UPDATE_RUNS) == N and max_id == THIS_RUN_ID:
    # This is the workflow we want to do the update
    print_status()
    manifest_update()
  elif max_id != THIS_RUN_ID:
    cancel(THIS_RUN_ID)
  # If it's the max, but we haven't seen N runs, then sleep and loop
  sleep(sec=120)
```

## Example (`print_status()`):
The Nightly Manifest Update will also summarize the parent workflow's conclusions. Here's what it will look like
| run_id | parent_id | parent_conclusion | parent_workflow_name |
| --- | --- | --- | --- |
| 6997938809 | 6997937815 | failure | Nightly Jax Unit Test (nightly 2023-11-26T20:52:04Z) |
| 6997937819 | 6997936667 | success | Nightly T5x Test (nightly 2023-11-26T20:51:50Z) |
| 6997936668 | 6997935547 | success | Nightly Pax Test (workflow_dispatch) |

## Note:
* After the introduction of this workflow, we are now at the limit of the number of workflows that can be chained together by workflow_run ([3 workflow limit](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows))
    * Nightly Jax Build -> Nightly Pax Build -> Nightly Rosetta Pax build and test -> Nightly Manifest Update 
    * This means that a new mechanism may need to be introduced to tackle #376 
