### PR TITLE
Pallas container: publish containers under JAX, add nightly test and README entries

### DIFF
--- a/.github/workflows/nightly-pallas-build.yaml
+++ b/.github/workflows/nightly-pallas-build.yaml
@@ -97,10 +97,10 @@ jobs:
     uses: ./.github/workflows/_publish_container.yaml
     with:
       SOURCE_IMAGE: ${{ needs.amd64.outputs.DOCKER_TAG_MEALKIT }}
-      TARGET_IMAGE: pallas
+      TARGET_IMAGE: jax
       TARGET_TAGS: |
-        type=raw,value=mealkit,priority=500
-        type=raw,value=mealkit-${{ needs.metadata.outputs.BUILD_DATE }},priority=500
+        type=raw,value=mealkit-pallas,priority=450
+        type=raw,value=mealkit-pallas-${{ needs.metadata.outputs.BUILD_DATE }},priority=450
 
   publish-final:
     needs: [metadata, amd64]
@@ -108,10 +108,10 @@ jobs:
     uses: ./.github/workflows/_publish_container.yaml
     with:
       SOURCE_IMAGE: ${{ needs.amd64.outputs.DOCKER_TAG_FINAL }}
-      TARGET_IMAGE: pallas
+      TARGET_IMAGE: jax
       TARGET_TAGS: |
-        type=raw,value=latest,priority=1000
-        type=raw,value=nightly-${{ needs.metadata.outputs.BUILD_DATE }},priority=900
+        type=raw,value=latest-pallas,priority=950
+        type=raw,value=nightly-pallas-${{ needs.metadata.outputs.BUILD_DATE }},priority=850
 
   finalize:
     if: "!cancelled()"

