### PR TITLE
Update manifest and pin newer numpy in containers

### DIFF
--- a/.github/container/Dockerfile.jax
+++ b/.github/container/Dockerfile.jax
@@ -85,6 +85,10 @@ ADD build-jax.sh local_cuda_arch test-jax.sh /usr/local/bin/
 
 RUN mkdir -p /opt/pip-tools.d
 RUN <<"EOF" bash -ex
+# Encourage a newer numpy so that pip's dependency resolver will allow newer
+# versions of other packages that rely on newer numpy, but also include fixes
+# for compatibility with newer JAX versions. e.g. chex.
+echo "numpy >= 1.24.1"                                  >> /opt/pip-tools.d/requirements-jax.in
 echo "-e file://${SRC_PATH_JAX}"                        >> /opt/pip-tools.d/requirements-jax.in
 echo "jaxlib @ file://$(ls ${SRC_PATH_JAX}/dist/*.whl)" >> /opt/pip-tools.d/requirements-jax.in
 EOF

--- a/.github/container/manifest.yaml
+++ b/.github/container/manifest.yaml
@@ -2,31 +2,31 @@
 jax:
   url: https://github.com/google/jax.git
   tracking_ref: main
-  latest_verified_commit: 595117b70c11055e569480b80907d8c8a9901805
+  latest_verified_commit: afa2f1e420de3d2cfd684cff080a3808ee66daf5
   mode: git-clone
 xla:
   url: https://github.com/openxla/xla.git
   tracking_ref: main
-  latest_verified_commit: 78a5297d8e4301cb3ba2514061f56f89104e3d88
+  latest_verified_commit: 64a7946ffd048daf65ef330fc4ca5e4c3c1482a0
   mode: git-clone
 flax:
   url: https://github.com/google/flax.git
   mirror_url: https://github.com/nvjax-svc-0/flax.git
   tracking_ref: main
-  latest_verified_commit: 230b0d77e98da22b6e574c3cbff743ca1504bfca
+  latest_verified_commit: 85dfad242e56098849dbf05e7e4657b3a40820f9
   mode: git-clone
   patches:
     pull/3340/head: file://patches/flax/PR-3340.patch # Add Sharding Annotations to Flax Modules
 transformer-engine:
   url: https://github.com/NVIDIA/TransformerEngine.git
   tracking_ref: main
-  latest_verified_commit: 92c1e500dd14608e54f75df8276baa1104c61d48
+  latest_verified_commit: d155eaac8e08d42e67d7efd812ee2a69954de816
   mode: git-clone
 t5x:
   url: https://github.com/google-research/t5x.git
   mirror_url: https://github.com/nvjax-svc-0/t5x.git
   tracking_ref: main
-  latest_verified_commit: 1bfd2f15e5e77b09d60301367f67fdc9bb756b46
+  latest_verified_commit: dbc4b6f426862d5a742a2104a17524f53dd442f0
   mode: git-clone
   patches:
     mirror/patch/partial-checkpoint-restore: file://patches/t5x/mirror-patch-partial-checkpoint-restore.patch # pull/1392/head  # https://github.com/google-research/t5x/pull/1392: Add support for partial checkpoint restore
@@ -36,7 +36,7 @@ paxml:
   url: https://github.com/google/paxml.git
   mirror_url: https://github.com/nvjax-svc-0/paxml.git
   tracking_ref: main
-  latest_verified_commit: 7ae682d4d99630008e190b96c5296990297175c2
+  latest_verified_commit: 60e9e29bd3c6cc53bb4462f8c03bd5408daacd7b
   mode: git-clone
   patches:
     pull/46/head: file://patches/paxml/PR-46.patch # adds Transformer Engine support
@@ -44,7 +44,7 @@ praxis:
   url: https://github.com/google/praxis.git
   mirror_url: https://github.com/nvjax-svc-0/praxis.git
   tracking_ref: main
-  latest_verified_commit: b6f32fa0fc6721db1cec75972b0f569c82095956
+  latest_verified_commit: 5b70196ffba154e78a5f78ce9175854b18cf936d
   mode: git-clone
   patches:
     pull/27/head: file://patches/praxis/PR-27.patch # This PR allows XLA:GPU to detect the MHA pattern more easily to call fused kernels from cublas.
@@ -53,7 +53,7 @@ lingvo:
   # Used only in ARM pax builds
   url: https://github.com/tensorflow/lingvo.git
   tracking_ref: master
-  latest_verified_commit: 0274fa20b4ff194c1c118b94b5f778caa5d9a84a
+  latest_verified_commit: ab71210c31706b190ebdd3bd3573ed833e693587
   mode: git-clone
 tensorflow-text:
   # Used only in ARM pax builds
@@ -68,18 +68,18 @@ pydantic:
 fiddle:
   url: https://github.com/google/fiddle.git
   tracking_ref: main
-  latest_verified_commit: d409cf95164599a88e49d2b6a23a0972a7170b0b
+  latest_verified_commit: a9e98709d4b109bf04ed61cee5ff366c50c82463
   mode: pip-vcs
 # Used by t5x
 airio:
   url: https://github.com/google/airio.git
   tracking_ref: main
-  latest_verified_commit: 69b3ec4ded478ad9cacdc97652a9d086a6a644c4
+  latest_verified_commit: 0e31f368b12d298e133b3a774e27d9bb0e85d087
   mode: pip-vcs
 clu:
   url: https://github.com/google/CommonLoopUtils.git
   tracking_ref: main
-  latest_verified_commit: 7ba2a9d83a3bc1a97b59482c2f02dc4b3614bc31
+  latest_verified_commit: f30bc441a14f0ccf8eaff79800f486a846613a8c
   mode: pip-vcs
 dllogger:
   url: https://github.com/NVIDIA/dllogger.git
@@ -94,10 +94,10 @@ jestimator:
 optax:
   url: https://github.com/deepmind/optax.git
   tracking_ref: master
-  latest_verified_commit: bf987e15eacf6efeb1a1a51b8868c094c3a15f9b
+  latest_verified_commit: bc22961422eb2397a4639ec945da0bea73d624d6
   mode: pip-vcs
 seqio:
   url: https://github.com/google/seqio.git
   tracking_ref: main
-  latest_verified_commit: 515d917bf58da4103a2bbf39c3716213c36aff03
+  latest_verified_commit: b582c96cb83f1472925c2b50b90059ad1da8c138
   mode: pip-vcs

--- a/.github/container/manifest.yaml
+++ b/.github/container/manifest.yaml
@@ -31,7 +31,8 @@ t5x:
   patches:
     mirror/patch/partial-checkpoint-restore: file://patches/t5x/mirror-patch-partial-checkpoint-restore.patch # pull/1392/head  # https://github.com/google-research/t5x/pull/1392: Add support for partial checkpoint restore
     mirror/patch/dali-support: file://patches/t5x/mirror-patch-dali-support.patch # pull/1393/head  # https://github.com/google-research/t5x/pull/1393: Adds DALI support to t5x
-    mirror/patch/t5x_te_in_contrib_noindent: file://patches/t5x/mirror-patch-t5x_te_in_contrib_noindent.patch # pull/1391/head  # https://github.com/google-research/t5x/pull/1391: Adds transformer engine support and GPU optimizations to T5x (enables H100)
+    # mirror/patch/t5x_te_in_contrib_noindent: file://patches/t5x/mirror-patch-t5x_te_in_contrib_noindent.patch # pull/1391/head  # https://github.com/google-research/t5x/pull/1391: Adds transformer engine support and GPU optimizations to T5x (enables H100)
+    mirror/ashors/fix_rng_dtype: file://patches/t5x/mirror-ashors-fix_rng_dtype.patch # fix on top of (and incorporating) https://github.com/google-research/t5x/pull/1391
 paxml:
   url: https://github.com/google/paxml.git
   mirror_url: https://github.com/nvjax-svc-0/paxml.git

