### PR TITLE
Move manifest file to base container

### DIFF
--- a/.github/container/Dockerfile.base
+++ b/.github/container/Dockerfile.base
@@ -2,10 +2,16 @@
 ARG BASE_IMAGE=nvidia/cuda:12.2.0-devel-ubuntu22.04
 ARG GIT_USER_NAME="JAX Toolbox"
 ARG GIT_USER_EMAIL=jax@nvidia.com
+ARG SRC_MANIFEST_FILE=manifest.yaml
+ARG DEST_MANIFEST_DIR=/opt/manifest.d
+
 
 FROM ${BASE_IMAGE}
 ARG GIT_USER_EMAIL
 ARG GIT_USER_NAME
+ARG SRC_MANIFEST_FILE
+ARG DEST_MANIFEST_DIR
+
 
 ###############################################################################
 ## Install Python and essential tools
@@ -98,3 +104,14 @@ RUN ln -s /opt/nvidia/nsight-compute/*/host/target-linux-x64/nsys /usr/local/cud
 ###############################################################################
 
 COPY check-shm.sh /opt/nvidia/entrypoint.d/
+
+###############################################################################
+## Copy manifest file to the container
+###############################################################################
+
+# Set the manifest env vars
+ENV MANIFEST_FILE=${DEST_MANIFEST_DIR}/${SRC_MANIFEST_FILE}
+# Copy all required files for manifestation
+COPY ${SRC_MANIFEST_FILE} ${DEST_MANIFEST_DIR}/${SRC_MANIFEST_FILE}
+COPY patches/ ${DEST_MANIFEST_DIR}/patches/
+

--- a/.github/container/Dockerfile.jax
+++ b/.github/container/Dockerfile.jax
@@ -1,6 +1,5 @@
 # syntax=docker/dockerfile:1-labs
 ARG BASE_IMAGE=ghcr.io/nvidia/jax-toolbox:base
-ARG SRC_MANIFEST_FILE=manifest.yaml
 ARG DEST_MANIFEST_DIR=/opt/manifest.d
 ARG SRC_PATH_JAX=/opt/jax
 ARG SRC_PATH_XLA=/opt/xla
@@ -17,7 +16,6 @@ ARG BUILD_DATE
 ###############################################################################
 
 FROM ${BASE_IMAGE} as builder
-ARG SRC_MANIFEST_FILE
 ARG DEST_MANIFEST_DIR
 ARG SRC_PATH_JAX
 ARG SRC_PATH_XLA
@@ -25,12 +23,7 @@ ARG BAZEL_CACHE
 ARG GIT_USER_NAME
 ARG GIT_USER_EMAIL
 
-# Set the manifest env vars
-ENV MANIFEST_FILE=${DEST_MANIFEST_DIR}/${SRC_MANIFEST_FILE}
-
 ADD --chmod=777 create-distribution.sh ${DEST_MANIFEST_DIR}/
-COPY ${SRC_MANIFEST_FILE} ${DEST_MANIFEST_DIR}/${SRC_MANIFEST_FILE}
-COPY patches/ ${DEST_MANIFEST_DIR}/patches/
 
 RUN get-source.sh -l jax -m ${MANIFEST_FILE}
 RUN --mount=type=ssh \
@@ -54,7 +47,6 @@ RUN build-jax.sh \
 
 ARG BASE_IMAGE
 FROM ${BASE_IMAGE} as mealkit
-ARG SRC_MANIFEST_FILE
 ARG DEST_MANIFEST_DIR
 ARG SRC_PATH_JAX
 ARG SRC_PATH_XLA
@@ -68,12 +60,8 @@ ENV CUDA_DEVICE_MAX_CONNECTIONS=1
 ENV NCCL_IB_SL=1
 ENV NCCL_NVLS_ENABLE=0
 ENV CUDA_MODULE_LOADING=EAGER
-# Set the manifest env vars
-ENV MANIFEST_FILE=${DEST_MANIFEST_DIR}/${SRC_MANIFEST_FILE}
 
 ADD --chmod=777 create-distribution.sh ${DEST_MANIFEST_DIR}/
-COPY ${SRC_MANIFEST_FILE} ${DEST_MANIFEST_DIR}/${SRC_MANIFEST_FILE}
-COPY patches/ ${DEST_MANIFEST_DIR}/patches/
 
 COPY --from=builder ${SRC_PATH_JAX} ${SRC_PATH_JAX}
 COPY --from=builder ${SRC_PATH_XLA} ${SRC_PATH_XLA}


### PR DESCRIPTION
This is the first step towards unifying Nightly and Presubmit builds.

The idea of this PR is to move manifest file to base container from jax container:
1. to avoid code repeating
2. as a preparation for the next step

The next step (the follow-up PR) involves modification of manifest file for Nightly Builds only (Presubmit builds will work with upstream manifest file, because it assumes changing in pipeline only).