### PR TITLE
Cancel orphaned slurm jobs

### DIFF
--- a/.github/workflows/_runner_ondemand_slurm.yaml
+++ b/.github/workflows/_runner_ondemand_slurm.yaml
@@ -54,42 +54,57 @@ jobs:
         id: submit
         shell: bash -x -e {0}
         run: |
-          ssh ${{ secrets.CLUSTER_LOGIN_USER }}@${{ vars.HOSTNAME_SLURM_LOGIN }} \
-            sbatch --parsable \
-          <<"EOF"
-          #!/bin/bash
-          #SBATCH --job-name=${{steps.meta.outputs.JOB_NAME }}
-          #SBATCH --exclusive
-          #SBATCH --nodes=1
-          #SBATCH --tasks=1
-          #SBATCH --gpus-per-node=8
-          #SBATCH --time="${{ inputs.TIME }}"
-          #SBATCH --output=${{ steps.meta.outputs.LOG_FILE }}
+          SLURM_JOB_ID=$(
+            ssh ${{ secrets.CLUSTER_LOGIN_USER }}@${{ vars.HOSTNAME_SLURM_LOGIN }} \
+              sbatch --parsable \
+            <<"EOF"
+            #!/bin/bash
+            #SBATCH --job-name=${{steps.meta.outputs.JOB_NAME }}
+            #SBATCH --exclusive
+            #SBATCH --nodes=1
+            #SBATCH --tasks=1
+            #SBATCH --gpus-per-node=8
+            #SBATCH --time="${{ inputs.TIME }}"
+            #SBATCH --output=${{ steps.meta.outputs.LOG_FILE }}
 
-          # obtain runner registration token
-          RUNNER_TOKEN=$(
-            curl \
-              -L \
-              -X POST \
-              -H "Accept: application/vnd.github+json" \
-              -H "Authorization: Bearer ${{ secrets.RUNNER_REGISTRATION_AUTH_TOKEN }}" \
-              -H "X-GitHub-Api-Version: 2022-11-28" \
-              https://api.github.com/repos/${{ github.repository }}/actions/runners/registration-token |\
-            jq -r '.token'
+            # obtain runner registration token
+            RUNNER_TOKEN=$(
+              curl \
+                -L \
+                -X POST \
+                -H "Accept: application/vnd.github+json" \
+                -H "Authorization: Bearer ${{ secrets.RUNNER_REGISTRATION_AUTH_TOKEN }}" \
+                -H "X-GitHub-Api-Version: 2022-11-28" \
+                https://api.github.com/repos/${{ github.repository }}/actions/runners/registration-token |\
+              jq -r '.token'
+            )
+
+            # launch runner
+            time docker run \
+              --network host \
+              --gpus all \
+              --privileged \
+              -v /runner \
+              -e RUNNER_NAME="${{ inputs.NAME }}" \
+              -e RUNNER_LABELS="${{ inputs.LABELS }}" \
+              -e RUNNER_REPO="${{ github.repository }}" \
+              -e RUNNER_TOKEN="${RUNNER_TOKEN}" \
+              -e RUNNER_EPHEMERAL=true \
+              -e DOCKER_ENABLED=true \
+              -e DOCKERD_IN_RUNNER=true \
+              ghcr.io/yhtang/actions-runner-dind:ubuntu-22.04  # use personal repo for the time being to avoid auth/cost issues
+            EOF
           )
+          echo "SLURM_JOB_ID=$SLURM_JOB_ID" >> $GITHUB_OUTPUT
 
-          # launch runner
-          time docker run \
-            --network host \
-            --gpus all \
-            --privileged \
-            -v /runner \
-            -e RUNNER_NAME="${{ inputs.NAME }}" \
-            -e RUNNER_LABELS="${{ inputs.LABELS }}" \
-            -e RUNNER_REPO="${{ github.repository }}" \
-            -e RUNNER_TOKEN="${RUNNER_TOKEN}" \
-            -e RUNNER_EPHEMERAL=true \
-            -e DOCKER_ENABLED=true \
-            -e DOCKERD_IN_RUNNER=true \
-            ghcr.io/yhtang/actions-runner-dind:ubuntu-22.04  # use personal repo for the time being to avoid auth/cost issues
-          EOF
+      - name: Wait for SLURM job to complete
+        shell: bash -x -e {0}
+        run: |
+          while squeue -j${{ steps.submit.outputs.SLURM_JOB_ID }} > /dev/null 2>&1; do echo "wait"; sleep 15; done
+
+      - name: Remove orphaned SLURM job if the CI job is canceled
+        if: cancelled()
+        shell: bash -x -e {0}
+        run: |
+          ssh ${{ secrets.CLUSTER_LOGIN_USER }}@${{ vars.HOSTNAME_SLURM_LOGIN }} \
+            scancel ${{ steps.submit.outputs.SLURM_JOB_ID }}

--- a/.github/workflows/_runner_ondemand_slurm.yaml
+++ b/.github/workflows/_runner_ondemand_slurm.yaml
@@ -100,7 +100,7 @@ jobs:
       - name: Wait for SLURM job to complete
         shell: bash -x -e {0}
         run: |
-          while squeue -j${{ steps.submit.outputs.SLURM_JOB_ID }} > /dev/null 2>&1; do echo "wait"; sleep 15; done
+          while ssh ${{ secrets.CLUSTER_LOGIN_USER }}@${{ vars.HOSTNAME_SLURM_LOGIN }} squeue -j${{ steps.submit.outputs.SLURM_JOB_ID }} > /dev/null 2>&1; do echo "wait"; sleep 15; done
 
       - name: Remove orphaned SLURM job if the CI job is canceled
         if: cancelled()

--- a/.github/workflows/_runner_ondemand_slurm.yaml
+++ b/.github/workflows/_runner_ondemand_slurm.yaml
@@ -54,48 +54,48 @@ jobs:
         id: submit
         shell: bash -x -e {0}
         run: |
-          SLURM_JOB_ID=$(
-            ssh ${{ secrets.CLUSTER_LOGIN_USER }}@${{ vars.HOSTNAME_SLURM_LOGIN }} \
-              sbatch --parsable \
-            <<"EOF"
-            #!/bin/bash
-            #SBATCH --job-name=${{steps.meta.outputs.JOB_NAME }}
-            #SBATCH --exclusive
-            #SBATCH --nodes=1
-            #SBATCH --tasks=1
-            #SBATCH --gpus-per-node=8
-            #SBATCH --time="${{ inputs.TIME }}"
-            #SBATCH --output=${{ steps.meta.outputs.LOG_FILE }}
+          SLURM_JOB_ID_FILE=$(mktemp)
+          ssh ${{ secrets.CLUSTER_LOGIN_USER }}@${{ vars.HOSTNAME_SLURM_LOGIN }} >${SLURM_JOB_ID_FILE} \
+            sbatch --parsable \
+          <<"EOF"
+          #!/bin/bash
+          #SBATCH --job-name=${{steps.meta.outputs.JOB_NAME }}
+          #SBATCH --exclusive
+          #SBATCH --nodes=1
+          #SBATCH --tasks=1
+          #SBATCH --gpus-per-node=8
+          #SBATCH --time="${{ inputs.TIME }}"
+          #SBATCH --output=${{ steps.meta.outputs.LOG_FILE }}
 
-            # obtain runner registration token
-            RUNNER_TOKEN=$(
-              curl \
-                -L \
-                -X POST \
-                -H "Accept: application/vnd.github+json" \
-                -H "Authorization: Bearer ${{ secrets.RUNNER_REGISTRATION_AUTH_TOKEN }}" \
-                -H "X-GitHub-Api-Version: 2022-11-28" \
-                https://api.github.com/repos/${{ github.repository }}/actions/runners/registration-token |\
-              jq -r '.token'
-            )
-
-            # launch runner
-            time docker run \
-              --network host \
-              --gpus all \
-              --privileged \
-              -v /runner \
-              -e RUNNER_NAME="${{ inputs.NAME }}" \
-              -e RUNNER_LABELS="${{ inputs.LABELS }}" \
-              -e RUNNER_REPO="${{ github.repository }}" \
-              -e RUNNER_TOKEN="${RUNNER_TOKEN}" \
-              -e RUNNER_EPHEMERAL=true \
-              -e DOCKER_ENABLED=true \
-              -e DOCKERD_IN_RUNNER=true \
-              ghcr.io/yhtang/actions-runner-dind:ubuntu-22.04  # use personal repo for the time being to avoid auth/cost issues
-            EOF
+          # obtain runner registration token
+          RUNNER_TOKEN=$(
+            curl \
+              -L \
+              -X POST \
+              -H "Accept: application/vnd.github+json" \
+              -H "Authorization: Bearer ${{ secrets.RUNNER_REGISTRATION_AUTH_TOKEN }}" \
+              -H "X-GitHub-Api-Version: 2022-11-28" \
+              https://api.github.com/repos/${{ github.repository }}/actions/runners/registration-token |\
+            jq -r '.token'
           )
-          echo "SLURM_JOB_ID=$SLURM_JOB_ID" >> $GITHUB_OUTPUT
+
+          # launch runner
+          time docker run \
+            --network host \
+            --gpus all \
+            --privileged \
+            -v /runner \
+            -e RUNNER_NAME="${{ inputs.NAME }}" \
+            -e RUNNER_LABELS="${{ inputs.LABELS }}" \
+            -e RUNNER_REPO="${{ github.repository }}" \
+            -e RUNNER_TOKEN="${RUNNER_TOKEN}" \
+            -e RUNNER_EPHEMERAL=true \
+            -e DOCKER_ENABLED=true \
+            -e DOCKERD_IN_RUNNER=true \
+            ghcr.io/yhtang/actions-runner-dind:ubuntu-22.04  # use personal repo for the time being to avoid auth/cost issues
+          EOF
+
+          echo "SLURM_JOB_ID=$(cat ${SLURM_JOB_ID_FILE})" >> $GITHUB_OUTPUT
 
       - name: Wait for SLURM job to complete
         shell: bash -x -e {0}

--- a/.github/workflows/_sandbox.yaml
+++ b/.github/workflows/_sandbox.yaml
@@ -11,3 +11,7 @@ jobs:
       LABELS: "TEST:${{ github.run_id }}"
       TIME: "01:00:00"
     secrets: inherit
+
+  pax-multi-node:
+    uses: ./.github/workflows/_test_pax.yaml
+    secrets: inherit

--- a/.github/workflows/_sandbox.yaml
+++ b/.github/workflows/_sandbox.yaml
@@ -4,38 +4,10 @@ on:
   workflow_dispatch:
 
 jobs:
-  sandbox:
-    runs-on: ubuntu-22.04
-    steps:
-      - name: Login to GitHub Container Registry
-        uses: docker/login-action@v2
-        with:
-          registry: ghcr.io
-          username: ${{ github.repository_owner }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Print usage
-        run: |
-          cat << EOF
-          This is an empty workflow file located in the main branch of your
-          repository. It serves as a testing ground for new GitHub Actions on
-          development branches before merging them to the main branch. By
-          defining and overloading this workflow on your development branch,
-          you can test new actions without affecting your main branch, ensuring
-          a smooth integration process once the changes are ready to be merged.
-
-          Usage:
-          
-          1. In your development branch, modify the sandbox.yml workflow file
-             to include the new actions you want to test. Make sure to commit
-             the changes to the development branch.
-          2. Navigate to the 'Actions' tab in your repository, select the
-             '~Sandbox' workflow, and choose your development branch from the
-             branch dropdown menu. Click on 'Run workflow' to trigger the
-             workflow on your development branch.
-          3. Once you have tested and verified the new actions in the Sandbox
-             workflow, you can incorporate them into your main workflow(s) and
-             merge the development branch into the main branch. Remember to
-             revert the changes to the sandbox.yml file in the main branch to
-             keep it empty for future testing.
-          EOF
+  runner:
+    uses: ./.github/workflows/_runner_ondemand_slurm.yaml
+    with:
+      NAME: "TEST-${{ github.run_id }}"
+      LABELS: "TEST:${{ github.run_id }}"
+      TIME: "01:00:00"
+    secrets: inherit

--- a/.github/workflows/_sandbox.yaml
+++ b/.github/workflows/_sandbox.yaml
@@ -4,14 +4,38 @@ on:
   workflow_dispatch:
 
 jobs:
-  runner:
-    uses: ./.github/workflows/_runner_ondemand_slurm.yaml
-    with:
-      NAME: "TEST-${{ github.run_id }}"
-      LABELS: "TEST:${{ github.run_id }}"
-      TIME: "01:00:00"
-    secrets: inherit
+  sandbox:
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
-  pax-multi-node:
-    uses: ./.github/workflows/_test_pax.yaml
-    secrets: inherit
+      - name: Print usage
+        run: |
+          cat << EOF
+          This is an empty workflow file located in the main branch of your
+          repository. It serves as a testing ground for new GitHub Actions on
+          development branches before merging them to the main branch. By
+          defining and overloading this workflow on your development branch,
+          you can test new actions without affecting your main branch, ensuring
+          a smooth integration process once the changes are ready to be merged.
+
+          Usage:
+          
+          1. In your development branch, modify the sandbox.yml workflow file
+             to include the new actions you want to test. Make sure to commit
+             the changes to the development branch.
+          2. Navigate to the 'Actions' tab in your repository, select the
+             '~Sandbox' workflow, and choose your development branch from the
+             branch dropdown menu. Click on 'Run workflow' to trigger the
+             workflow on your development branch.
+          3. Once you have tested and verified the new actions in the Sandbox
+             workflow, you can incorporate them into your main workflow(s) and
+             merge the development branch into the main branch. Remember to
+             revert the changes to the sandbox.yml file in the main branch to
+             keep it empty for future testing.
+          EOF

--- a/.github/workflows/_test_pax.yaml
+++ b/.github/workflows/_test_pax.yaml
@@ -63,6 +63,7 @@ jobs:
           EOF
           chmod 600 ~/.ssh/known_hosts
           echo "FILE=$(realpath ~/.ssh/known_hosts)" >> $GITHUB_OUTPUT
+
       - name: Labels and metadata
         id: meta
         shell: bash -x -e {0}
@@ -79,6 +80,7 @@ jobs:
           for var in IMAGE TEST_CASE_NAME TOTAL_TASKS NODES GPUS_PER_NODE JOB_NAME LOG_FILE MODEL_PATH; do
             echo "$var=${!var}" >> $GITHUB_OUTPUT
           done
+
       - name: Submit SLURM jobs over SSH
         id: submit
         shell: bash -O expand_aliases -x -e {0}
@@ -113,6 +115,9 @@ jobs:
               ${{ inputs.EXTRA_TEST_ARGS }}
           EOF
           )
+
+          echo "SLURM_JOB_ID=${JOB}" >> $GITHUB_OUTPUT
+
           set +x
           while sshx squeue -j $JOB | grep -q $JOB; do
             echo "SLURM Job $JOB is still running."
@@ -127,6 +132,14 @@ jobs:
           echo "SLURM_STATE=${SLURM_STATE}" >> "$GITHUB_OUTPUT"
           echo "SLURM_EXITCODE=${SLURM_EXITCODE}" >> "$GITHUB_OUTPUT"
           set -x
+
+      - name: Remove orphaned SLURM job if the CI job is canceled
+        if: cancelled()
+        shell: bash -x -e {0}
+        run: |
+          ssh ${{ secrets.CLUSTER_LOGIN_USER }}@${{ vars.HOSTNAME_SLURM_LOGIN }} \
+            scancel ${{ steps.submit.outputs.SLURM_JOB_ID }}
+
       - name: Retrieve training logs and upload to TensorBoard server
         shell: bash -x -e {0}
         run: |
@@ -140,6 +153,7 @@ jobs:
           rsync -rtz --progress \
             output/ \
             ${{ secrets.TENSORBOARD_UPLOAD_USER }}@${{ vars.HOSTNAME_TENSORBOARD }}:/tensorboard-logs/${{ inputs.FW_NAME }}-${GITHUB_RUN_ID}/ || true
+
       - name: Write SLURM job status to file
         shell: bash -x -e {0}
         run: |
@@ -245,6 +259,8 @@ jobs:
           EOF
           )
 
+          echo "SLURM_JOB_ID=${JOB}" >> $GITHUB_OUTPUT
+
           set +x
           while sshx squeue -j $JOB | grep -q $JOB; do
             echo "SLURM Job $JOB is still running."
@@ -262,6 +278,13 @@ jobs:
           echo "SLURM_EXITCODE=${SLURM_EXITCODE}" >> "$GITHUB_OUTPUT"
 
           set -x
+
+      - name: Remove orphaned SLURM job if the CI job is canceled
+        if: cancelled()
+        shell: bash -x -e {0}
+        run: |
+          ssh ${{ secrets.CLUSTER_LOGIN_USER }}@${{ vars.HOSTNAME_SLURM_LOGIN }} \
+            scancel ${{ steps.submit.outputs.SLURM_JOB_ID }}
 
       - name: Retrieve training logs and upload to TensorBoard server
         shell: bash -x -e {0}
@@ -376,6 +399,8 @@ jobs:
           EOF
           )
 
