### PR TITLE
[Draft] Make the t5x container work on Aarch64

### DIFF
--- a/.github/container/Dockerfile.t5x
+++ b/.github/container/Dockerfile.t5x
@@ -15,6 +15,46 @@ ARG REPO_T5X
 ARG REF_T5X
 ARG SRC_PATH_T5X
 
+# force a recent version to have latest protobuf dep
+# Install now as some build need them.
+RUN pip install "tensorflow_datasets==4.9.2"
+RUN pip install "tensorflow==2.13.0"
+RUN pip install "chex==0.1.7"
+RUN <<"EOF" bash -ex
+cd /opt
+git clone http://github.com/tensorflow/text.git
+cd text
+git checkout v2.13.0
+EOF
+
+RUN <<"EOF" bash -ex
+cd /opt/text
+
+wget https://github.com/bazelbuild/bazelisk/releases/download/v1.17.0/bazelisk-linux-arm64 -O /usr/bin/bazel ;
+chmod a+x /usr/bin/bazel
+
+./oss_scripts/run_build.sh
+find * | grep '.whl$'
+EOF
+RUN pip install /opt/text/tensorflow_text-*.whl
+#RUN echo "-e file:///opt/text/tensorflow_text-*.whl"  >> /opt/pip-tools.d/manifest.t5x
+
+# Install T5 now, Pip will build the wheel from source, it needs Rust.
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs > /tmp/rustup.sh && \
+    echo "be3535b3033ff5e0ecc4d589a35d3656f681332f860c5fd6684859970165ddcc /tmp/rustup.sh" | sha256sum --check && \
+    bash /tmp/rustup.sh -y && \
+    export PATH=$PATH:/root/.cargo/bin && \
+    pip install t5 && \
+    rm -Rf /root/.cargo /root/.rustup && \
+    mv /root/.profile /root/.profile.save && \
+    grep -v cargo /root/.profile.save > /root/.profile && \
+    rm /root/.profile.save && \
+    mv /root/.bashrc /root/.bashrc.save && \
+    grep -v cargo /root/.bashrc.save > /root/.bashrc && \
+    rm /root/.bashrc.save && \
+        rm -Rf /root/.cache /tmp/*
+
+
 RUN <<"EOF" bash -ex
 get-source.sh -f ${REPO_T5X} -r ${REF_T5X} -d ${SRC_PATH_T5X}
 echo "-e file://${SRC_PATH_T5X}[gpu]" >> /opt/pip-tools.d/manifest.t5x
@@ -22,6 +62,17 @@ echo "-e file://${SRC_PATH_T5X}[gpu]" >> /opt/pip-tools.d/manifest.t5x
 # remove head-of-tree specs from select dependencies
 pushd ${SRC_PATH_T5X}
 sed -i "s| @ git+https://github.com/google/flax#egg=flax||g" setup.py
+# for ARM64 build
+sed -i "s/tensorflow/#tensorflow/" setup.py
+sed -i "s/t5=/#t5=/" setup.py
+sed -i "s/^jax/#jax/" setup.py
+
+sed -i "s/f'jax/#f'jax/" setup.py
+sed -i "s/'tpu/#'tpu/" setup.py
+
+sed -i 's/protobuf/#protobuf/' setup.py
+sed -i 's/numpy/#numpy/' setup.py
+
 if git diff --quiet; then
     echo "URL specs no longer present in select dependencies of t5x"
     exit 1

--- a/.github/container/Dockerfile.t5x
+++ b/.github/container/Dockerfile.t5x
@@ -1,4 +1,6 @@
 # syntax=docker/dockerfile:1-labs
+# Example command to build manually:
+#   docker buildx build -f Dockerfile.t5x --tag t5x --build-arg BASE_IMAGE=ghcr.io/nvidia/jax:mealkit-2023-12-12 .
 
 ARG BASE_IMAGE=ghcr.io/nvidia/jax:mealkit
 ARG REPO_T5X=https://github.com/google-research/t5x.git
@@ -38,6 +40,7 @@ find * | grep '.whl$'
 EOF
 RUN pip install /opt/text/tensorflow_text-*.whl
 #RUN echo "-e file:///opt/text/tensorflow_text-*.whl"  >> /opt/pip-tools.d/manifest.t5x
+RUN echo "tensorflow-text @  file://$(ls /opt/text/tensorflow_text-*.whl)" >> /opt/pip-tools.d/manifest.t5x
 
 # Install T5 now, Pip will build the wheel from source, it needs Rust.
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs > /tmp/rustup.sh && \
@@ -53,7 +56,7 @@ RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs > /tmp/rustup.sh &
     grep -v cargo /root/.bashrc.save > /root/.bashrc && \
     rm /root/.bashrc.save && \
         rm -Rf /root/.cache /tmp/*
-
+RUN "t5 >> /opt/pip-tools.d/manifest.t5x"
 
 RUN <<"EOF" bash -ex
 get-source.sh -f ${REPO_T5X} -r ${REF_T5X} -d ${SRC_PATH_T5X}
@@ -90,4 +93,15 @@ ADD test-t5x.sh /usr/local/bin
 
 FROM mealkit as final
 
+RUN pip uninstall -y tensorflow-text
 RUN pip-finalize.sh
+# Super basic test. It failed on GH as some dependency on pypi install no-arch wheels on ARM when they are in fact x86-64 wheels.
+RUN python -c "import t5x"
+
+#pip install grain-nightly # Install x86 so on ARM.
+#pip install git+https://github.com/google/grain.git # Don't work
+## So try to manually build it.
+#cd /opt
+#git clone https://github.com/google/grain.git
+#cd grain
+#bash grain/oss/build_whl.sh # Many issues.

--- a/.github/container/install-t5x.sh
+++ b/.github/container/install-t5x.sh
@@ -1,0 +1,56 @@
+#/bin/bash -ex
+#DOCKER_BUILDKIT=1 docker build --network=host -f Dockerfile.t5x -t t5x --build-arg BASE_IMAGE=jax --build-arg T5X_REF=$REF_T5X --build-arg REF_TE=$REF_TE .
+
+#/opt/jax/build/bazel-6.1.2-linux-arm64
+pip install chex==0.1.7
+cd /opt
+git clone https://github.com/google-research/t5x.git
+cd t5x
+export T5X_INSTALLED_DIR=/opt/t5x
+
+sed -i 's/tensorflow/#tensorflow/' ${T5X_INSTALLED_DIR}/setup.py
+sed -i 's/t5=/#t5=/' ${T5X_INSTALLED_DIR}/setup.py
+sed -i 's/^jax/#jax/' ${T5X_INSTALLED_DIR}/setup.py
+
+sed -i "s/f'jax/#f'jax/" ${T5X_INSTALLED_DIR}/setup.py
+sed -i "s/'tpu/#'tpu/" ${T5X_INSTALLED_DIR}/setup.py
+
+sed -i 's/protobuf/#protobuf/' ${T5X_INSTALLED_DIR}/setup.py
+sed -i 's/numpy/#numpy/' ${T5X_INSTALLED_DIR}/setup.py
+cat ${T5X_INSTALLED_DIR}/setup.py
+
+pip install tensorflow_datasets==4.9.2 # force a recent version to have latest protobuf dep
+pip install auditwheel tensorflow==2.13.0
+
+cd /opt/jax/build/
+ln -s bazel-6.1.2-linux-arm64 bazel
+export PATH=$PATH:/opt/jax/build/
+
+# Need as specific bazel version
+wget https://github.com/bazelbuild/bazelisk/releases/download/v1.17.0/bazelisk-linux-arm64 -O /usr/bin/bazel ;
+chmod a+x /usr/bin/bazel
+
+cd /opt
+git clone http://github.com/tensorflow/text.git
+pushd text
+git checkout v2.13.0
+./oss_scripts/run_build.sh
+find * | grep '.whl$'
+pip install ./tensorflow_text-*.whl
+popd
+
+
+# Install T5 now, Pip will build the wheel from source, it needs Rust.
+curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs > /tmp/rustup.sh && \
+    echo "be3535b3033ff5e0ecc4d589a35d3656f681332f860c5fd6684859970165ddcc /tmp/rustup.sh" | sha256sum --check && \
+    bash /tmp/rustup.sh -y && \
+    export PATH=$PATH:/root/.cargo/bin && \
+    pip install t5 && \
+    rm -Rf /root/.cargo /root/.rustup && \
+    mv /root/.profile /root/.profile.save && \
+    grep -v cargo /root/.profile.save > /root/.profile && \
+    rm /root/.profile.save && \
+    mv /root/.bashrc /root/.bashrc.save && \
+    grep -v cargo /root/.bashrc.save > /root/.bashrc && \
+    rm /root/.bashrc.save && \
+        rm -Rf /root/.cache /tmp/*


### PR DESCRIPTION
Replace https://github.com/NVIDIA/JAX-Toolbox/pull/252 with updates for the new pip-compile changes.

grain-nightly is installed as a dependency. But the wheel is bugged. It is marked as arch independent, but it is arch dependent.
When I try to build locally, it fails.
