### PR TITLE
Fix extract-patches to look for correct patch dir in image

### DIFF
--- a/.github/workflows/_build_rosetta.yaml
+++ b/.github/workflows/_build_rosetta.yaml
@@ -141,15 +141,6 @@ jobs:
           build-args: |
             BASE_IMAGE=${{ steps.defaults.outputs.BASE_IMAGE }}
 
-      - name: Extract patches
-        run: rosetta/scripts/extract-patches.sh ${{ steps.final-metadata.outputs.tags }}
-
-      - name: Archive generated patches
-        uses: actions/upload-artifact@v3
-        with:
-          name: patches-${{ inputs.BASE_LIBRARY }}-${{ inputs.BUILD_DATE }}-${{ github.run_id }}-${{ inputs.ARCHITECTURE }}
-          path: rosetta/patches
-
       - name: Generate sitrep
         if: success() || failure()
         shell: bash -x -e {0}

--- a/rosetta/scripts/extract-patches.sh
+++ b/rosetta/scripts/extract-patches.sh
@@ -6,13 +6,14 @@ cd $SCRIPT_DIR
 if [[ $# -lt 1 || $# -gt 2 ]]; then
   echo "Copies the patches from within an image to the GIT_ROOT/rosetta/patches dir"
   echo
-  echo "Usage: $0 <image> <rosetta dir: default GIT_ROOT/rosetta/>"
+  echo "Usage: $0 <image> <patch dir in image: default /opt/manifest.d/patches> <rosetta dir: default GIT_ROOT/rosetta/>"
   exit 1
 fi
 
 IMAGE=$1
-ROSETTA_DIR=${2:-$(readlink -f ../)}
+IMAGE_PATCH_DIR=${2:-"/opt/manifest.d/patches"}
+ROSETTA_DIR=${3:-$(readlink -f ../)}
 
 container_id=$(docker create $IMAGE)
-docker cp $container_id:/opt/rosetta/patches $ROSETTA_DIR
+docker cp $container_id:$IMAGE_PATCH_DIR $ROSETTA_DIR
 docker rm -v $container_id


### PR DESCRIPTION
`extract-patches.sh` looks for incorrect dir in image which results in https://github.com/NVIDIA/JAX-Toolbox/actions/runs/7279876719/job/19837106057#step:13:24

This PR fixes the script to look in the correct path and make that path configurable.

Example workflow - https://github.com/NVIDIA/JAX-Toolbox/actions/runs/7282838670