+          echo "SLURM_JOB_ID=${JOB}" >> $GITHUB_OUTPUT
+
           set +x
           while sshx squeue -j $JOB | grep -q $JOB; do
             echo "SLURM Job $JOB is still running."
@@ -393,6 +418,13 @@ jobs:
           echo "SLURM_EXITCODE=${SLURM_EXITCODE}" >> "$GITHUB_OUTPUT"
 
           set -x
+
+      - name: Remove orphaned SLURM job if the CI job is canceled
+        if: cancelled()
+        shell: bash -x -e {0}
+        run: |
+          ssh ${{ secrets.CLUSTER_LOGIN_USER }}@${{ vars.HOSTNAME_SLURM_LOGIN }} \
+            scancel ${{ steps.submit.outputs.SLURM_JOB_ID }}
 
       - name: Retrieve training logs and upload to TensorBoard server
         shell: bash -x -e {0}
@@ -457,8 +489,9 @@ jobs:
 
   sitrep:
     needs: [single-process-multi-device, pax-multi-node, single-process-evaluation, metrics]
-    if: success() || failure()
+    if: "!cancelled()"
     uses: ./.github/workflows/_sitrep_mgmn.yaml
+    secrets: inherit
     with:
       BADGE_FILENAME: ${{ inputs.BADGE_FILENAME }}
       ARTIFACT_NAME: ${{ inputs.ARTIFACT_NAME }}
