### PR TITLE
Increase TE test time

### DIFF
--- a/.github/workflows/_test_te.yaml
+++ b/.github/workflows/_test_te.yaml
@@ -115,7 +115,7 @@ jobs:
           #SBATCH --nodes=1
           #SBATCH --tasks=1
           #SBATCH --gpus-per-node=${{ matrix.N_GPU }}
-          #SBATCH --time=00:05:00
+          #SBATCH --time=00:15:00
           #SBATCH --output=${{ steps.meta.outputs.SLURM_LOG_FILE }}
           #SBATCH --export="ENROOT_PASSWORD=${{ secrets.GITHUB_TOKEN }}"
           time srun \


### PR DESCRIPTION
Because of limited number of runners, we encounter the error below:
```
slurmstepd: error: *** JOB 18886 ON compute-permanent-node-954 CANCELLED AT 2023-11-24T10:25:54 DUE TO TIME LIMIT ***
```

Try to increase a waiting time to reduce the number of test failures because of timeout