### PR TITLE
Enable PAX ARM build in nightlies

### DIFF
--- a/.github/workflows/nightly-rosetta-pax-build.yaml
+++ b/.github/workflows/nightly-rosetta-pax-build.yaml
@@ -98,7 +98,6 @@ jobs:
   arm64:
     needs: metadata
     uses: ./.github/workflows/_build_rosetta.yaml
-    if: false  # TODO: Enable when arm64 build is ready
     with:
       ARCHITECTURE: arm64
       BUILD_DATE: ${{ needs.metadata.outputs.BUILD_DATE }}
@@ -130,7 +129,7 @@ jobs:
         echo "MESSAGE='${MSG}'" >> $GITHUB_OUTPUT
         echo "COLOR='${BADGE_COLOR}'" >> $GITHUB_OUTPUT
         echo "STATUS='${STATUS}'" >> ${GITHUB_OUTPUT}
-  
+
   publish-mealkit:
     # needs: [metadata, amd64, arm64]
     needs: [metadata, amd64]


### PR DESCRIPTION
PAX ARM builded started breaking recently and was disabled in https://github.com/NVIDIA/JAX-Toolbox/pull/426.

Fix for the ARM build was landed in https://github.com/NVIDIA/JAX-Toolbox/commit/f5abca98db688cc9cd8d92414c4a9b2dcdb105be and this PR reenables the nightly PAX ARM builds

Example workflow - https://github.com/NVIDIA/JAX-Toolbox/actions/runs/7413427817/job/20172335298

Closes #428 