@@ -466,7 +499,8 @@ jobs:
 
   summary:
     runs-on: ubuntu-22.04
-
+    needs: [single-process-multi-device, pax-multi-node, single-process-evaluation]
+    if: "!cancelled()"
     steps:
       - name: Generate TensorBoard query URL
         run: |
@@ -483,7 +517,7 @@ jobs:
   outcome:
     needs: sitrep
     runs-on: ubuntu-22.04
-    if: ( always() )
+    if: "!cancelled()"
     steps:
       - name: Sets workflow status based on test outputs
         run: |

--- a/.github/workflows/_test_pax_rosetta.yaml
+++ b/.github/workflows/_test_pax_rosetta.yaml
@@ -104,6 +104,9 @@ jobs:
               ${{ inputs.EXTRA_TEST_ARGS }}
           EOF
           )
+
+          echo "SLURM_JOB_ID=${JOB}" >> $GITHUB_OUTPUT
+
           set +x
           while sshx squeue -j $JOB | grep -q $JOB; do
             echo "SLURM Job $JOB is still running."
@@ -118,6 +121,14 @@ jobs:
           echo "SLURM_STATE=${SLURM_STATE}" >> "$GITHUB_OUTPUT"
           echo "SLURM_EXITCODE=${SLURM_EXITCODE}" >> "$GITHUB_OUTPUT"
           set -x
