### PR TITLE
Fix for build badge publishing for Nightly Rosetta Pax Build

### DIFF
--- a/.github/workflows/nightly-rosetta-pax-build.yaml
+++ b/.github/workflows/nightly-rosetta-pax-build.yaml
@@ -111,6 +111,7 @@ jobs:
     needs: [metadata, amd64]
     uses: ./.github/workflows/_publish_badge.yaml
     if: always()
+    secrets: inherit
     with:
       ENDPOINT_FILENAME: 'rosetta-pax-build-status.json'
       PUBLISH: ${{ needs.metadata.outputs.PUBLISH == 'true' }}


### PR DESCRIPTION
In Nightly Rosetta Pax Build the `publish-build-badge` job fails, because no secrects are passed to downstream job `_publish_badge.yaml`, which uses at least github-token secret to publish badge.

The solution: allow `publish-build-badge` inherit secrets by adding `secrets: inherit` from upstream job.