### PR TITLE
Fixes issue where dated rosetta nightlies were not tagged if tests failed

### DIFF
--- a/.github/workflows/nightly-rosetta-pax-build.yaml
+++ b/.github/workflows/nightly-rosetta-pax-build.yaml
@@ -183,19 +183,9 @@ jobs:
       TARGET_TAGS: |
         type=raw,value=latest,priority=1000
 
-  test-pax:
-    # needs: [metadata, amd64, arm64]
-    needs: [metadata, amd64]
-    uses: ./.github/workflows/_test_pax_rosetta.yaml
-    if: (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success') || github.event_name == 'workflow_dispatch'
-    with:
-      PAX_IMAGE: ${{ needs.amd64.outputs.DOCKER_TAG_FINAL }}
-    secrets: inherit
-
   publish-pax:
     needs: [metadata, test-amd64]
     uses: ./.github/workflows/_publish_t5x_pax_results.yaml
-    if: (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success') || github.event_name == 'workflow_dispatch'
     with:
       BUILD_DATE: ${{ needs.metadata.outputs.BUILD_DATE }}
       EXPERIMENT_SUBDIR: ROSETTA_PAX

--- a/.github/workflows/nightly-rosetta-pax-build.yaml
+++ b/.github/workflows/nightly-rosetta-pax-build.yaml
@@ -154,7 +154,23 @@ jobs:
     secrets: inherit
 
   # TODO: ARM Tests
-  publish-final:
+  # The dated nightly is tagged regardless of the test results to assist troubleshooting
+  publish-final-dated:
+    # needs: [metadata, amd64, arm64]
+    needs: [metadata, amd64]
+    if: needs.metadata.outputs.PUBLISH == 'true'
+    uses: ./.github/workflows/_publish_container.yaml
+    with:
+      SOURCE_IMAGE: |
+        ${{ needs.amd64.outputs.DOCKER_TAG_FINAL }}
+      # ${{ needs.arm64.outputs.DOCKER_TAG_FINAL }}
+      TARGET_IMAGE: pax
+      TARGET_TAGS: |
+        type=raw,value=nightly-${{ needs.metadata.outputs.BUILD_DATE }},priority=900
+
+  # TODO: ARM Tests
+  # The latest tag is reserved for images that pass all the CI tests
+  publish-final-latest:
     # needs: [metadata, amd64, arm64, test-amd64]
     needs: [metadata, amd64, test-amd64]
     if: needs.metadata.outputs.PUBLISH == 'true'
@@ -165,8 +181,7 @@ jobs:
       # ${{ needs.arm64.outputs.DOCKER_TAG_FINAL }}
       TARGET_IMAGE: pax
       TARGET_TAGS: |
-        ${{ needs.test-amd64.outputs.TEST_STATUS == 'success' && 'type=raw,value=latest,priority=1000' || '' }}
-        type=raw,value=nightly-${{ needs.metadata.outputs.BUILD_DATE }},priority=900
+        type=raw,value=latest,priority=1000
 
   test-pax:
     # needs: [metadata, amd64, arm64]

--- a/.github/workflows/nightly-rosetta-t5x-build-test.yaml
+++ b/.github/workflows/nightly-rosetta-t5x-build-test.yaml
@@ -154,7 +154,21 @@ jobs:
       T5X_IMAGE: ${{ needs.amd64.outputs.DOCKER_TAG_FINAL }}
     secrets: inherit
 
-  publish-final:
+  # The dated nightly is tagged regardless of the test results to assist troubleshooting
+  publish-final-dated:
+    needs: [metadata, amd64, arm64]
+    if: needs.metadata.outputs.PUBLISH == 'true'
+    uses: ./.github/workflows/_publish_container.yaml
+    with:
+      SOURCE_IMAGE: |
+        ${{ needs.amd64.outputs.DOCKER_TAG_FINAL }}
+        ${{ needs.arm64.outputs.DOCKER_TAG_FINAL }}
+      TARGET_IMAGE: t5x
+      TARGET_TAGS: |
+        type=raw,value=nightly-${{ needs.metadata.outputs.BUILD_DATE }},priority=900
+
+  # The latest tag is reserved for images that pass all the CI tests
+  publish-final-latest:
     needs: [metadata, amd64, arm64, test-t5x-amd64, test-unit-amd64]
     if: needs.metadata.outputs.PUBLISH == 'true'
     uses: ./.github/workflows/_publish_container.yaml
@@ -164,8 +178,7 @@ jobs:
         ${{ needs.arm64.outputs.DOCKER_TAG_FINAL }}
       TARGET_IMAGE: t5x
       TARGET_TAGS: |
-        ${{ ( needs.test-t5x-amd64.outputs.TEST_STATUS == 'success' && needs.test-unit-amd64.outputs.TEST_STATUS == 'success' ) && 'type=raw,value=latest,priority=1000' || '' }}
-        type=raw,value=nightly-${{ needs.metadata.outputs.BUILD_DATE }},priority=900
+        type=raw,value=latest,priority=1000
 
   publish-t5x:
     needs: [metadata, test-t5x-amd64]


### PR DESCRIPTION
The issue was that if tests failed, the `publish-final` step wasn't run b/c a failure in any of the `needs:` jobs would implicitly cause `publish-final` to be skipped. So the ternary operator to conditionally add `latest` wasn't run and `nightly-YYYY-MM-DD` was skipped.

Simple remedy is to introduce two publish steps. The code is repeated, but it is much clearer than adding complicated `if:` logic