+
+      - name: Remove orphaned SLURM job if the CI job is canceled
+        if: cancelled()
+        shell: bash -x -e {0}
+        run: |
+          ssh ${{ secrets.CLUSTER_LOGIN_USER }}@${{ vars.HOSTNAME_SLURM_LOGIN }} \
+            scancel ${{ steps.submit.outputs.SLURM_JOB_ID }}
+
       - name: Retrieve training logs and upload to TensorBoard server
         shell: bash -x -e {0}
         run: |
@@ -131,6 +142,7 @@ jobs:
           rsync -rtz --progress \
             output/ \
             ${{ secrets.TENSORBOARD_UPLOAD_USER }}@${{ vars.HOSTNAME_TENSORBOARD }}:/tensorboard-logs/${{ inputs.ARTIFACT_NAME }}rosetta-pax-/ || true
+
       - name: Write SLURM job status to file
         shell: bash -x -e {0}
         run: |
@@ -236,6 +248,8 @@ jobs:
           EOF
           )
 
+          echo "SLURM_JOB_ID=${JOB}" >> $GITHUB_OUTPUT
+
           set +x
           while sshx squeue -j $JOB | grep -q $JOB; do
             echo "SLURM Job $JOB is still running."
@@ -253,6 +267,13 @@ jobs:
           echo "SLURM_EXITCODE=${SLURM_EXITCODE}" >> "$GITHUB_OUTPUT"
 
           set -x
