### PR TITLE
Fix PAX nightly container publication

### DIFF
--- a/.github/workflows/nightly-pax-build.yaml
+++ b/.github/workflows/nightly-pax-build.yaml
@@ -109,7 +109,7 @@ jobs:
     with:
       SOURCE_IMAGE: |
         ${{ needs.amd64.outputs.DOCKER_TAG_MEALKIT }}
-        # ${{ needs.arm64.outputs.DOCKER_TAG_MEALKIT }}
+      # ${{ needs.arm64.outputs.DOCKER_TAG_MEALKIT }}
       TARGET_IMAGE: upstream-pax
       TARGET_TAGS: |
         type=raw,value=mealkit,priority=500
@@ -123,7 +123,7 @@ jobs:
     with:
       SOURCE_IMAGE: |
         ${{ needs.amd64.outputs.DOCKER_TAG_FINAL }}
-        # ${{ needs.arm64.outputs.DOCKER_TAG_FINAL }}
+      # ${{ needs.arm64.outputs.DOCKER_TAG_FINAL }}
       TARGET_IMAGE: upstream-pax
       TARGET_TAGS: |
         type=raw,value=latest,priority=1000

--- a/.github/workflows/nightly-rosetta-pax-build.yaml
+++ b/.github/workflows/nightly-rosetta-pax-build.yaml
@@ -161,7 +161,7 @@ jobs:
     with:
       SOURCE_IMAGE: |
         ${{ needs.amd64.outputs.DOCKER_TAG_FINAL }}
-        # ${{ needs.arm64.outputs.DOCKER_TAG_FINAL }}
+      # ${{ needs.arm64.outputs.DOCKER_TAG_FINAL }}
       TARGET_IMAGE: pax
       TARGET_TAGS: |
         ${{ needs.test-amd64.outputs.TEST_STATUS == 'success' && 'type=raw,value=latest,priority=1000' || '' }}


### PR DESCRIPTION
There was a YAML indentation issue when I last time rebased #405 and it ended up causing the comment `#` to enter the image list when we publish PAX nightly images.