--- a/.github/container/patches/flax/PR-3340.patch
+++ b/.github/container/patches/flax/PR-3340.patch
@@ -373,7 +373,7 @@ index 076fd680..6eff2dd1 100644
  
  
 -- 
-2.25.1
+2.43.0
 
 
 From d1f3ec337b85b5c5377aab72d814adfc89dd4af5 Mon Sep 17 00:00:00 2001
@@ -436,5 +436,5 @@ index 999acf2c..8e031c77 100644
      else:
        bias = None
 -- 
-2.25.1
+2.43.0
 

--- a/.github/container/patches/paxml/PR-46.patch
+++ b/.github/container/patches/paxml/PR-46.patch
@@ -683,7 +683,7 @@ index 587181d..e7fe54a 100644
  
    train_state_partition_specs = (
 -- 
-2.25.1
+2.43.0
 
 
 From 9d6b6db6039d7e6658dd179e5838379c7dc967e3 Mon Sep 17 00:00:00 2001
@@ -717,7 +717,7 @@ index d44ca67..2b9dba4 100644
          assert self.packed_input == False
          assert len(self.moe_layers) == 0
 -- 
-2.25.1
+2.43.0
 
 
 From 1612dc7a1f77f0a515eb4801087a8b4f0756e5b9 Mon Sep 17 00:00:00 2001
@@ -744,7 +744,7 @@ index 2b9dba4..ef20305 100644
      return x_out
  
 -- 
-2.25.1
+2.43.0
 
 
 From 71507dc4b1396252e6fa746d1299854c204f0c51 Mon Sep 17 00:00:00 2001
@@ -771,7 +771,7 @@ index e7fe54a..4093c3b 100644
      vars_with_opt = tasks_lib.filter_vars_for_grad_or_opt(
          mdl_vars, excluded_for_learner
 -- 
-2.25.1
+2.43.0
 
 
 From 2a8233302c7e42b7dc7628c41abb637518d15c29 Mon Sep 17 00:00:00 2001
@@ -808,7 +808,7 @@ index ef20305..fed1601 100644
          finally:
              pass
 -- 
-2.25.1
+2.43.0
 
 
 From 2a6e5a960f438653b4c9cbeb0c016225af853279 Mon Sep 17 00:00:00 2001
@@ -975,7 +975,7 @@ index fed1601..5914e54 100644
      def update_fp8_metas_if_needed(mdl_vars, grads):
          return TransformerEngineHelper.get_helper().update_fp8_metas_if_needed(mdl_vars, grads)
 -- 
-2.25.1
+2.43.0
 
 
 From b57188225e7890dfc54d70db7d89fcb32e61e762 Mon Sep 17 00:00:00 2001
@@ -1136,7 +1136,7 @@ index 4093c3b..2e8fc35 100644
          grads, states.opt_states[0], vars_with_opt, wps_with_opt
      )
 -- 
-2.25.1
+2.43.0
 
 
 From c43766ee2e8cda686176a3895e87150b10d5de5e Mon Sep 17 00:00:00 2001
@@ -1528,7 +1528,7 @@ index fd482df..b271258 100644
      @contextmanager
      def fp8_autocast(dp_mesh_axis="replica", tp_mesh_axis="mdl", fsdp_mesh_axis="data"):
 -- 
-2.25.1
+2.43.0
 
 
 From abc0fabc3e2ffb42d1f62254ad42448a39cbd128 Mon Sep 17 00:00:00 2001
@@ -1563,5 +1563,5 @@ index b271258..cbac7cf 100644
  
  class TransformerEngineHelperBase:
 -- 
-2.25.1
+2.43.0
 

--- a/.github/container/patches/praxis/PR-27.patch
+++ b/.github/container/patches/praxis/PR-27.patch
@@ -34,5 +34,5 @@ index a35ce8b..52886bc 100644
        self.add_summary('attention_mask', atten_mask)
      if self.attention_extra_logit is None:
 -- 
-2.25.1
+2.43.0
 

--- a/.github/container/patches/praxis/PR-36.patch
+++ b/.github/container/patches/praxis/PR-36.patch
@@ -247,7 +247,7 @@ index ab6cff3..c79dac9 100644
        # Annotate the inputs before the pipeline to prevent unexpected
        # propagation from earlier layers.
 -- 
-2.25.1
+2.43.0
 
 
 From ff1745796009cf1ec59f463f8e776c66f1286938 Mon Sep 17 00:00:00 2001
@@ -358,5 +358,5 @@ index e3b2f7c..b31526e 100644
            trans_in_fn=_get_to_f32_converter(bf16_vars_to_convert),
            trans_out_fn=_get_to_bf16_converter(bf16_vars_to_convert),
 -- 
-2.25.1
+2.43.0
 

--- a/.github/container/patches/t5x/mirror-ashors-fix_rng_dtype.patch
+++ b/.github/container/patches/t5x/mirror-ashors-fix_rng_dtype.patch
@@ -1,7 +1,7 @@
 From 6ac19ca55511e08e8751ab95e312df0399c19c5b Mon Sep 17 00:00:00 2001
 From: Terry Kong <terryk@nvidia.com>
 Date: Mon, 24 Apr 2023 10:18:29 -0700
-Subject: [PATCH 01/17] Added transformer engine support and GPU optimizations
+Subject: [PATCH 01/18] Added transformer engine support and GPU optimizations
 
 Co-authored-by: Sahil Jain <sahilj@nvidia.com>
 Co-authored-by: Terry Kong <terryk@nvidia.com>
@@ -2465,13 +2465,13 @@ index 752beb3..4eae811 100644
        jnp.asarray([learning_rate]))
    metrics["learning_rate/current"] = clu.metrics.LastValue.from_model_output(
 -- 
-2.43.0
+2.34.1
 
 
 From 325f0e38720581c4f2535f3da23f40f425560138 Mon Sep 17 00:00:00 2001
 From: Terry Kong <terryk@nvidia.com>
 Date: Tue, 11 Jul 2023 12:10:33 -0700
-Subject: [PATCH 02/17] UNINSTALL_TE in fine-tuning scripts now defaults to
+Subject: [PATCH 02/18] UNINSTALL_TE in fine-tuning scripts now defaults to
  no-action
 
 ---
@@ -2500,13 +2500,13 @@ index 388d2ec..135ecf6 100755
  # Global batch size
  BSIZE=$(( GPUS_PER_NODE * BSIZE_PER_GPU * SLURM_JOB_NUM_NODES / TP_SIZE))
 -- 
-2.43.0
+2.34.1
 
 
 From f75aa370fe5c82dc8cf2f5a3ef3bdba407b60628 Mon Sep 17 00:00:00 2001
 From: Terry Kong <terryk@nvidia.com>
 Date: Wed, 12 Jul 2023 20:26:28 -0700
-Subject: [PATCH 03/17] remove use_gda from LegacyCheckpointManager in train.py
+Subject: [PATCH 03/18] remove use_gda from LegacyCheckpointManager in train.py
  for fp8
 
 ---
@@ -2528,13 +2528,13 @@ index e7ee77d..7fe705c 100644
    # Start warming up the input pipeline in the background. This must happen
    # after input pipeline checkpoints were restored.
 -- 
-2.43.0
+2.34.1
 
 
 From 395cf5bcca9c26f7fdaabca8541aa8368bcb8f91 Mon Sep 17 00:00:00 2001
 From: Terry Kong <terryk@nvidia.com>
 Date: Tue, 18 Jul 2023 15:55:01 -0700
-Subject: [PATCH 04/17] Allow singlenode scripts to tee to stdout for better
+Subject: [PATCH 04/18] Allow singlenode scripts to tee to stdout for better
  indication of training status
 
 ---
@@ -2565,13 +2565,13 @@ index def1a1a..0d12f30 100755
 +  2>&1 | tee \
    ${LOG_DIR}/${T5_SIZE}_gpu_${NUM_GPUS}_${PREC}_gbs_${BSIZE}_fp8_${ENABLE_FP8}_fuseqkv_${FUSE_QKV}_transbs_${TRANSPOSE_BS}.log
 -- 
-2.43.0
+2.34.1
 
 
 From 7cc636157b1afd8496baea7977876124b205db9e Mon Sep 17 00:00:00 2001
 From: Reese Wang <rewang@nvidia.com>
 Date: Fri, 14 Jul 2023 05:00:58 -0700
-Subject: [PATCH 05/17] Explicit specify self_attn_mask_type
+Subject: [PATCH 05/18] Explicit specify self_attn_mask_type
 
 ---
  t5x/te_helper.py | 10 ++++++++--
@@ -2606,13 +2606,13 @@ index fb5f48f..f3750ca 100644
  
  class TransformerEngineHelper(TransformerEngineHelperBase):
 -- 
-2.43.0
+2.34.1
 
 
 From d17222e423d83ea2faba226fad5f6a2b1bc9307f Mon Sep 17 00:00:00 2001
 From: Terry Kong <terryk@nvidia.com>
 Date: Thu, 3 Aug 2023 14:25:22 -0700
-Subject: [PATCH 06/17] Disables check for packing by the te_helper util since
+Subject: [PATCH 06/18] Disables check for packing by the te_helper util since
  not all dataset configs use packing (CV/Multimodal)
 
 ---
@@ -2633,13 +2633,13 @@ index f3750ca..f585752 100644
          "Transformer Engine does not support dataset.packing, please turn it off."
  
 -- 
-2.43.0
+2.34.1
 
 
 From c0448f9284bf910699dc7ecba202c2f213fa7481 Mon Sep 17 00:00:00 2001
 From: Terry Kong <terryk@nvidia.com>
 Date: Sat, 26 Aug 2023 16:13:11 -0700
-Subject: [PATCH 07/17] Corrected T5x large baselines
+Subject: [PATCH 07/18] Corrected T5x large baselines
 
 Updated T5x-large MNLI and SQUAD baselines
 ---
@@ -2660,13 +2660,13 @@ index a9974e1..660df3a 100644
  | [T5-v1.1-xl](../t5/t5_1_1/xl.gin)       | A100 80G SXM     | bf16      | 256   | 1     | 8        | ~4322         | 16.9        | 5.5 days      | 1,408   | 91.15%             | 89.36 / 95.29      | [log](https://tensorboard.dev/experiment/vuRoEYgkRgWiEtbvgxlOqw/#scalars&_smoothingWeight=0) |[pile](../t5/t5_1_1/examples/xl_pile_pretrain.gin)
  | [T5-v1.1-xxl](../t5/t5_1_1/xxl.gin)     | A100 80G SXM     | bf16      | 512   | 8     | 36       | ~1887         | 3.69        | 12.6 days     | 6,431  |N/A(partial run)   | N/A(partial run)   |                  |[pile](../t5/t5_1_1/examples/xxl_pile_pretrain.gin)
 -- 
-2.43.0
+2.34.1
 
 
 From 443df5e4414dcbac5482fc2672e1484a554c1bd2 Mon Sep 17 00:00:00 2001
 From: Terry Kong <terryk@nvidia.com>
 Date: Fri, 8 Sep 2023 15:09:08 -0700
-Subject: [PATCH 08/17] Add t5-large FP8 logs
+Subject: [PATCH 08/18] Add t5-large FP8 logs
 
 ---
  docs/usage/gpu-usage.md | 2 +-
@@ -2686,13 +2686,13 @@ index 660df3a..c31094d 100644
  | [T5-v1.1-xl](../t5/t5_1_1/xl.gin)       | **H100 80G SXM** | TE-fp8    | 256   | 1     | 8        | ~9688         | **37.8**    | **2.4 days**  | **614** | N/A (perf test)    | N/A (perf test)    |                 |[pile](../t5/t5_1_1/examples/xl_pile_pretrain.gin)
  
 -- 
-2.43.0
+2.34.1
 
 
 From 8494e0ba9683f1776500d0a401f29633f6b6130b Mon Sep 17 00:00:00 2001
 From: Ming-Xu Huang <mingh@nvidia.com>
 Date: Fri, 20 Oct 2023 14:26:09 +0800
-Subject: [PATCH 09/17] Fix missing fp8_meta_collection in the eval stage.
+Subject: [PATCH 09/18] Fix missing fp8_meta_collection in the eval stage.
 
 ---
  t5x/models.py | 2 +-
@@ -2712,13 +2712,13 @@ index fcd9fd5..a4276ec 100644
          enable_dropout=False,
          method=self.module.encode,
 -- 
-2.43.0
+2.34.1
 
 
 From 181087dbc71a268e4d96fbd3adb429ab630f0486 Mon Sep 17 00:00:00 2001
 From: Ming-Xu Huang <mingh@nvidia.com>
 Date: Fri, 20 Oct 2023 14:48:40 +0800
-Subject: [PATCH 10/17] Remove redundant code.
+Subject: [PATCH 10/18] Remove redundant code.
 
 ---
  t5x/models.py | 17 -----------------
@@ -2753,13 +2753,13 @@ index a4276ec..faeb6d0 100644
      # `decoder_input_tokens`. The EOS is stripped to avoid decoding to stop
      # after the prompt by matching to `output_vocabulary.eos_id`.
 -- 
-2.43.0
+2.34.1
 
 
 From 4d051703078985ca95b23def87672513dbce9daa Mon Sep 17 00:00:00 2001
 From: Ming-Xu Huang <mingh@nvidia.com>
 Date: Fri, 20 Oct 2023 15:05:40 +0800
-Subject: [PATCH 11/17] Fix deprecating warning about TE.
+Subject: [PATCH 11/18] Fix deprecating warning about TE.
 
 ---
  t5x/te_helper.py | 8 ++++----
@@ -2805,13 +2805,13 @@ index f585752..568f596 100644
          name=name)
  
 -- 
-2.43.0
+2.34.1
 
 
 From 5fff9dc6557e084378d24fc9c14376331e7f3d3a Mon Sep 17 00:00:00 2001
 From: Terry Kong <terryk@nvidia.com>
 Date: Fri, 27 Oct 2023 09:08:10 -0700
-Subject: [PATCH 12/17] Updates TE api from te.extend_* to te.flax.extend_*
+Subject: [PATCH 12/18] Updates TE api from te.extend_* to te.flax.extend_*
  (#7)
 
 Co-authored-by: NVIDIA <jax@nvidia.com>
@@ -2833,13 +2833,13 @@ index 568f596..05c5f6b 100644
    @staticmethod
    def update_fp8_metas(grad_accum, flax_mutables):
 -- 
-2.43.0
+2.34.1
 
 
 From e36be07a36c476545a5bbbb59e5c7a44419deb02 Mon Sep 17 00:00:00 2001
 From: Terry Kong <terryk@nvidia.com>
 Date: Tue, 31 Oct 2023 21:52:22 -0700
-Subject: [PATCH 13/17] Adds ENABLE_TE env var and renames TEConfig.enabled ->
+Subject: [PATCH 13/18] Adds ENABLE_TE env var and renames TEConfig.enabled ->
  TEConfig.enable_fp8 (#8)
 
 * Allows ENABLE_TE env var to control whether TE code path is invoked
@@ -2996,13 +2996,13 @@ index 05c5f6b..7657c52 100644
      return TENotInstalledHelper
  
 -- 
-2.43.0
+2.34.1
 
 
 From 4b8a1ad34509a5f62dea7ce0d3efef87e2a4e9d1 Mon Sep 17 00:00:00 2001
 From: Ming-Xu Huang <mingh@nvidia.com>
 Date: Tue, 7 Nov 2023 10:57:34 +0800
-Subject: [PATCH 14/17] Adapting to TE/JAX/Custom_partitioning.
+Subject: [PATCH 14/18] Adapting to TE/JAX/Custom_partitioning.
 
 ---
  t5x/te_helper.py | 5 ++---
@@ -3032,13 +3032,13 @@ index 7657c52..b064d2b 100644
  
    @staticmethod
 -- 
-2.43.0
+2.34.1
 
 
 From d08a6847857b6549ed8bfe1441d3742a6a13ac08 Mon Sep 17 00:00:00 2001
 From: Ming-Xu Huang <mingh@nvidia.com>
 Date: Wed, 22 Nov 2023 13:53:49 +0800
-Subject: [PATCH 15/17] Running Partitioner.compile within Mesh context-manager
+Subject: [PATCH 15/18] Running Partitioner.compile within Mesh context-manager
 
 ---
  t5x/partitioning.py | 9 ++++++++-
@@ -3072,13 +3072,13 @@ index 2ae6e7a..d9ba8bd 100644
  
  class PjitPartitioner(BasePjitPartitioner):
 -- 
-2.43.0
+2.34.1
 
 
 From a08b8bf78e14c288d6d7a66ad17a9bea69044cd7 Mon Sep 17 00:00:00 2001
 From: Terry Kong <terryk@nvidia.com>
 Date: Tue, 14 Nov 2023 23:42:35 -0800
-Subject: [PATCH 16/17] Updates multiprocessing scripts to use SLURM output
+Subject: [PATCH 16/18] Updates multiprocessing scripts to use SLURM output
  variables instead of input variables (#9)
 
 * Update multiprocess scripts
@@ -3549,13 +3549,13 @@ index d083540..56919a5 100755
 -set +x
 +echo Finished
 -- 
-2.43.0
+2.34.1
 
 
 From 74d742f053dabbe594637ad1f481237a23065512 Mon Sep 17 00:00:00 2001
 From: ashors1 <71393111+ashors1@users.noreply.github.com>
 Date: Wed, 6 Dec 2023 14:56:45 -0800
-Subject: [PATCH 17/17] Force initial flax mutables to be a frozen dict (#11)
+Subject: [PATCH 17/18] Force initial flax mutables to be a frozen dict (#11)
 
 ---
  t5x/trainer.py | 2 +-
@@ -3575,5 +3575,31 @@ index 4eae811..6dcce29 100644
  
    if num_microbatches is None or num_microbatches <= 1:
 -- 
-2.43.0
+2.34.1
+
+
+From 4d5ec2fe4a665142de514ad08544c54ab4be6133 Mon Sep 17 00:00:00 2001
+From: ashors1 <ashors@nvidia.com>
+Date: Thu, 28 Dec 2023 07:24:33 -0800
+Subject: [PATCH 18/18] update rng dtype in predict_batch
+
+---
+ t5x/models.py | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/t5x/models.py b/t5x/models.py
+index faeb6d0..a48b068 100644
+--- a/t5x/models.py
++++ b/t5x/models.py
+@@ -640,7 +640,7 @@ class EncoderDecoderModel(BaseTransformerModel):
+   def predict_batch(self,
+                     params: PyTreeDef,
+                     batch: Mapping[str, jnp.ndarray],
+-                    rng: Optional[jax.random.KeyArray] = None,
++                    rng: Optional[jax.Array] = None,
+                     flax_mutables: Optional[PyTreeDef] = None) -> jnp.ndarray:
+     """Predicts a batch of outputs from the model.
+ 
+-- 
+2.34.1
 

--- a/.github/container/patches/t5x/mirror-patch-dali-support.patch
+++ b/.github/container/patches/t5x/mirror-patch-dali-support.patch
@@ -357,7 +357,7 @@ index 752beb3..5475376 100644
  def _warn_action_not_run(action, task, metric):
    logging.warning(
 -- 
-2.25.1
+2.43.0
 
 
 From fbb093fa5851499289804594078b473696c52476 Mon Sep 17 00:00:00 2001
@@ -383,5 +383,5 @@ index c0263ca..600e3a4 100644
          checkpoint_cfg=checkpoint_cfg,
          partitioner=partitioner,
 -- 
-2.25.1
+2.43.0
 

--- a/.github/container/patches/t5x/mirror-patch-partial-checkpoint-restore.patch
+++ b/.github/container/patches/t5x/mirror-patch-partial-checkpoint-restore.patch
@@ -25,5 +25,5 @@ index 61682ed..77e0860 100644
    ]
    # 2. From a checkpoint specified by `checkpoint_cfg.restore.path`, if set.
 -- 
-2.25.1
+2.43.0
 

--- a/.github/container/patches/t5x/mirror-patch-t5x_te_in_contrib_noindent.patch
+++ b/.github/container/patches/t5x/mirror-patch-t5x_te_in_contrib_noindent.patch
@@ -1,7 +1,7 @@
 From 6ac19ca55511e08e8751ab95e312df0399c19c5b Mon Sep 17 00:00:00 2001
 From: Terry Kong <terryk@nvidia.com>
 Date: Mon, 24 Apr 2023 10:18:29 -0700
-Subject: [PATCH 01/16] Added transformer engine support and GPU optimizations
+Subject: [PATCH 01/17] Added transformer engine support and GPU optimizations
 
 Co-authored-by: Sahil Jain <sahilj@nvidia.com>
 Co-authored-by: Terry Kong <terryk@nvidia.com>
@@ -2465,13 +2465,13 @@ index 752beb3..4eae811 100644
        jnp.asarray([learning_rate]))
    metrics["learning_rate/current"] = clu.metrics.LastValue.from_model_output(
 -- 
-2.25.1
+2.43.0
 
 
 From 325f0e38720581c4f2535f3da23f40f425560138 Mon Sep 17 00:00:00 2001
 From: Terry Kong <terryk@nvidia.com>
 Date: Tue, 11 Jul 2023 12:10:33 -0700
-Subject: [PATCH 02/16] UNINSTALL_TE in fine-tuning scripts now defaults to
+Subject: [PATCH 02/17] UNINSTALL_TE in fine-tuning scripts now defaults to
  no-action
 
 ---
@@ -2500,13 +2500,13 @@ index 388d2ec..135ecf6 100755
  # Global batch size
  BSIZE=$(( GPUS_PER_NODE * BSIZE_PER_GPU * SLURM_JOB_NUM_NODES / TP_SIZE))
 -- 
-2.25.1
+2.43.0
 
 
 From f75aa370fe5c82dc8cf2f5a3ef3bdba407b60628 Mon Sep 17 00:00:00 2001
 From: Terry Kong <terryk@nvidia.com>
 Date: Wed, 12 Jul 2023 20:26:28 -0700
-Subject: [PATCH 03/16] remove use_gda from LegacyCheckpointManager in train.py
+Subject: [PATCH 03/17] remove use_gda from LegacyCheckpointManager in train.py
  for fp8
 
 ---
@@ -2528,13 +2528,13 @@ index e7ee77d..7fe705c 100644
    # Start warming up the input pipeline in the background. This must happen
    # after input pipeline checkpoints were restored.
 -- 
-2.25.1
+2.43.0
 
 
 From 395cf5bcca9c26f7fdaabca8541aa8368bcb8f91 Mon Sep 17 00:00:00 2001
 From: Terry Kong <terryk@nvidia.com>
 Date: Tue, 18 Jul 2023 15:55:01 -0700
-Subject: [PATCH 04/16] Allow singlenode scripts to tee to stdout for better
+Subject: [PATCH 04/17] Allow singlenode scripts to tee to stdout for better
  indication of training status
 
 ---
@@ -2565,13 +2565,13 @@ index def1a1a..0d12f30 100755
 +  2>&1 | tee \
    ${LOG_DIR}/${T5_SIZE}_gpu_${NUM_GPUS}_${PREC}_gbs_${BSIZE}_fp8_${ENABLE_FP8}_fuseqkv_${FUSE_QKV}_transbs_${TRANSPOSE_BS}.log
 -- 
-2.25.1
+2.43.0
 
 
 From 7cc636157b1afd8496baea7977876124b205db9e Mon Sep 17 00:00:00 2001
 From: Reese Wang <rewang@nvidia.com>
 Date: Fri, 14 Jul 2023 05:00:58 -0700
-Subject: [PATCH 05/16] Explicit specify self_attn_mask_type
+Subject: [PATCH 05/17] Explicit specify self_attn_mask_type
 
 ---
  t5x/te_helper.py | 10 ++++++++--
@@ -2606,13 +2606,13 @@ index fb5f48f..f3750ca 100644
  
  class TransformerEngineHelper(TransformerEngineHelperBase):
 -- 
-2.25.1
+2.43.0
 
 
 From d17222e423d83ea2faba226fad5f6a2b1bc9307f Mon Sep 17 00:00:00 2001
 From: Terry Kong <terryk@nvidia.com>
 Date: Thu, 3 Aug 2023 14:25:22 -0700
-Subject: [PATCH 06/16] Disables check for packing by the te_helper util since
+Subject: [PATCH 06/17] Disables check for packing by the te_helper util since
  not all dataset configs use packing (CV/Multimodal)
 
 ---
@@ -2633,13 +2633,13 @@ index f3750ca..f585752 100644
          "Transformer Engine does not support dataset.packing, please turn it off."
  
 -- 
-2.25.1
+2.43.0
 
 
 From c0448f9284bf910699dc7ecba202c2f213fa7481 Mon Sep 17 00:00:00 2001
 From: Terry Kong <terryk@nvidia.com>
 Date: Sat, 26 Aug 2023 16:13:11 -0700
-Subject: [PATCH 07/16] Corrected T5x large baselines
+Subject: [PATCH 07/17] Corrected T5x large baselines
 
 Updated T5x-large MNLI and SQUAD baselines
 ---
@@ -2660,13 +2660,13 @@ index a9974e1..660df3a 100644
  | [T5-v1.1-xl](../t5/t5_1_1/xl.gin)       | A100 80G SXM     | bf16      | 256   | 1     | 8        | ~4322         | 16.9        | 5.5 days      | 1,408   | 91.15%             | 89.36 / 95.29      | [log](https://tensorboard.dev/experiment/vuRoEYgkRgWiEtbvgxlOqw/#scalars&_smoothingWeight=0) |[pile](../t5/t5_1_1/examples/xl_pile_pretrain.gin)
  | [T5-v1.1-xxl](../t5/t5_1_1/xxl.gin)     | A100 80G SXM     | bf16      | 512   | 8     | 36       | ~1887         | 3.69        | 12.6 days     | 6,431  |N/A(partial run)   | N/A(partial run)   |                  |[pile](../t5/t5_1_1/examples/xxl_pile_pretrain.gin)
 -- 
-2.25.1
+2.43.0
 
 
 From 443df5e4414dcbac5482fc2672e1484a554c1bd2 Mon Sep 17 00:00:00 2001
 From: Terry Kong <terryk@nvidia.com>
 Date: Fri, 8 Sep 2023 15:09:08 -0700
-Subject: [PATCH 08/16] Add t5-large FP8 logs
+Subject: [PATCH 08/17] Add t5-large FP8 logs
 
 ---
  docs/usage/gpu-usage.md | 2 +-
@@ -2686,13 +2686,13 @@ index 660df3a..c31094d 100644
  | [T5-v1.1-xl](../t5/t5_1_1/xl.gin)       | **H100 80G SXM** | TE-fp8    | 256   | 1     | 8        | ~9688         | **37.8**    | **2.4 days**  | **614** | N/A (perf test)    | N/A (perf test)    |                 |[pile](../t5/t5_1_1/examples/xl_pile_pretrain.gin)
  
 -- 
-2.25.1
+2.43.0
 
 
 From 8494e0ba9683f1776500d0a401f29633f6b6130b Mon Sep 17 00:00:00 2001
 From: Ming-Xu Huang <mingh@nvidia.com>
 Date: Fri, 20 Oct 2023 14:26:09 +0800
-Subject: [PATCH 09/16] Fix missing fp8_meta_collection in the eval stage.
+Subject: [PATCH 09/17] Fix missing fp8_meta_collection in the eval stage.
 
 ---
  t5x/models.py | 2 +-
@@ -2712,13 +2712,13 @@ index fcd9fd5..a4276ec 100644
          enable_dropout=False,
          method=self.module.encode,
 -- 
-2.25.1
+2.43.0
 
 
 From 181087dbc71a268e4d96fbd3adb429ab630f0486 Mon Sep 17 00:00:00 2001
 From: Ming-Xu Huang <mingh@nvidia.com>
 Date: Fri, 20 Oct 2023 14:48:40 +0800
-Subject: [PATCH 10/16] Remove redundant code.
+Subject: [PATCH 10/17] Remove redundant code.
 
 ---
  t5x/models.py | 17 -----------------
@@ -2753,13 +2753,13 @@ index a4276ec..faeb6d0 100644
      # `decoder_input_tokens`. The EOS is stripped to avoid decoding to stop
      # after the prompt by matching to `output_vocabulary.eos_id`.
 -- 
-2.25.1
+2.43.0
 
 
 From 4d051703078985ca95b23def87672513dbce9daa Mon Sep 17 00:00:00 2001
 From: Ming-Xu Huang <mingh@nvidia.com>
 Date: Fri, 20 Oct 2023 15:05:40 +0800
-Subject: [PATCH 11/16] Fix deprecating warning about TE.
+Subject: [PATCH 11/17] Fix deprecating warning about TE.
 
 ---
  t5x/te_helper.py | 8 ++++----
@@ -2805,13 +2805,13 @@ index f585752..568f596 100644
          name=name)
  
 -- 
-2.25.1
+2.43.0
 
 
 From 5fff9dc6557e084378d24fc9c14376331e7f3d3a Mon Sep 17 00:00:00 2001
 From: Terry Kong <terryk@nvidia.com>
 Date: Fri, 27 Oct 2023 09:08:10 -0700
-Subject: [PATCH 12/16] Updates TE api from te.extend_* to te.flax.extend_*
+Subject: [PATCH 12/17] Updates TE api from te.extend_* to te.flax.extend_*
  (#7)
 
 Co-authored-by: NVIDIA <jax@nvidia.com>
@@ -2833,13 +2833,13 @@ index 568f596..05c5f6b 100644
    @staticmethod
    def update_fp8_metas(grad_accum, flax_mutables):
 -- 
-2.25.1
+2.43.0
 
 
 From e36be07a36c476545a5bbbb59e5c7a44419deb02 Mon Sep 17 00:00:00 2001
 From: Terry Kong <terryk@nvidia.com>
 Date: Tue, 31 Oct 2023 21:52:22 -0700
-Subject: [PATCH 13/16] Adds ENABLE_TE env var and renames TEConfig.enabled ->
+Subject: [PATCH 13/17] Adds ENABLE_TE env var and renames TEConfig.enabled ->
  TEConfig.enable_fp8 (#8)
 
 * Allows ENABLE_TE env var to control whether TE code path is invoked
@@ -2996,13 +2996,13 @@ index 05c5f6b..7657c52 100644
      return TENotInstalledHelper
  
 -- 
-2.25.1
+2.43.0
 
 
 From 4b8a1ad34509a5f62dea7ce0d3efef87e2a4e9d1 Mon Sep 17 00:00:00 2001
 From: Ming-Xu Huang <mingh@nvidia.com>
 Date: Tue, 7 Nov 2023 10:57:34 +0800
-Subject: [PATCH 14/16] Adapting to TE/JAX/Custom_partitioning.
+Subject: [PATCH 14/17] Adapting to TE/JAX/Custom_partitioning.
 
 ---
  t5x/te_helper.py | 5 ++---
@@ -3032,13 +3032,13 @@ index 7657c52..b064d2b 100644
  
    @staticmethod
 -- 
-2.25.1
+2.43.0
 
 
 From d08a6847857b6549ed8bfe1441d3742a6a13ac08 Mon Sep 17 00:00:00 2001
 From: Ming-Xu Huang <mingh@nvidia.com>
 Date: Wed, 22 Nov 2023 13:53:49 +0800
-Subject: [PATCH 15/16] Running Partitioner.compile within Mesh context-manager
+Subject: [PATCH 15/17] Running Partitioner.compile within Mesh context-manager
 
 ---
  t5x/partitioning.py | 9 ++++++++-
@@ -3072,13 +3072,13 @@ index 2ae6e7a..d9ba8bd 100644
  
  class PjitPartitioner(BasePjitPartitioner):
 -- 
-2.25.1
+2.43.0
 
 
 From a08b8bf78e14c288d6d7a66ad17a9bea69044cd7 Mon Sep 17 00:00:00 2001
 From: Terry Kong <terryk@nvidia.com>
 Date: Tue, 14 Nov 2023 23:42:35 -0800
-Subject: [PATCH 16/16] Updates multiprocessing scripts to use SLURM output
+Subject: [PATCH 16/17] Updates multiprocessing scripts to use SLURM output
  variables instead of input variables (#9)
 
 * Update multiprocess scripts
@@ -3549,5 +3549,31 @@ index d083540..56919a5 100755
 -set +x
 +echo Finished
 -- 
-2.25.1
+2.43.0
+
+
+From 74d742f053dabbe594637ad1f481237a23065512 Mon Sep 17 00:00:00 2001
+From: ashors1 <71393111+ashors1@users.noreply.github.com>
+Date: Wed, 6 Dec 2023 14:56:45 -0800
+Subject: [PATCH 17/17] Force initial flax mutables to be a frozen dict (#11)
+
+---
+ t5x/trainer.py | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/t5x/trainer.py b/t5x/trainer.py
+index 4eae811..6dcce29 100644
+--- a/t5x/trainer.py
++++ b/t5x/trainer.py
+@@ -684,7 +684,7 @@ def accumulate_grads_microbatched(
+   # them and return flax_mutables from `get_initial_variables` and `loss_fn`.
+ 
+   initial_flax_mutables = (
+-      train_state.flax_mutables if train_state.flax_mutables else {}
++      train_state.flax_mutables if train_state.flax_mutables else FrozenDict({})
+   )
+ 
+   if num_microbatches is None or num_microbatches <= 1:
+-- 
+2.43.0
 

--- a/rosetta/rosetta/projects/diffusion/augmentations.py
+++ b/rosetta/rosetta/projects/diffusion/augmentations.py
@@ -31,16 +31,16 @@ class AugmentationCallable(typing_extensions.Protocol):
         Returns the augmented sample and fresh rng """
     def __call__(self,
                  to_aug: Augmentable, 
-                 rng: jax.random.KeyArray
-                 ) -> Tuple[Augmentable, jax.random.KeyArray]:
+                 rng: jax.Array
+                 ) -> Tuple[Augmentable, jax.Array]:
         ...
 
 def text_conditioning_dropout(to_aug: Augmentable,
-                              rng: jax.random.KeyArray, 
+                              rng: jax.Array,
                               dropout_rate: float = 0.1,
                               drop_key: Optional[str] = None,
                               null_value = None,
-                              ) -> Tuple[Augmentable, jax.random.KeyArray]:
+                              ) -> Tuple[Augmentable, jax.Array]:
     """ 
     Can take either a dictionary, where it will dropout on the 'text_mask' key by default,
     or drop_key if supplied. If given just an array, it will dropout assuming shape = [b, ...]

--- a/rosetta/rosetta/projects/diffusion/denoisers.py
+++ b/rosetta/rosetta/projects/diffusion/denoisers.py
@@ -42,7 +42,7 @@ class DenoisingFunctionCallableWithParams(typing_extensions.Protocol):
                  noised_sample: jnp.ndarray,
                  sigma: jnp.ndarray,
                  other_cond: Optional[Mapping[str, jnp.ndarray]]=None,
-                 dropout_rng: Optional[jax.random.KeyArray]=None
+                 dropout_rng: Optional[jax.Array]=None
                  ) -> jnp.ndarray:
         ...
 
@@ -52,7 +52,7 @@ class DenoisingFunctionCallable(typing_extensions.Protocol):
                  noised_sample: jnp.ndarray,
                  sigma: jnp.ndarray,
                  other_cond: Optional[Mapping[str, jnp.ndarray]]=None,
-                 dropout_rng: Optional[jax.random.KeyArray]=None
+                 dropout_rng: Optional[jax.Array]=None
                  ) -> jnp.ndarray:
         ...
 
@@ -62,7 +62,7 @@ class DenoisingFunctionWithAuxCallable(typing_extensions.Protocol):
                  noised_sample: jnp.ndarray,
                  sigma: jnp.ndarray,
                  other_cond: Optional[Mapping[str, jnp.ndarray]]=None,
-                 dropout_rng: Optional[jax.random.KeyArray]=None
+                 dropout_rng: Optional[jax.Array]=None
                  ) -> Tuple[jnp.ndarray, Mapping[str, jnp.ndarray]]:
         ...
 
@@ -72,7 +72,7 @@ class NoisePredictorCallable(typing_extensions.Protocol):
                  noised_sample: jnp.ndarray,
                  sigma: jnp.ndarray,
                  other_cond: Optional[Mapping[str, jnp.ndarray]]=None,
-                 dropout_rng: Optional[jax.random.KeyArray]=None
+                 dropout_rng: Optional[jax.Array]=None
                  ) -> jnp.ndarray:
         ...
 
@@ -82,7 +82,7 @@ class NoisePredictorWithAuxCallable(typing_extensions.Protocol):
                  noised_sample: jnp.ndarray,
                  sigma: jnp.ndarray,
                  other_cond: Optional[Mapping[str, jnp.ndarray]]=None,
-                 dropout_rng: Optional[jax.random.KeyArray]=None
+                 dropout_rng: Optional[jax.Array]=None
                  ) -> Tuple[jnp.ndarray, Mapping[str, jnp.ndarray]]:
         ...
 
@@ -118,7 +118,7 @@ class Denoiser(abc.ABC):
         self,
         params: PyTreeDef,
         batch: Mapping[str, jnp.ndarray],
-        rngs: Optional[jax.random.KeyArray] = None,
+        rngs: Optional[jax.Array] = None,
         mutable: flax_scope.CollectionFilter = False,
         other_variables: Optional[PyTreeDef] = None,
     ) -> Union[jnp.ndarray, Tuple[jnp.ndarray, flax_scope.FrozenVariableDict]]:
@@ -136,7 +136,7 @@ class Denoiser(abc.ABC):
                        noised_sample: jnp.ndarray,
                        sigma: jnp.ndarray,
                        other_cond: Optional[Mapping[str, jnp.ndarray]]=None,
-                       dropout_rng: Optional[jax.random.KeyArray]=None,
+                       dropout_rng: Optional[jax.Array]=None,
                        flax_mutables: Optional[PyTreeDef]=None,
                        ) -> jnp.ndarray:
         """ Returns denoised sample given noised sample and conditioning """
@@ -177,7 +177,7 @@ class EDMUnconditionalDenoiser(Denoiser):
         self,
         params: PyTreeDef,
         batch: Mapping[str, jnp.ndarray],
-        rngs: Optional[jax.random.KeyArray] = None,
+        rngs: Optional[jax.Array] = None,
         mutable: flax_scope.CollectionFilter = False,
         other_variables: Optional[PyTreeDef] = None,
     ) -> Union[jnp.ndarray, Tuple[jnp.ndarray, flax_scope.FrozenVariableDict]]:
@@ -207,7 +207,7 @@ class EDMTextConditionedDenoiser(EDMUnconditionalDenoiser):
         self,
         params: PyTreeDef,
         batch: Mapping[str, jnp.ndarray],
-        rngs: Optional[jax.random.KeyArray] = None,
+        rngs: Optional[jax.Array] = None,
         mutable: flax_scope.CollectionFilter = False,
         other_variables: Optional[PyTreeDef] = None,
     ) -> Union[jnp.ndarray, Tuple[jnp.ndarray, flax_scope.FrozenVariableDict]]:
@@ -239,7 +239,7 @@ class EDMTextConditionedSuperResDenoiser(EDMTextConditionedDenoiser):
         self,
         params: PyTreeDef,
         batch: Mapping[str, jnp.ndarray],
-        rngs: Optional[jax.random.KeyArray] = None,
+        rngs: Optional[jax.Array] = None,
         mutable: flax_scope.CollectionFilter = False,
         other_variables: Optional[PyTreeDef] = None,
     ) -> Union[jnp.ndarray, Tuple[jnp.ndarray, flax_scope.FrozenVariableDict]]:
@@ -274,7 +274,7 @@ class EDMLatentConditionalDenoiser(EDMUnconditionalDenoiser):
         self,
         params: PyTreeDef,
         batch: Mapping[str, jnp.ndarray],
-        rngs: Optional[jax.random.KeyArray] = None,
+        rngs: Optional[jax.Array] = None,
         mutable: flax_scope.CollectionFilter = False,
         other_variables: Optional[PyTreeDef] = None,
     ) -> Union[jnp.ndarray, Tuple[jnp.ndarray, flax_scope.FrozenVariableDict]]:
@@ -318,7 +318,7 @@ class VP_EPSNoisePredictor(abc.ABC):
         self,
         params: PyTreeDef,
         batch: Mapping[str, jnp.ndarray],
-        rngs: Optional[jax.random.KeyArray] = None,
+        rngs: Optional[jax.Array] = None,
         mutable: flax_scope.CollectionFilter = False,
         other_variables: Optional[PyTreeDef] = None,
     ) -> Union[jnp.ndarray, Tuple[jnp.ndarray, flax_scope.FrozenVariableDict]]:
@@ -336,7 +336,7 @@ class VP_EPSNoisePredictor(abc.ABC):
                     noised_sample: jnp.ndarray,
                     sigma: jnp.ndarray,
                     other_cond: Optional[Mapping[str, jnp.ndarray]]=None,
-                    dropout_rng: Optional[jax.random.KeyArray]=None
+                    dropout_rng: Optional[jax.Array]=None
                     ) -> jnp.ndarray:
         """ Returns denoised sample given noised sample and conditioning """
         sigma = expand_dims_like(sigma, noised_sample)
@@ -357,7 +357,7 @@ class VP_EPSNoisePredictorTextConditional(VP_EPSNoisePredictor):
         self,
         params: PyTreeDef,
         batch: Mapping[str, jnp.ndarray],
-        rngs: Optional[jax.random.KeyArray] = None,
+        rngs: Optional[jax.Array] = None,
         mutable: flax_scope.CollectionFilter = False,
         other_variables: Optional[PyTreeDef] = None,
     ) -> Union[jnp.ndarray, Tuple[jnp.ndarray, flax_scope.FrozenVariableDict]]:

--- a/rosetta/rosetta/projects/diffusion/losses.py
+++ b/rosetta/rosetta/projects/diffusion/losses.py
@@ -36,7 +36,7 @@ class DiffusionLossCallable(typing_extensions.Protocol):
         Returns the loss and the noises used """
     def __call__(self,
                  denoise_fn: Callable,
-                 rng: jax.random.KeyArray,
+                 rng: jax.Array,
                  samples: jnp.ndarray,
                  other_cond: Optional[Mapping[str, jnp.ndarray]]
                  ) -> Tuple[jnp.ndarray, jnp.ndarray, jnp.ndarray]:
@@ -47,7 +47,7 @@ class EPSDiffusionLossCallable(typing_extensions.Protocol):
         Returns the loss and the noises used """
     def __call__(self,
                  eps_predictor: Callable,
-                 rng: jax.random.KeyArray,
+                 rng: jax.Array,
                  samples: jnp.ndarray,
                  other_cond: Optional[Mapping[str, jnp.ndarray]]
                  ) -> Tuple[jnp.ndarray, jnp.ndarray, jnp.ndarray]:
@@ -70,7 +70,7 @@ class EDMLoss:
         sigma = sigma / self.dim_noise_scalar
         return (sigma ** 2 + self.sigma_data ** 2) / (sigma * self.sigma_data) ** 2
 
-    def _noise_sampler(self, rng: jax.random.KeyArray, count: int, dim_scalar:float=1.):
+    def _noise_sampler(self, rng: jax.Array, count: int, dim_scalar:float=1.):
         rnd_normal = jax.random.normal(rng, (count, ))
         return jnp.exp(rnd_normal * self.p_std + self.p_mean) * dim_scalar
 
@@ -78,7 +78,7 @@ class EDMLoss:
 
     def __call__(self,
                  denoise_fn: Callable,
-                 rng: jax.random.KeyArray,
+                 rng: jax.Array,
                  samples: jnp.ndarray,
                  other_cond: Optional[Mapping[str, jnp.ndarray]]=None
                  ) -> Tuple[jnp.ndarray, jnp.ndarray, jnp.ndarray]:
@@ -116,7 +116,7 @@ class EDMLoss:
 class EDMSuperResolutionLoss(EDMLoss):
     def __call__(self,
                  denoise_fn: Callable,
-                 rng: jax.random.KeyArray,
+                 rng: jax.Array,
                  samples: jnp.ndarray,
                  other_cond: Optional[Mapping[str, jnp.ndarray]]=None
                  ) -> Tuple[jnp.ndarray, jnp.ndarray, jnp.ndarray]:

--- a/rosetta/rosetta/projects/diffusion/models.py
+++ b/rosetta/rosetta/projects/diffusion/models.py
@@ -95,7 +95,7 @@ class DenoisingDiffusionModel(DiffusionBase):
     def loss_fn(self,
                 params: PyTreeDef,
                 batch: BatchType,
-                dropout_rng: Optional[jax.random.KeyArray],
+                dropout_rng: Optional[jax.Array],
                 flax_mutables: Optional[PyTreeDef] = None,
                 ) -> Tuple[jnp.ndarray, MetricsMap]:
         denoise_fn = self._denoise_fn(params, flax_mutables)
@@ -113,7 +113,7 @@ class DenoisingDiffusionModel(DiffusionBase):
     def predict_batch(self,
                       params: PyTreeDef,
                       batch: BatchType,
-                      rng: Optional[jax.random.KeyArray] = None,
+                      rng: Optional[jax.Array] = None,
                       *,
                       sampling_cfg: Optional[samplers.SamplingConfig] = None,
                       ) -> jnp.ndarray:
@@ -122,7 +122,7 @@ class DenoisingDiffusionModel(DiffusionBase):
     def predict_batch_with_aux(self,
                                params: PyTreeDef,
                                batch: BatchType,
-                               rng: Optional[jax.random.KeyArray] = None,
+                               rng: Optional[jax.Array] = None,
                                *,
                                sampling_cfg: Optional[samplers.SamplingConfig] = None,
                                ) -> Tuple[jnp.ndarray, Mapping[str, jnp.ndarray]]:
@@ -147,7 +147,7 @@ class DenoisingDiffusionModel(DiffusionBase):
 
     def get_initial_variables(
         self,
-        rng: jax.random.KeyArray,
+        rng: jax.Array,
         input_shapes: Mapping[str, Array],
         input_types: Optional[Mapping[str, jnp.dtype]] = None
     ) -> flax_scope.FrozenVariableDict:

--- a/rosetta/rosetta/projects/diffusion/samplers.py
+++ b/rosetta/rosetta/projects/diffusion/samplers.py
@@ -48,7 +48,7 @@ class DiffusionSamplerCallable(typing_extensions.Protocol):
                  denoise_fn: Callable,
                  step_indices: jnp.ndarray,
                  latent: jnp.ndarray,
-                 rng: Optional[jax.random.KeyArray],
+                 rng: Optional[jax.Array],
                  other_cond: Optional[Mapping[str, jnp.ndarray]],
                  sampling_cfg: Optional[SamplingConfig]=None
                  ) -> jnp.ndarray:
@@ -60,7 +60,7 @@ class DiffusionSampler(abc.ABC):
                denoise_fn: Callable,
                step_indices: jnp.ndarray,
                latent: jnp.ndarray,
-               rng: Optional[jax.random.KeyArray],
+               rng: Optional[jax.Array],
                other_cond: Optional[Mapping[str, jnp.ndarray]], 
                sampling_cfg: Optional[SamplingConfig]=None
                ) -> jnp.ndarray:
@@ -108,12 +108,12 @@ class EDMSampler(DiffusionSampler):
         self.dim_noise_scalar = dim_noise_scalar
 
 
-    def _sample_noise(self, shape: Tuple, rng: jax.random.KeyArray):
+    def _sample_noise(self, shape: Tuple, rng: jax.Array):
         return jax.random.normal(rng, shape) * self.S_noise
 
     def _scannable_single_step(self, denoise_fn, num_steps, t_steps, other_cond, null_cond, second_order_correct=True, cf_guidance_weight=None):
         """ Wraps single_step_sample to make it usable in jax.lax.scan """
-        def wrapped_fn(x_rng_state: Tuple[jnp.ndarray, jax.random.KeyArray], idx: int):
+        def wrapped_fn(x_rng_state: Tuple[jnp.ndarray, jax.Array], idx: int):
             return self.single_step_sample(denoise_fn, num_steps, t_steps, x_rng_state[1], idx, \
                                            second_order_correct=second_order_correct, x_curr=x_rng_state[0], \
                                            other_cond=other_cond, null_cond=null_cond, cf_guidance_weight=cf_guidance_weight)
@@ -166,14 +166,14 @@ class EDMSampler(DiffusionSampler):
     def single_step_sample(self, denoise_fn: DenoisingFunctionCallable, 
                            num_steps: int,
                            t_steps: jnp.ndarray,
-                           rng: jax.random.KeyArray,
+                           rng: jax.Array,
                            t_idx:int,
                            x_curr: jnp.ndarray=None,
                            other_cond:Optional[BatchType]=None,
                            null_cond:Optional[BatchType]=None,
                            second_order_correct=True,
                            cf_guidance_weight:Optional[float]=None
-        ) ->  Tuple[Tuple[jnp.ndarray, jnp.ndarray], jax.random.KeyArray]:
+        ) ->  Tuple[Tuple[jnp.ndarray, jnp.ndarray], jax.Array]:
         """ Single step of sampling """
         rng, step_rng = jax.random.split(rng)
 
@@ -218,7 +218,7 @@ class EDMSampler(DiffusionSampler):
                denoise_fn: Callable,
                step_indices: jnp.ndarray,
                latent: jnp.ndarray,
-               rng: jax.random.KeyArray,
+               rng: jax.Array,
                other_cond: Optional[BatchType]=None,
                sampling_cfg: Optional[SamplingConfig]=None
                ) -> jnp.ndarray:
@@ -262,7 +262,7 @@ class EDMSampler(DiffusionSampler):
                     denoise_fn: Callable,
                     sampling_cfg: SamplingConfig,
                     latent: jnp.ndarray,
-                    rng: jax.random.KeyArray,
+                    rng: jax.Array,
                     other_cond: Optional[BatchType]=None,
                     )-> jnp.ndarray:
         # Classifier-free guidance will be enabled if cf_guidance_weight is not None

--- a/rosetta/rosetta/projects/inference_serving/t5/models.py
+++ b/rosetta/rosetta/projects/inference_serving/t5/models.py
@@ -72,7 +72,7 @@ class EncoderOnlyModel(BaseTransformerModel):
 
   def get_initial_variables(
       self,
-      rng: jax.random.KeyArray,
+      rng: jax.Array,
       input_shapes: Mapping[str, Array],
       input_types: Optional[Mapping[str, jnp.dtype]] = None
   ) -> flax_scope.FrozenVariableDict:
@@ -104,7 +104,7 @@ class EncoderOnlyModel(BaseTransformerModel):
       self,
       params: PyTreeDef,
       batch: Mapping[str, jnp.ndarray],
-      dropout_rng: Optional[jax.random.KeyArray] = None,
+      dropout_rng: Optional[jax.Array] = None,
       mutable: flax_scope.CollectionFilter = False,
       other_variables: Optional[PyTreeDef] = None,
   ) -> Union[jnp.ndarray, Tuple[jnp.ndarray, flax_scope.FrozenVariableDict]]:
@@ -171,6 +171,6 @@ class EncoderOnlyModel(BaseTransformerModel):
       self,
       params: PyTreeDef,
       batch: Mapping[str, jnp.ndarray],
-      rng: Optional[jax.random.KeyArray] = None,
+      rng: Optional[jax.Array] = None,
   ) -> Tuple[jnp.ndarray, Mapping[str, jnp.ndarray]]:
       raise NotImplementedError("Predict Batch is not implemented for encoder only. Use score_batch")

--- a/rosetta/rosetta/projects/vit/models.py
+++ b/rosetta/rosetta/projects/vit/models.py
@@ -48,7 +48,7 @@ class ViTModel(BaseModel):
   def loss_fn(
       self, params: PyTreeDef,
       batch: Mapping[str, jnp.ndarray],
-      dropout_rng: jax.random.KeyArray | None,
+      dropout_rng: jax.Array | None,
       flax_mutables: Optional[PyTreeDef] = None,
   ) -> tuple[jnp.ndarray, MetricsMap]:
     """Computes loss and metrics.
@@ -114,7 +114,7 @@ class ViTModel(BaseModel):
       self,
       params: PyTreeDef,
       batch: Mapping[str, jnp.ndarray],
-      rng: jax.random.KeyArray | None = None,
+      rng: jax.Array | None = None,
       flax_mutables: Optional[PyTreeDef] = None,
   ) -> tuple[jnp.ndarray, Mapping[str, jnp.ndarray]]:
     """Predict a batch from the modelwith auxiliary outputs.
@@ -190,7 +190,7 @@ class ViTModel(BaseModel):
 
   def get_initial_variables(
       self,
-      rng: jax.random.KeyArray,
+      rng: jax.Array,
       input_shapes: Mapping[str, Array],
       input_types: Mapping[str, jnp.dtype] | None = None,
       flax_mutables: Optional[PyTreeDef] = None,


### PR DESCRIPTION
As of #405 the presubmit CI is based on package versions listed in the `manifest.yaml` that is committed to the repository. This has not been updated for ~1 month, so the presubmit CI is testing ~1 month old versions of the ecosystem. This PR updates it using the commit from https://github.com/NVIDIA/JAX-Toolbox/tree/znightly-2024-01-03-7395605285, generated by the nightly CI run.

Because this bumps the JAX version by ~1 month, we have to include fixes for deprecations. In particular replacing `jax.random.KeyArray` with plain `jax.Array` (https://github.com/nvjax-svc-0/t5x/commit/4d5ec2fe4a665142de514ad08544c54ab4be6133).

The deprecated name is used in older versions of the `chex` package, which are being selected by pip's dependency resolver despite newer versions being available. We avoid this by giving pip a helping hand and nudging it to use a newer `numpy` version, which allows it to select a newer `chex`. But it's easy to imagine similar issues in future with other packages.

Closes #448.