+
+      - name: Remove orphaned SLURM job if the CI job is canceled
+        if: cancelled()
+        shell: bash -x -e {0}
+        run: |
+          ssh ${{ secrets.CLUSTER_LOGIN_USER }}@${{ vars.HOSTNAME_SLURM_LOGIN }} \
+            scancel ${{ steps.submit.outputs.SLURM_JOB_ID }}
 
       - name: Retrieve training logs and upload to TensorBoard server
         shell: bash -x -e {0}
@@ -370,6 +391,8 @@ jobs:
           EOF
           )
 
+          echo "SLURM_JOB_ID=${JOB}" >> $GITHUB_OUTPUT
+
           set +x
           while sshx squeue -j $JOB | grep -q $JOB; do
             echo "SLURM Job $JOB is still running."
@@ -387,6 +410,13 @@ jobs:
           echo "SLURM_EXITCODE=${SLURM_EXITCODE}" >> "$GITHUB_OUTPUT"
 
           set -x
+
+      - name: Remove orphaned SLURM job if the CI job is canceled
+        if: cancelled()
+        shell: bash -x -e {0}
+        run: |
+          ssh ${{ secrets.CLUSTER_LOGIN_USER }}@${{ vars.HOSTNAME_SLURM_LOGIN }} \
+            scancel ${{ steps.submit.outputs.SLURM_JOB_ID }}
 
       - name: Retrieve training logs and upload to TensorBoard server
         shell: bash -x -e {0}
