### PR TITLE
Fix tensorboard upload for upstream MGMN tests

### DIFF
--- a/.github/workflows/_sitrep_mgmn.yaml
+++ b/.github/workflows/_sitrep_mgmn.yaml
@@ -123,7 +123,7 @@ jobs:
           to_json schemaVersion label message color \
           > ${{ inputs.BADGE_FILENAME }}
 
-          echo "STATUS='${status}'" >> ${GITHUB_OUTPUT}
+          echo "STATUS=${status}" >> ${GITHUB_OUTPUT}
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v3

--- a/.github/workflows/_test_pax.yaml
+++ b/.github/workflows/_test_pax.yaml
@@ -27,7 +27,7 @@ on:
         type: string
         description: 'Name of the framework being used'
         required: false
-        default: 'pax'
+        default: 'PAXML'
     outputs:
       TEST_STATUS:
         description: 'Summary pass/fail value indicating if results from tests are acceptable'

--- a/.github/workflows/nightly-pax-test-mgmn.yaml
+++ b/.github/workflows/nightly-pax-test-mgmn.yaml
@@ -122,5 +122,5 @@ jobs:
     needs: [metadata, run-jobs]
     uses: ./.github/workflows/_finalize.yaml
     with:
-      PUBLISH_BADGE: ${{ needs.metadata.outputs.PUBLISH }}
+      PUBLISH_BADGE: ${{ needs.metadata.outputs.PUBLISH == 'true' }}
     secrets: inherit

--- a/.github/workflows/nightly-pax-test-mgmn.yaml
+++ b/.github/workflows/nightly-pax-test-mgmn.yaml
@@ -92,6 +92,8 @@ jobs:
     with:
       BUILD_DATE: ${{ needs.metadata.outputs.BUILD_DATE }}
       EXPERIMENT_SUBDIR: PAX
+      # This is derived from https://github.com/NVIDIA/JAX-Toolbox/blob/main/.github/workflows/_test_pax.yaml#L142.
+      # The format is name of the framework followed by a dash.
       ARTIFACT_NAME: "${{ inputs.FW_NAME }}-"
     secrets: inherit
 

--- a/.github/workflows/nightly-pax-test-mgmn.yaml
+++ b/.github/workflows/nightly-pax-test-mgmn.yaml
@@ -118,7 +118,7 @@ jobs:
       FILE_ISSUE: true
 
   finalize:
-    if: "!cancelled()"
+    if: ${{ !cancelled() }}
     needs: [metadata, run-jobs]
     uses: ./.github/workflows/_finalize.yaml
     with:

--- a/.github/workflows/nightly-pax-test-mgmn.yaml
+++ b/.github/workflows/nightly-pax-test-mgmn.yaml
@@ -92,7 +92,7 @@ jobs:
     with:
       BUILD_DATE: ${{ needs.metadata.outputs.BUILD_DATE }}
       EXPERIMENT_SUBDIR: PAX
-      # This is derived from https://github.com/NVIDIA/JAX-Toolbox/blob/main/.github/workflows/_test_pax.yaml#L142.
+      # This is derived from https://github.com/NVIDIA/JAX-Toolbox/blob/fe2b42267b0dc569631a789bdc584ef9cdb0b4e6/.github/workflows/_test_pax.yaml#L142.
       # The format is name of the framework followed by a dash.
       ARTIFACT_NAME: "${{ inputs.FW_NAME }}-"
     secrets: inherit

--- a/.github/workflows/nightly-pax-test-mgmn.yaml
+++ b/.github/workflows/nightly-pax-test-mgmn.yaml
@@ -18,6 +18,11 @@ on:
         description: Publish dated results to tensorboard server?
         default: false
         required: false
+      FW_NAME:
+        type: string
+        description: 'Name of the framework being used'
+        required: false
+        default: 'PAXML'
 
 permissions:
   contents: read  # to fetch code
