### PR TITLE
Reenable PAX ARM build

### DIFF
--- a/.github/workflows/nightly-pax-build.yaml
+++ b/.github/workflows/nightly-pax-build.yaml
@@ -94,7 +94,6 @@ jobs:
   arm64:
     needs: metadata
     uses: ./.github/workflows/_build_pax.yaml
-    if: false  # TODO: enable arm64 build after the build is fixed
     with:
       ARCHITECTURE: arm64
       BASE_IMAGE: ${{ needs.metadata.outputs.BASE_IMAGE_ARM64 }}


### PR DESCRIPTION
PAX ARM builded started breaking recently and was disabled in https://github.com/NVIDIA/JAX-Toolbox/pull/426.

Fix for the ARM build was landed in https://github.com/NVIDIA/JAX-Toolbox/commit/f5abca98db688cc9cd8d92414c4a9b2dcdb105be and this PR reenables the nightly PAX ARM builds