@@ -505,6 +535,8 @@ jobs:
           EOF
           )
 
+          echo "SLURM_JOB_ID=${JOB}" >> $GITHUB_OUTPUT
+
           set +x
           while sshx squeue -j $JOB | grep -q $JOB; do
             echo "SLURM Job $JOB is still running."
@@ -522,6 +554,13 @@ jobs:
           echo "SLURM_EXITCODE=${SLURM_EXITCODE}" >> "$GITHUB_OUTPUT"
 
           set -x
+
+      - name: Remove orphaned SLURM job if the CI job is canceled
+        if: cancelled()
+        shell: bash -x -e {0}
+        run: |
+          ssh ${{ secrets.CLUSTER_LOGIN_USER }}@${{ vars.HOSTNAME_SLURM_LOGIN }} \
+            scancel ${{ steps.submit.outputs.SLURM_JOB_ID }}
 
       - name: Retrieve training logs and upload to TensorBoard server
         shell: bash -x -e {0}
@@ -637,6 +676,8 @@ jobs:
           EOF
           )
 
+          echo "SLURM_JOB_ID=${JOB}" >> $GITHUB_OUTPUT
+
           set +x
           while sshx squeue -j $JOB | grep -q $JOB; do
             echo "SLURM Job $JOB is still running."
@@ -654,6 +695,13 @@ jobs:
           echo "SLURM_EXITCODE=${SLURM_EXITCODE}" >> "$GITHUB_OUTPUT"
 
           set -x
+
+      - name: Remove orphaned SLURM job if the CI job is canceled
+        if: cancelled()
+        shell: bash -x -e {0}
+        run: |
+          ssh ${{ secrets.CLUSTER_LOGIN_USER }}@${{ vars.HOSTNAME_SLURM_LOGIN }} \
+            scancel ${{ steps.submit.outputs.SLURM_JOB_ID }}
 
       - name: Retrieve training logs and upload to TensorBoard server
         shell: bash -x -e {0}
@@ -726,7 +774,7 @@ jobs:
   publish-test:
     needs: [single-process-multi-device-te, rosetta-pax-multi-node, rosetta-pax-multi-node-te, rosetta-pax-single-node-dropout-te, single-process-evaluation-te, metrics]
     uses: ./.github/workflows/_publish_badge.yaml
-    if: ( always() )
+    if: "!cancelled()"
     secrets: inherit
     with:
       ENDPOINT_FILENAME: '${{ inputs.ARTIFACT_NAME }}rosetta-pax-test-status.json'
