### PR TITLE
Revert 4e4e137

### DIFF
--- a/.github/container/Dockerfile.jax
+++ b/.github/container/Dockerfile.jax
@@ -37,17 +37,6 @@ RUN --mount=type=ssh \
     --mount=type=secret,id=SSH_KNOWN_HOSTS,target=/root/.ssh/known_hosts \
     git clone "${REPO_XLA}" "${SRC_PATH_XLA}" && cd "${SRC_PATH_XLA}" && git checkout ${REF_XLA}
 
-# TODO: This is a WAR to NCCL errors we observe in TOT. Should be removed when no longer needed
-RUN <<EOF bash -ex
-cd ${SRC_PATH_XLA}
-
-git config --global user.name "${GIT_USER_NAME}"
-git config --global user.email "${GIT_USER_EMAIL}"
-git remote add -f ashors1 https://github.com/ashors1/xla
-git cherry-pick --allow-empty $(git merge-base ashors/main ashors1/revert-84222)..ashors1/revert-84222
-git remote remove ashors1
-EOF
-
 ADD build-jax.sh local_cuda_arch test-jax.sh /usr/local/bin/
 ADD xla-arm64-neon.patch /opt
 RUN build-jax.sh \


### PR DESCRIPTION
This reverts the XLA WAR that was added to prevent NCCL OOM errors. This issue was addressed in XLA commit [0e751bf](https://github.com/openxla/xla/commit/0e751bf4ca01a081f6276d3353649aae441259b7), so the WAR is no longer needed. 