### PR TITLE
Match only major versions of CUDA and cuDNN

### DIFF
--- a/.github/container/install-cudnn.sh
+++ b/.github/container/install-cudnn.sh
@@ -7,20 +7,23 @@ export TZ=America/Los_Angeles
 
 apt-get update
 
-# Extract CUDA version from `nvcc --version` output line
+# Extract major CUDA version from `nvcc --version` output line
 # Input: "Cuda compilation tools, release X.Y, VX.Y.Z"
-# Output: X.Y
-cuda_version=$(nvcc --version | sed -n 's/^.*release \([0-9]*\.[0-9]*\).*$/\1/p')
+# Output: X
+cuda_major_version=$(nvcc --version | sed -n 's/^.*release \([0-9]*\.[0-9]*\).*$/\1/p' | cut -d. -f1)
 
 # Find latest cuDNN version compatible with existing CUDA by matching
-# ${cuda_version} in the package version string
-libcudnn_version=$(apt-cache show libcudnn8 | sed -n "s/^Version: \(.*+cuda${cuda_version}\)$/\1/p" | head -n 1)
-libcudnn_dev_version=$(apt-cache show libcudnn8-dev | sed -n "s/^Version: \(.*+cuda${cuda_version}\)$/\1/p" | head -n 1)
+# ${cuda_major_version} in the package version string
+# In most cases cuDNN release is behind CUDA ones. It is considered, that major 
+# version of CUDA and cuDNN are compatible.
+# For example, CUDA 12.3 + cuDNN 8.9.6 (libcudnn8 version: 8.9.6.50-1+cuda12.2) is 
+# considered to be compatible.
+libcudnn_version=$(apt-cache show libcudnn8 |  sed -n "s/^Version: \(.*+cuda${cuda_major_version}\.[0-9]*\)$/\1/p" | head -n 1)
+libcudnn_dev_version=$(apt-cache show libcudnn8-dev | sed -n "s/^Version: \(.*+cuda${cuda_major_version}\.[0-9]\)$/\1/p" | head -n 1)
 if [[ -z "${libcudnn_version}" || -z "${libcudnn_dev_version}" ]]; then
     echo "Could not find compatible cuDNN version for CUDA ${cuda_version}"
     exit 1
 fi
-
 
 apt-get update
 apt-get install -y \


### PR DESCRIPTION
The high level issue is that cuDNN releases lag behind CUDA releases and so CUDA 12.3 is out but there's no officially 12.3 compatible cuDNN release yet. cuDNN uses a different versioning system, they are at 8.9.6 right now, but the package version shows what version of CUDA it is compatible with. For example,
```
$> apt-get update
$> apt-cache show libcudnn8-dev | grep Version
Version: 8.9.6.50-1+cuda12.2
Version: 8.9.6.50-1+cuda11.8
Version: 8.9.5.30-1+cuda12.2
Version: 8.9.5.30-1+cuda11.8
Version: 8.9.5.29-1+cuda12.2
Version: 8.9.5.29-1+cuda11.8
Version: 8.9.4.25-1+cuda12.2
Version: 8.9.4.25-1+cuda11.8
Version: 8.9.3.28-1+cuda12.1
Version: 8.9.3.28-1+cuda11.8
Version: 8.9.2.26-1+cuda12.1
Version: 8.9.2.26-1+cuda11.8
Version: 8.9.1.23-1+cuda12.1
Version: 8.9.1.23-1+cuda11.8
Version: 8.9.0.131-1+cuda12.1
Version: 8.9.0.131-1+cuda11.8
Version: 8.8.1.3-1+cuda12.0
Version: 8.8.1.3-1+cuda11.8
Version: 8.8.0.121-1+cuda12.0
Version: 8.8.0.121-1+cuda11.8
Version: 8.7.0.84-1+cuda11.8
Version: 8.6.0.163-1+cuda11.8
Version: 8.5.0.96-1+cuda11.7
```
So having these libcudnn8 available to install versions, we can install one that is compatible with CUDA major version (12 in out case) with CUDA.
So, for example with CUDA 12.3 we can install cuDNN 8.9.6.50-1+cuda12.2.