### PR TITLE
Update XLA+arm64 patch

### DIFF
--- a/.github/container/manifest.yaml
+++ b/.github/container/manifest.yaml
@@ -2,31 +2,31 @@
 jax:
   url: https://github.com/google/jax.git
   tracking_ref: main
-  latest_verified_commit: afa2f1e420de3d2cfd684cff080a3808ee66daf5
+  latest_verified_commit: 1ed6a818c7f05768f20cd0e0cf3101ee9b63abd9
   mode: git-clone
 xla:
   url: https://github.com/openxla/xla.git
   tracking_ref: main
-  latest_verified_commit: 64a7946ffd048daf65ef330fc4ca5e4c3c1482a0
+  latest_verified_commit: 079610a2a0c1013c7418bb8fe9554c5f9db0a7cd
   mode: git-clone
 flax:
   url: https://github.com/google/flax.git
   mirror_url: https://github.com/nvjax-svc-0/flax.git
   tracking_ref: main
-  latest_verified_commit: 85dfad242e56098849dbf05e7e4657b3a40820f9
+  latest_verified_commit: cb6843f29d3400d7dab6751d4b693e4862f57d98
   mode: git-clone
   patches:
     pull/3340/head: file://patches/flax/PR-3340.patch # Add Sharding Annotations to Flax Modules
 transformer-engine:
   url: https://github.com/NVIDIA/TransformerEngine.git
   tracking_ref: main
-  latest_verified_commit: d155eaac8e08d42e67d7efd812ee2a69954de816
+  latest_verified_commit: 1bb8b6ebae1ecadd7d817d572245ce5243166d32
   mode: git-clone
 t5x:
   url: https://github.com/google-research/t5x.git
   mirror_url: https://github.com/nvjax-svc-0/t5x.git
   tracking_ref: main
-  latest_verified_commit: dbc4b6f426862d5a742a2104a17524f53dd442f0
+  latest_verified_commit: 18f74b7891223faf96825d02ef7d7b23630a4c3c
   mode: git-clone
   patches:
     mirror/patch/partial-checkpoint-restore: file://patches/t5x/mirror-patch-partial-checkpoint-restore.patch # pull/1392/head  # https://github.com/google-research/t5x/pull/1392: Add support for partial checkpoint restore
@@ -37,7 +37,7 @@ paxml:
   url: https://github.com/google/paxml.git
   mirror_url: https://github.com/nvjax-svc-0/paxml.git
   tracking_ref: main
-  latest_verified_commit: 60e9e29bd3c6cc53bb4462f8c03bd5408daacd7b
+  latest_verified_commit: 97bdcc0c1b63296b114370bd3d9616b8753ed18b
   mode: git-clone
   patches:
     pull/46/head: file://patches/paxml/PR-46.patch # adds Transformer Engine support
@@ -45,7 +45,7 @@ praxis:
   url: https://github.com/google/praxis.git
   mirror_url: https://github.com/nvjax-svc-0/praxis.git
   tracking_ref: main
-  latest_verified_commit: 5b70196ffba154e78a5f78ce9175854b18cf936d
+  latest_verified_commit: 8319b421f65bdc737c91444e062fe52b50e8d9b2
   mode: git-clone
   patches:
     pull/27/head: file://patches/praxis/PR-27.patch # This PR allows XLA:GPU to detect the MHA pattern more easily to call fused kernels from cublas.
@@ -54,7 +54,7 @@ lingvo:
   # Used only in ARM pax builds
   url: https://github.com/tensorflow/lingvo.git
   tracking_ref: master
-  latest_verified_commit: ab71210c31706b190ebdd3bd3573ed833e693587
+  latest_verified_commit: 17d1b70d67a3ba05773750adecf7ac3296e619d5
   mode: git-clone
 tensorflow-text:
   # Used only in ARM pax builds
@@ -75,7 +75,7 @@ fiddle:
 airio:
   url: https://github.com/google/airio.git
   tracking_ref: main
-  latest_verified_commit: 0e31f368b12d298e133b3a774e27d9bb0e85d087
+  latest_verified_commit: d9076165b52664d4a009b844755adc9ce93b05bf
   mode: pip-vcs
 clu:
   url: https://github.com/google/CommonLoopUtils.git
@@ -100,5 +100,5 @@ optax:
 seqio:
   url: https://github.com/google/seqio.git
   tracking_ref: main
-  latest_verified_commit: b582c96cb83f1472925c2b50b90059ad1da8c138
+  latest_verified_commit: f217c6632f48f4c26ee6e9bafcfe51f3c2c99e93
   mode: pip-vcs

