### PR TITLE
Dockerfiles: consistently use 1-labs frontend

### DIFF
--- a/.github/container/Dockerfile.base
+++ b/.github/container/Dockerfile.base
@@ -1,3 +1,4 @@
+# syntax=docker/dockerfile:1-labs
 ARG BASE_IMAGE=nvidia/cuda:12.2.0-devel-ubuntu22.04
 ARG GIT_USER_NAME="JAX Toolbox"
 ARG GIT_USER_EMAIL=jax@nvidia.com

--- a/.github/container/Dockerfile.jax
+++ b/.github/container/Dockerfile.jax
@@ -1,3 +1,4 @@
+# syntax=docker/dockerfile:1-labs
 ARG BASE_IMAGE=ghcr.io/nvidia/jax-toolbox:base
 ARG REPO_JAX="https://github.com/google/jax.git"
 ARG REPO_XLA="https://github.com/openxla/xla.git"


### PR DESCRIPTION
We have this line in the other Dockerfiles. `1.3-labs` or `1.4` is needed to enable heredoc syntax, which is used in these files. Without an explicit syntax version then building images will fail on systems with older versions of Docker, which default to older syntax versions.

cc: @nouiz 