@@ -87,6 +92,7 @@ jobs:
     with:
       BUILD_DATE: ${{ needs.metadata.outputs.BUILD_DATE }}
       EXPERIMENT_SUBDIR: PAX
+      ARTIFACT_NAME: "${{ inputs.FW_NAME }}-"
     secrets: inherit
 
   publish-verified-image:

--- a/.github/workflows/nightly-t5x-test-mgmn.yaml
+++ b/.github/workflows/nightly-t5x-test-mgmn.yaml
@@ -91,6 +91,8 @@ jobs:
     with:
       BUILD_DATE: ${{ needs.metadata.outputs.BUILD_DATE }}
       EXPERIMENT_SUBDIR: T5X
+      # This is derived from https://github.com/NVIDIA/JAX-Toolbox/blob/main/.github/workflows/_test_t5x.yaml#L144.
+      # The format is name of the framework followed by a dash.
       ARTIFACT_NAME: "${{ inputs.FW_NAME }}-"
     secrets: inherit
 

--- a/.github/workflows/nightly-t5x-test-mgmn.yaml
+++ b/.github/workflows/nightly-t5x-test-mgmn.yaml
@@ -117,7 +117,7 @@ jobs:
       FILE_ISSUE: true
 
   finalize:
-    if: "!cancelled()"
+    if: ${{ !cancelled() }}
     needs: [metadata, run-jobs]
     uses: ./.github/workflows/_finalize.yaml
     with:

--- a/.github/workflows/nightly-t5x-test-mgmn.yaml
+++ b/.github/workflows/nightly-t5x-test-mgmn.yaml
@@ -18,6 +18,11 @@ on:
         description: Publish dated results to tensorboard server?
         default: false
         required: false
+      FW_NAME:
+        type: string
+        description: 'Name of the framework being used'
+        required: false
+        default: 'T5X'
 
 permissions:
   contents: read  # to fetch code
@@ -86,6 +91,7 @@ jobs:
     with:
       BUILD_DATE: ${{ needs.metadata.outputs.BUILD_DATE }}
       EXPERIMENT_SUBDIR: T5X
+      ARTIFACT_NAME: "${{ inputs.FW_NAME }}-"
     secrets: inherit
 
   publish-verified-image:

--- a/.github/workflows/nightly-t5x-test-mgmn.yaml
+++ b/.github/workflows/nightly-t5x-test-mgmn.yaml
@@ -91,7 +91,7 @@ jobs:
     with:
       BUILD_DATE: ${{ needs.metadata.outputs.BUILD_DATE }}
       EXPERIMENT_SUBDIR: T5X
-      # This is derived from https://github.com/NVIDIA/JAX-Toolbox/blob/main/.github/workflows/_test_t5x.yaml#L144.
+      # This is derived from https://github.com/NVIDIA/JAX-Toolbox/blob/fe2b42267b0dc569631a789bdc584ef9cdb0b4e6/.github/workflows/_test_t5x.yaml#L144.
       # The format is name of the framework followed by a dash.
       ARTIFACT_NAME: "${{ inputs.FW_NAME }}-"
     secrets: inherit

--- a/.github/workflows/nightly-t5x-test-mgmn.yaml
+++ b/.github/workflows/nightly-t5x-test-mgmn.yaml
@@ -121,5 +121,5 @@ jobs:
     needs: [metadata, run-jobs]
     uses: ./.github/workflows/_finalize.yaml
     with:
-      PUBLISH_BADGE: ${{ needs.metadata.outputs.PUBLISH }}
+      PUBLISH_BADGE: ${{ needs.metadata.outputs.PUBLISH == 'true' }}
     secrets: inherit


### PR DESCRIPTION
Tensorboard upload for MGMN tests is failing due to a path discrepancy. See [here](https://github.com/NVIDIA/JAX-Toolbox/actions/runs/7140133979/job/19445974430#step:5:26)

This PR prepends the correct prefix for Tensorboard upload.

Custom runs: 
- https://github.com/NVIDIA/JAX-Toolbox/actions/runs/7145569906