--- a/.github/container/patches/t5x/mirror-ashors-fix_rng_dtype.patch
+++ b/.github/container/patches/t5x/mirror-ashors-fix_rng_dtype.patch
@@ -2465,7 +2465,7 @@ index 752beb3..4eae811 100644
        jnp.asarray([learning_rate]))
    metrics["learning_rate/current"] = clu.metrics.LastValue.from_model_output(
 -- 
-2.34.1
+2.43.0
 
 
 From 325f0e38720581c4f2535f3da23f40f425560138 Mon Sep 17 00:00:00 2001
@@ -2500,7 +2500,7 @@ index 388d2ec..135ecf6 100755
  # Global batch size
  BSIZE=$(( GPUS_PER_NODE * BSIZE_PER_GPU * SLURM_JOB_NUM_NODES / TP_SIZE))
 -- 
-2.34.1
+2.43.0
 
 
 From f75aa370fe5c82dc8cf2f5a3ef3bdba407b60628 Mon Sep 17 00:00:00 2001
@@ -2528,7 +2528,7 @@ index e7ee77d..7fe705c 100644
    # Start warming up the input pipeline in the background. This must happen
    # after input pipeline checkpoints were restored.
 -- 
-2.34.1
+2.43.0
 
 
 From 395cf5bcca9c26f7fdaabca8541aa8368bcb8f91 Mon Sep 17 00:00:00 2001
@@ -2565,7 +2565,7 @@ index def1a1a..0d12f30 100755
 +  2>&1 | tee \
    ${LOG_DIR}/${T5_SIZE}_gpu_${NUM_GPUS}_${PREC}_gbs_${BSIZE}_fp8_${ENABLE_FP8}_fuseqkv_${FUSE_QKV}_transbs_${TRANSPOSE_BS}.log
 -- 
-2.34.1
+2.43.0
 
 
 From 7cc636157b1afd8496baea7977876124b205db9e Mon Sep 17 00:00:00 2001
@@ -2606,7 +2606,7 @@ index fb5f48f..f3750ca 100644
  
  class TransformerEngineHelper(TransformerEngineHelperBase):
 -- 
-2.34.1
+2.43.0
 
 
 From d17222e423d83ea2faba226fad5f6a2b1bc9307f Mon Sep 17 00:00:00 2001
@@ -2633,7 +2633,7 @@ index f3750ca..f585752 100644
          "Transformer Engine does not support dataset.packing, please turn it off."
  
 -- 
-2.34.1
+2.43.0
 
 
 From c0448f9284bf910699dc7ecba202c2f213fa7481 Mon Sep 17 00:00:00 2001
@@ -2660,7 +2660,7 @@ index a9974e1..660df3a 100644
  | [T5-v1.1-xl](../t5/t5_1_1/xl.gin)       | A100 80G SXM     | bf16      | 256   | 1     | 8        | ~4322         | 16.9        | 5.5 days      | 1,408   | 91.15%             | 89.36 / 95.29      | [log](https://tensorboard.dev/experiment/vuRoEYgkRgWiEtbvgxlOqw/#scalars&_smoothingWeight=0) |[pile](../t5/t5_1_1/examples/xl_pile_pretrain.gin)
  | [T5-v1.1-xxl](../t5/t5_1_1/xxl.gin)     | A100 80G SXM     | bf16      | 512   | 8     | 36       | ~1887         | 3.69        | 12.6 days     | 6,431  |N/A(partial run)   | N/A(partial run)   |                  |[pile](../t5/t5_1_1/examples/xxl_pile_pretrain.gin)
 -- 
-2.34.1
+2.43.0
 
 
 From 443df5e4414dcbac5482fc2672e1484a554c1bd2 Mon Sep 17 00:00:00 2001
@@ -2686,7 +2686,7 @@ index 660df3a..c31094d 100644
  | [T5-v1.1-xl](../t5/t5_1_1/xl.gin)       | **H100 80G SXM** | TE-fp8    | 256   | 1     | 8        | ~9688         | **37.8**    | **2.4 days**  | **614** | N/A (perf test)    | N/A (perf test)    |                 |[pile](../t5/t5_1_1/examples/xl_pile_pretrain.gin)
  
 -- 
-2.34.1
+2.43.0
 
 
 From 8494e0ba9683f1776500d0a401f29633f6b6130b Mon Sep 17 00:00:00 2001
@@ -2712,7 +2712,7 @@ index fcd9fd5..a4276ec 100644
          enable_dropout=False,
          method=self.module.encode,
 -- 
-2.34.1
+2.43.0
 
 
 From 181087dbc71a268e4d96fbd3adb429ab630f0486 Mon Sep 17 00:00:00 2001
@@ -2753,7 +2753,7 @@ index a4276ec..faeb6d0 100644
      # `decoder_input_tokens`. The EOS is stripped to avoid decoding to stop
      # after the prompt by matching to `output_vocabulary.eos_id`.
 -- 
-2.34.1
+2.43.0
 
 
 From 4d051703078985ca95b23def87672513dbce9daa Mon Sep 17 00:00:00 2001
@@ -2805,7 +2805,7 @@ index f585752..568f596 100644
          name=name)
  
 -- 
-2.34.1
+2.43.0
 
 
 From 5fff9dc6557e084378d24fc9c14376331e7f3d3a Mon Sep 17 00:00:00 2001
@@ -2833,7 +2833,7 @@ index 568f596..05c5f6b 100644
    @staticmethod
    def update_fp8_metas(grad_accum, flax_mutables):
 -- 
-2.34.1
+2.43.0
 
 
 From e36be07a36c476545a5bbbb59e5c7a44419deb02 Mon Sep 17 00:00:00 2001
@@ -2996,7 +2996,7 @@ index 05c5f6b..7657c52 100644
      return TENotInstalledHelper
  
 -- 
-2.34.1
+2.43.0
 
 
 From 4b8a1ad34509a5f62dea7ce0d3efef87e2a4e9d1 Mon Sep 17 00:00:00 2001
@@ -3032,7 +3032,7 @@ index 7657c52..b064d2b 100644
  
    @staticmethod
 -- 
-2.34.1
+2.43.0
 
 
 From d08a6847857b6549ed8bfe1441d3742a6a13ac08 Mon Sep 17 00:00:00 2001
@@ -3072,7 +3072,7 @@ index 2ae6e7a..d9ba8bd 100644
  
  class PjitPartitioner(BasePjitPartitioner):
 -- 
-2.34.1
+2.43.0
 
 
 From a08b8bf78e14c288d6d7a66ad17a9bea69044cd7 Mon Sep 17 00:00:00 2001
@@ -3549,7 +3549,7 @@ index d083540..56919a5 100755
 -set +x
 +echo Finished
 -- 
-2.34.1
+2.43.0
 
 
 From 74d742f053dabbe594637ad1f481237a23065512 Mon Sep 17 00:00:00 2001
@@ -3575,7 +3575,7 @@ index 4eae811..6dcce29 100644
  
    if num_microbatches is None or num_microbatches <= 1:
 -- 
-2.34.1
+2.43.0
 
 
 From 4d5ec2fe4a665142de514ad08544c54ab4be6133 Mon Sep 17 00:00:00 2001
@@ -3601,5 +3601,5 @@ index faeb6d0..a48b068 100644
      """Predicts a batch of outputs from the model.
  
 -- 
-2.34.1
+2.43.0
 

--- a/.github/container/xla-arm64-neon.patch
+++ b/.github/container/xla-arm64-neon.patch
@@ -1,13 +1,13 @@
-diff --git a/xla/pjrt/transpose_kernels.h b/xla/pjrt/transpose_kernels.h
-index 26a60c122..0a4011d9b 100644
---- a/xla/pjrt/transpose_kernels.h
-+++ b/xla/pjrt/transpose_kernels.h
-@@ -33,7 +33,7 @@ limitations under the License.
- #define XLA_HAS_SSE2
+diff --git a/xla/ef57.cc b/xla/ef57.cc
+index d419f7810..9c526eeed 100644
+--- a/xla/ef57.cc
++++ b/xla/ef57.cc
+@@ -81,7 +81,7 @@ void ConvertF64ToEf57(absl::Span<const double> input,
+     output.remove_prefix(kFloatsPerSseIteration);
+   }
  #endif
- 
--#if defined(__ARM_NEON) && !defined(__ARM_BIG_ENDIAN)
-+#if defined(__ARM_NEON) && !defined(__ARM_BIG_ENDIAN) && !defined(__CUDACC__)
- #define XLA_HAS_ARM_NEON
- #endif
- 
+-#if defined(XLA_HAS_ARM_NEON) && defined(XLA_HAS_ARM64)
++#if defined(XLA_HAS_ARM_NEON) && defined(XLA_HAS_ARM64) && defined(__clang__)
+   constexpr int kDoublesPerNeonIteration = sizeof(float64x2_t) / sizeof(double);
+   constexpr int kFloatsPerNeonIteration = sizeof(float32x2x2_t) / sizeof(float);
+   while (input.size() >= kDoublesPerNeonIteration) {


### PR DESCRIPTION
https://github.com/openxla/xla/commit/49f45a12bcca8edc7f215887dbb112b2639d8a97 introduced some ARM intrinsic code that does not compile with GCC: https://godbolt.org/z/aYfds9Y15.
That commit also stopped the patch we apply to XLA from applying cleanly.
This updates the patch to disable vectorisation of that function when compiling for ARM with GCC.
It's not clear to me precisely which failure the old patch introduced in #367 was targeting (cc: @DwarKapex).