--- a/.github/workflows/nightly-pallas-test-unit.yaml
+++ b/.github/workflows/nightly-pallas-test-unit.yaml
@@ -1,0 +1,75 @@
+name: Nightly Pallas unit test
+run-name: Nightly Pallas unit test (${{ github.event_name == 'workflow_run' && format('nightly {0}', github.event.workflow_run.created_at) || github.event_name }})
+
+on:
+  workflow_run:
+    workflows: [Nightly Pallas build]
+    types: [completed]
+    branches: [main]
+  workflow_dispatch:
+    inputs:
+      PALLAS_IMAGE:
+        type: string
+        description: 'Pallas image built by NVIDIA/JAX-Toolbox'
+        default: 'ghcr.io/nvidia/pallas:latest'
+        required: true
+      PUBLISH:
+        type: boolean
+        description: Update status badge?
+        default: false
+        required: true
+
+permissions:
+  contents: read  # to fetch code
+  actions:  write # to cancel previous workflows
+  packages: write # to upload container
+
+env:
+  DEFAULT_PALLAS_IMAGE: 'ghcr.io/nvidia/pallas:latest'
+
+jobs:
+
+  if-upstream-failed:
+    if: (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'failure') && github.event_name != 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo 'Upstream workflow failed, aborting run' && exit 1
+
+  metadata:
+    runs-on: ubuntu-22.04
+    outputs:
+      PALLAS_IMAGE: ${{ steps.image.outputs.PALLAS_IMAGE }}
+      PUBLISH: ${{ steps.if-publish.outputs.PUBLISH }}
+    steps:
+      - name: Determine Pallas image to use
+        id: image
+        shell: bash -x -e {0}
+        run: |
+          if [[ -z "${{ inputs.PALLAS_IMAGE }}" ]]; then
+            PALLAS_IMAGE=${{ env.DEFAULT_PALLAS_IMAGE }}
+          else
+            PALLAS_IMAGE=${{ inputs.PALLAS_IMAGE }}
+          fi
+          echo "PALLAS_IMAGE=${PALLAS_IMAGE}" >> $GITHUB_OUTPUT
+
+      - name: Determine whether results will be 'published'
+        id: if-publish
+        shell: bash -x -e {0}
+        run: |
+          echo "PUBLISH=${{ github.event_name == 'workflow_run' || (github.event_name == 'workflow_dispatch' && inputs.PUBLISH) }}" >> $GITHUB_OUTPUT
+
+  run:
+    needs: metadata
+    uses: ./.github/workflows/_test_pallas.yaml
+    if: (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success') || github.event_name == 'workflow_dispatch'
+    with:
+      PALLAS_IMAGE: ${{ needs.metadata.outputs.PALLAS_IMAGE }}
+    secrets: inherit
+
+  finalize:
+    if: "!cancelled()"
+    needs: [metadata, run]
+    uses: ./.github/workflows/_finalize.yaml
+    with:
+      PUBLISH_BADGE: ${{ needs.metadata.outputs.PUBLISH == 'true' }}
+    secrets: inherit

--- a/README.md
+++ b/README.md
@@ -86,6 +86,20 @@ Included in JAX build
 [![test-badge-rosetta-pax]][workflow-rosetta-pax]
             </td>
         </tr>
+        <!-- Pallas -->
+        <tr>
+            <td>
+[![container-badge-pallas]][container-link-pallas]
+            </td>
+            <td>
+[![build-badge-pallas]][workflow-pallas]
+            </td>
+            <td>
+[![test-badge-pallas-V100]][workflow-pallas-unit]
+<br>
+[![test-badge-pallas-A100]][workflow-pallas-unit]
+            </td>
+        </tr>
     </tbody>
 </table>
 
@@ -95,22 +109,26 @@ Included in JAX build
 [container-badge-te]: https://img.shields.io/static/v1?label=&message=TE&color=gray&logo=docker
 [container-badge-rosetta-t5x]: https://img.shields.io/static/v1?label=&message=T5X&color=gray&logo=docker
 [container-badge-rosetta-pax]: https://img.shields.io/static/v1?label=&message=PAX&color=gray&logo=docker
+[container-badge-pallas]: https://img.shields.io/static/v1?label=&message=Pallas&color=gray&logo=docker
 
 [container-link-base]: https://github.com/NVIDIA/JAX-Toolbox/pkgs/container/jax-toolbox
 [container-link-jax]: https://github.com/NVIDIA/JAX-Toolbox/pkgs/container/jax
 [container-link-te]: https://github.com/NVIDIA/JAX-Toolbox/pkgs/container/jax-te
 [container-link-rosetta-t5x]: https://github.com/NVIDIA/JAX-Toolbox/pkgs/container/t5x
 [container-link-rosetta-pax]: https://github.com/NVIDIA/JAX-Toolbox/pkgs/container/pax
+[container-link-pallas]: https://github.com/NVIDIA/JAX-Toolbox/pkgs/container/pallas
 
 [build-badge-base]: https://img.shields.io/github/actions/workflow/status/NVIDIA/JAX-Toolbox/weekly-base-build.yaml?branch=main&label=weekly&logo=github-actions&logoColor=dddddd
 [build-badge-jax]: https://img.shields.io/github/actions/workflow/status/NVIDIA/JAX-Toolbox/nightly-jax-build.yaml?branch=main&label=nightly&logo=github-actions&logoColor=dddddd
 [build-badge-rosetta-t5x]: https://img.shields.io/endpoint?url=https%3A%2F%2Fgist.githubusercontent.com%2Fnvjax%2F913c2af68649fe568e9711c2dabb23ae%2Fraw%2Frosetta-t5x-build-status.json&logo=github-actions&logoColor=dddddd
 [build-badge-rosetta-pax]: https://img.shields.io/endpoint?url=https%3A%2F%2Fgist.githubusercontent.com%2Fnvjax%2F913c2af68649fe568e9711c2dabb23ae%2Fraw%2Frosetta-pax-build-status.json&logo=github-actions&logoColor=dddddd
+[build-badge-pallas]: https://img.shields.io/github/actions/workflow/status/NVIDIA/JAX-Toolbox/nightly-pallas-build.yaml?branch=main&label=nightly&logo=github-actions&logoColor=dddddd
 
 [workflow-base]: https://github.com/NVIDIA/JAX-Toolbox/actions/workflows/weekly-base-build.yaml
 [workflow-jax]: https://github.com/NVIDIA/JAX-Toolbox/actions/workflows/nightly-jax-build.yaml
 [workflow-rosetta-t5x]: https://github.com/NVIDIA/JAX-Toolbox/actions/workflows/nightly-rosetta-t5x-build-test.yaml
 [workflow-rosetta-pax]: https://github.com/NVIDIA/JAX-Toolbox/actions/workflows/nightly-rosetta-pax-build.yaml
+[workflow-pallas]: https://github.com/NVIDIA/JAX-Toolbox/actions/workflows/nightly-pallas-build.yaml
 
 [test-badge-jax-V100]: https://img.shields.io/endpoint?url=https%3A%2F%2Fgist.githubusercontent.com%2Fnvjax%2F913c2af68649fe568e9711c2dabb23ae%2Fraw%2Fbadge-jax-unit-test-V100.json&logo=nvidia
 [test-badge-jax-A100]: https://img.shields.io/endpoint?url=https%3A%2F%2Fgist.githubusercontent.com%2Fnvjax%2F913c2af68649fe568e9711c2dabb23ae%2Fraw%2Fbadge-jax-unit-test-A100.json&logo=nvidia
@@ -120,15 +138,18 @@ Included in JAX build
 [integration-test-badge-te]: https://img.shields.io/endpoint?url=https%3A%2F%2Fgist.githubusercontent.com%2Fnvjax%2F913c2af68649fe568e9711c2dabb23ae%2Fraw%2Fte-integration-test-status.json&logo=nvidia
 [test-badge-rosetta-t5x]: https://img.shields.io/endpoint?url=https%3A%2F%2Fgist.githubusercontent.com%2Fnvjax%2F913c2af68649fe568e9711c2dabb23ae%2Fraw%2Frosetta-t5x-overall-test-status.json&logo=nvidia
 [test-badge-rosetta-pax]: https://img.shields.io/endpoint?url=https%3A%2F%2Fgist.githubusercontent.com%2Fnvjax%2F913c2af68649fe568e9711c2dabb23ae%2Fraw%2Frosetta-pax-overall-test-status.json&logo=nvidia
+[test-badge-pallas-V100]: https://img.shields.io/endpoint?url=https%3A%2F%2Fgist.githubusercontent.com%2Fnvjax%2F913c2af68649fe568e9711c2dabb23ae%2Fraw%2Fbadge-pallas-unit-test-V100.json&logo=nvidia
+[test-badge-pallas-A100]: https://img.shields.io/endpoint?url=https%3A%2F%2Fgist.githubusercontent.com%2Fnvjax%2F913c2af68649fe568e9711c2dabb23ae%2Fraw%2Fbadge-pallas-unit-test-A100.json&logo=nvidia
 
 [workflow-jax-unit]: https://github.com/NVIDIA/JAX-Toolbox/actions/workflows/nightly-jax-test-unit.yaml
 [workflow-te-test]: https://github.com/NVIDIA/JAX-Toolbox/actions/workflows/nightly-te-test.yaml
 [workflow-t5x-perf]: https://github.com/NVIDIA/JAX-Toolbox/actions/workflows/nightly-t5x-test-mgmn.yaml
 [workflow-pax-perf]: https://github.com/NVIDIA/JAX-Toolbox/actions/workflows/nightly-pax-test-mgmn.yaml
+[workflow-pallas-unit]: https://github.com/NVIDIA/JAX-Toolbox/actions/workflows/nightly-pallas-test-unit.yaml
 
 
 ## Note
-This repo currently hosts a public CI for JAX on NVIDIA GPUs and covers some JAX libraries like: [T5x](https://github.com/google-research/t5x), [PAXML](https://github.com/google/paxml), [Transformer Engine](https://github.com/NVIDIA/TransformerEngine), and others to come soon.
+This repo currently hosts a public CI for JAX on NVIDIA GPUs and covers some JAX libraries like: [T5x](https://github.com/google-research/t5x), [PAXML](https://github.com/google/paxml), [Transformer Engine](https://github.com/NVIDIA/TransformerEngine), [Pallas](https://jax.readthedocs.io/en/latest/pallas/quickstart.html) and others to come soon.
 
 ## Supported Models
 We currently enable training and evaluation for the following models:

--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ Included in JAX build
 [container-link-te]: https://github.com/NVIDIA/JAX-Toolbox/pkgs/container/jax-te
 [container-link-rosetta-t5x]: https://github.com/NVIDIA/JAX-Toolbox/pkgs/container/t5x
 [container-link-rosetta-pax]: https://github.com/NVIDIA/JAX-Toolbox/pkgs/container/pax
-[container-link-pallas]: https://github.com/NVIDIA/JAX-Toolbox/pkgs/container/pallas
+[container-link-pallas]: https://github.com/NVIDIA/JAX-Toolbox/pkgs/container/jax
 
 [build-badge-base]: https://img.shields.io/github/actions/workflow/status/NVIDIA/JAX-Toolbox/weekly-base-build.yaml?branch=main&label=weekly&logo=github-actions&logoColor=dddddd
 [build-badge-jax]: https://img.shields.io/github/actions/workflow/status/NVIDIA/JAX-Toolbox/nightly-jax-build.yaml?branch=main&label=nightly&logo=github-actions&logoColor=dddddd


### PR DESCRIPTION
Builds on #423. Publishes Pallas-enabled images as `jax:latest-pallas` etc. instead of `pallas:latest`.