@@ -780,7 +828,8 @@ jobs:
 
   summary:
     runs-on: ubuntu-22.04
-
+    needs: [single-process-multi-device-te, rosetta-pax-multi-node, rosetta-pax-multi-node-te, rosetta-pax-single-node-dropout-te, single-process-evaluation-te]
+    if: "!cancelled()"
     steps:
       - name: Generate TensorBoard query URL
         run: |
@@ -797,7 +846,7 @@ jobs:
   outcome:
     needs: publish-test
     runs-on: ubuntu-22.04
-    if: ( always() )
+    if: "!cancelled()"
     steps:
       - name: Sets workflow status based on test outputs 
         run: |

--- a/.github/workflows/_test_t5x.yaml
+++ b/.github/workflows/_test_t5x.yaml
@@ -112,6 +112,8 @@ jobs:
           EOF
           )
 
+          echo "SLURM_JOB_ID=${JOB}" >> $GITHUB_OUTPUT
+
           set +x
           while sshx squeue -j $JOB | grep -q $JOB; do
             echo "SLURM Job $JOB is still running."
@@ -128,6 +130,13 @@ jobs:
           echo "SLURM_EXITCODE=${SLURM_EXITCODE}" >> "$GITHUB_OUTPUT"
 
           set -x
+
+      - name: Remove orphaned SLURM job if the CI job is canceled
+        if: cancelled()
+        shell: bash -x -e {0}
+        run: |
+          ssh ${{ secrets.CLUSTER_LOGIN_USER }}@${{ vars.HOSTNAME_SLURM_LOGIN }} \
+            scancel ${{ steps.submit.outputs.SLURM_JOB_ID }}
 
       - name: Retrieve training logs and upload to TensorBoard server
         shell: bash -x -e {0}
@@ -235,6 +244,8 @@ jobs:
           EOF
           )
 
+          echo "SLURM_JOB_ID=${JOB}" >> $GITHUB_OUTPUT
+
           set +x
           while sshx squeue -j $JOB | grep -q $JOB; do
             echo "SLURM Job $JOB is still running."
@@ -251,6 +262,13 @@ jobs:
           echo "SLURM_EXITCODE=${SLURM_EXITCODE}" >> "$GITHUB_OUTPUT"
 
           set -x
+
+      - name: Remove orphaned SLURM job if the CI job is canceled
+        if: cancelled()
+        shell: bash -x -e {0}
+        run: |
+          ssh ${{ secrets.CLUSTER_LOGIN_USER }}@${{ vars.HOSTNAME_SLURM_LOGIN }} \
+            scancel ${{ steps.submit.outputs.SLURM_JOB_ID }}
 
       - name: Retrieve training logs and upload to TensorBoard server
         shell: bash -x -e {0}
@@ -317,8 +335,9 @@ jobs:
 
   sitrep:
     needs: [t5x-multi-node, t5x-multi-gpu, metrics]
-    if: success() || failure()
+    if: "!cancelled()"
     uses: ./.github/workflows/_sitrep_mgmn.yaml
+    secrets: inherit
     with:
       BADGE_FILENAME: ${{ inputs.BADGE_FILENAME }}
       ARTIFACT_NAME: ${{ inputs.ARTIFACT_NAME }}
@@ -326,7 +345,8 @@ jobs:
 
   summary:
     runs-on: ubuntu-22.04
-
+    needs: [t5x-multi-node, t5x-multi-gpu]
+    if: "!cancelled()"
     steps:
       - name: Generate TensorBoard query URL
         run: |
@@ -343,7 +363,7 @@ jobs:
   outcome:
     needs: sitrep
     runs-on: ubuntu-22.04
-    if: ( always() )
+    if: "!cancelled()"
     steps:
       - name: Sets workflow status based on test outputs
         run: |

--- a/.github/workflows/_test_t5x_rosetta.yaml
+++ b/.github/workflows/_test_t5x_rosetta.yaml
@@ -109,6 +109,8 @@ jobs:
           EOF
           )
 
+          echo "SLURM_JOB_ID=${JOB}" >> $GITHUB_OUTPUT
+
           set +x
           while sshx squeue -j $JOB | grep -q $JOB; do
             echo "SLURM Job $JOB is still running."
