### PR TITLE
Publish ARM tags for upstream PAX image

### DIFF
--- a/.github/workflows/nightly-pax-build.yaml
+++ b/.github/workflows/nightly-pax-build.yaml
@@ -116,7 +116,7 @@ jobs:
     with:
       SOURCE_IMAGE: |
         ${{ needs.amd64.outputs.DOCKER_TAG_MEALKIT }}
-      # ${{ needs.arm64.outputs.DOCKER_TAG_MEALKIT }}
+        ${{ needs.arm64.outputs.DOCKER_TAG_MEALKIT }}
       TARGET_IMAGE: upstream-pax
       TARGET_TAGS: |
         type=raw,value=mealkit,priority=500
@@ -130,7 +130,7 @@ jobs:
     with:
       SOURCE_IMAGE: |
         ${{ needs.amd64.outputs.DOCKER_TAG_FINAL }}
-      # ${{ needs.arm64.outputs.DOCKER_TAG_FINAL }}
+        ${{ needs.arm64.outputs.DOCKER_TAG_FINAL }}
       TARGET_IMAGE: upstream-pax
       TARGET_TAGS: |
         type=raw,value=latest,priority=1000


### PR DESCRIPTION
These ARM tags are required for downstream Rosetta PAX build jobs