@@ -125,6 +127,13 @@ jobs:
           echo "SLURM_EXITCODE=${SLURM_EXITCODE}" >> "$GITHUB_OUTPUT"
 
           set -x
+
+      - name: Remove orphaned SLURM job if the CI job is canceled
+        if: cancelled()
+        shell: bash -x -e {0}
+        run: |
+          ssh ${{ secrets.CLUSTER_LOGIN_USER }}@${{ vars.HOSTNAME_SLURM_LOGIN }} \
+            scancel ${{ steps.submit.outputs.SLURM_JOB_ID }}
 
       - name: Retrieve training logs and upload to TensorBoard server
         shell: bash -x -e {0}
@@ -253,6 +262,8 @@ jobs:
           EOF
           )
 
+          echo "SLURM_JOB_ID=${JOB}" >> $GITHUB_OUTPUT
+
           set +x
           while sshx squeue -j $JOB | grep -q $JOB; do
             echo "SLURM Job $JOB is still running."
@@ -269,6 +280,13 @@ jobs:
           echo "SLURM_EXITCODE=${SLURM_EXITCODE}" >> "$GITHUB_OUTPUT"
 
           set -x
+
+      - name: Remove orphaned SLURM job if the CI job is canceled
+        if: cancelled()
+        shell: bash -x -e {0}
+        run: |
+          ssh ${{ secrets.CLUSTER_LOGIN_USER }}@${{ vars.HOSTNAME_SLURM_LOGIN }} \
+            scancel ${{ steps.submit.outputs.SLURM_JOB_ID }}
 
       - name: Retrieve training logs and upload to TensorBoard server
         shell: bash -x -e {0}
@@ -541,7 +559,7 @@ jobs:
   publish-test:
     needs: [multi-gpu-multi-node, single-process-multi-device]
     uses: ./.github/workflows/_publish_badge.yaml
-    if: success() || failure()
+    if: "!cancelled()"
     secrets: inherit
     with:
       ENDPOINT_FILENAME: '${{ inputs.ARTIFACT_NAME }}rosetta-t5x-test-completion-status.json'
@@ -602,7 +620,8 @@ jobs:
 
   summary:
     runs-on: ubuntu-22.04
-
+    needs: [multi-gpu-multi-node, single-process-multi-device]
+    if: "!cancelled()"
     steps:
       - name: Generate TensorBoard query URL
         run: |
@@ -619,7 +638,7 @@ jobs:
   outcome:
     needs: publish-test
     runs-on: ubuntu-22.04
-    if: success() || failure()
+    if: "!cancelled()"
     steps:
       - name: Sets workflow status based on test outputs 
         run: |

--- a/.github/workflows/_test_te.yaml
+++ b/.github/workflows/_test_te.yaml
@@ -133,6 +133,8 @@ jobs:
           EOF
           )
 
+          echo "SLURM_JOB_ID=${JOB}" >> $GITHUB_OUTPUT
+
           set +x
           while sshx squeue -j $JOB | grep -q $JOB; do
             echo "SLURM Job $JOB is still running."
@@ -140,6 +142,13 @@ jobs:
           done
           echo "SLRUM Job $JOB finished."
           set -x
+
+      - name: Remove orphaned SLURM job if the CI job is canceled
+        if: cancelled()
+        shell: bash -x -e {0}
+        run: |
+          ssh ${{ secrets.CLUSTER_LOGIN_USER }}@${{ vars.HOSTNAME_SLURM_LOGIN }} \
+            scancel ${{ steps.submit.outputs.SLURM_JOB_ID }}
 
       - name: Retrieve training logs
         shell: bash -x -e {0}


### PR DESCRIPTION
Fixes #415 

Currently, if a multi-node CI job submits a SLURM job and then gets canceled while waiting for the SLURM job to run, the SLURM job will become orphaned: it will be left in the queue to run, thus wasting computing resources, even though its result will not be collected. This is fixed by:
1. Keeping track of the submitted SLURM job id using the `SLURM_JOB_ID` step output variable
2. Defining a cancellation step that runs if the job is canceled cancel the SLURM job.

The effect of cancellation is verified by manually cancelling the following sandbox workflow:
https://github.com/NVIDIA/JAX-Toolbox/actions/runs/7173955368