### PR TITLE
Update T5X patchlist 

### DIFF
--- a/.github/container/manifest.yaml
+++ b/.github/container/manifest.yaml
@@ -2,31 +2,31 @@
 jax:
   url: https://github.com/google/jax.git
   tracking_ref: main
-  latest_verified_commit: 1ed6a818c7f05768f20cd0e0cf3101ee9b63abd9
+  latest_verified_commit: 2356e57af47baa37286177676a5a4bcd0c7b8c40
   mode: git-clone
 xla:
   url: https://github.com/openxla/xla.git
   tracking_ref: main
-  latest_verified_commit: 079610a2a0c1013c7418bb8fe9554c5f9db0a7cd
+  latest_verified_commit: 17ec7b4031608d3ddaca83e0661ed3aa0393e9d9
   mode: git-clone
 flax:
   url: https://github.com/google/flax.git
   mirror_url: https://github.com/nvjax-svc-0/flax.git
   tracking_ref: main
-  latest_verified_commit: cb6843f29d3400d7dab6751d4b693e4862f57d98
+  latest_verified_commit: 7cbc3c13ecd8a1713732113dec7939d0b75342c6
   mode: git-clone
   patches:
     pull/3340/head: file://patches/flax/PR-3340.patch # Add Sharding Annotations to Flax Modules
 transformer-engine:
   url: https://github.com/NVIDIA/TransformerEngine.git
   tracking_ref: main
-  latest_verified_commit: 1bb8b6ebae1ecadd7d817d572245ce5243166d32
+  latest_verified_commit: bb759adc2a53c57cc387f531c580a16149e3d4ac
   mode: git-clone
 t5x:
   url: https://github.com/google-research/t5x.git
   mirror_url: https://github.com/nvjax-svc-0/t5x.git
   tracking_ref: main
-  latest_verified_commit: dbc4b6f426862d5a742a2104a17524f53dd442f0
+  latest_verified_commit: 18f74b7891223faf96825d02ef7d7b23630a4c3c
   mode: git-clone
   patches:
     mirror/patch/partial-checkpoint-restore: file://patches/t5x/mirror-patch-partial-checkpoint-restore.patch # pull/1392/head  # https://github.com/google-research/t5x/pull/1392: Add support for partial checkpoint restore
@@ -36,7 +36,7 @@ paxml:
   url: https://github.com/google/paxml.git
   mirror_url: https://github.com/nvjax-svc-0/paxml.git
   tracking_ref: main
-  latest_verified_commit: 97bdcc0c1b63296b114370bd3d9616b8753ed18b
+  latest_verified_commit: e666687c20ed64383485853cc7691228b4f4d302
   mode: git-clone
   patches:
     pull/46/head: file://patches/paxml/PR-46.patch # adds Transformer Engine support
@@ -44,7 +44,7 @@ praxis:
   url: https://github.com/google/praxis.git
   mirror_url: https://github.com/nvjax-svc-0/praxis.git
   tracking_ref: main
-  latest_verified_commit: 8319b421f65bdc737c91444e062fe52b50e8d9b2
+  latest_verified_commit: d126ac2cf4bc4808280d2842bbd3af872c6f682b
   mode: git-clone
   patches:
     pull/27/head: file://patches/praxis/PR-27.patch # This PR allows XLA:GPU to detect the MHA pattern more easily to call fused kernels from cublas.
@@ -68,13 +68,13 @@ pydantic:
 fiddle:
   url: https://github.com/google/fiddle.git
   tracking_ref: main
-  latest_verified_commit: a9e98709d4b109bf04ed61cee5ff366c50c82463
+  latest_verified_commit: 26b9a44620038f906af8fc4947763d9abba0bfd2
   mode: pip-vcs
 # Used by t5x
 airio:
   url: https://github.com/google/airio.git
   tracking_ref: main
-  latest_verified_commit: d9076165b52664d4a009b844755adc9ce93b05bf
+  latest_verified_commit: e472ba33fee92f412663cf2a9bef55161a87e3ce
   mode: pip-vcs
 clu:
   url: https://github.com/google/CommonLoopUtils.git
@@ -99,16 +99,16 @@ optax:
 seqio:
   url: https://github.com/google/seqio.git
   tracking_ref: main
-  latest_verified_commit: f217c6632f48f4c26ee6e9bafcfe51f3c2c99e93
+  latest_verified_commit: 36d3ef0d3f027d40d0600e11a7e17b0c88c20cff
   mode: pip-vcs
 # used by Pallas
 openxla-triton:
   url: https://github.com/openxla/triton.git
   tracking_ref: llvm-head
-  latest_verified_commit: 5bc2308c5c258c16fece71eaa303d85de31cc4e2
+  latest_verified_commit: 1a9969fadc0a4cf694e751d24f3e40802602c3b1
   mode: git-clone
 jax-triton:
   url: https://github.com/jax-ml/jax-triton.git
   tracking_ref: main
-  latest_verified_commit: 7778c47c0a27c0988c914dce640dec61e44bbe8c
+  latest_verified_commit: 4a5791d00809ac96f92d42a80a4f52501d1421be
   mode: git-clone

--- a/.github/container/manifest.yaml
+++ b/.github/container/manifest.yaml
@@ -31,8 +31,7 @@ t5x:
   patches:
     mirror/patch/partial-checkpoint-restore: file://patches/t5x/mirror-patch-partial-checkpoint-restore.patch # pull/1392/head  # https://github.com/google-research/t5x/pull/1392: Add support for partial checkpoint restore
     mirror/patch/dali-support: file://patches/t5x/mirror-patch-dali-support.patch # pull/1393/head  # https://github.com/google-research/t5x/pull/1393: Adds DALI support to t5x
-    # mirror/patch/t5x_te_in_contrib_noindent: file://patches/t5x/mirror-patch-t5x_te_in_contrib_noindent.patch # pull/1391/head  # https://github.com/google-research/t5x/pull/1391: Adds transformer engine support and GPU optimizations to T5x (enables H100)
-    mirror/ashors/fix_rng_dtype: file://patches/t5x/mirror-ashors-fix_rng_dtype.patch # fix on top of (and incorporating) https://github.com/google-research/t5x/pull/1391
+    mirror/patch/t5x_te_in_contrib_noindent: file://patches/t5x/mirror-patch-t5x_te_in_contrib_noindent.patch # pull/1391/head  # https://github.com/google-research/t5x/pull/1391: Adds transformer engine support and GPU optimizations to T5x (enables H100)
 paxml:
   url: https://github.com/google/paxml.git
   mirror_url: https://github.com/nvjax-svc-0/paxml.git

--- a/.github/container/patches/flax/PR-3340.patch
+++ b/.github/container/patches/flax/PR-3340.patch
@@ -373,7 +373,7 @@ index 076fd680..6eff2dd1 100644
  
  
 -- 
-2.43.0
+2.25.1
 
 
 From d1f3ec337b85b5c5377aab72d814adfc89dd4af5 Mon Sep 17 00:00:00 2001
@@ -436,5 +436,5 @@ index 999acf2c..8e031c77 100644
      else:
        bias = None
 -- 
-2.43.0
+2.25.1
 

--- a/.github/container/patches/paxml/PR-46.patch
+++ b/.github/container/patches/paxml/PR-46.patch
@@ -683,7 +683,7 @@ index 587181d..e7fe54a 100644
  
    train_state_partition_specs = (
 -- 
-2.43.0
+2.25.1
 
 
 From 9d6b6db6039d7e6658dd179e5838379c7dc967e3 Mon Sep 17 00:00:00 2001
@@ -717,7 +717,7 @@ index d44ca67..2b9dba4 100644
          assert self.packed_input == False
          assert len(self.moe_layers) == 0
 -- 
-2.43.0
+2.25.1
 
 
 From 1612dc7a1f77f0a515eb4801087a8b4f0756e5b9 Mon Sep 17 00:00:00 2001
@@ -744,7 +744,7 @@ index 2b9dba4..ef20305 100644
      return x_out
  
 -- 
-2.43.0
+2.25.1
 
 
 From 71507dc4b1396252e6fa746d1299854c204f0c51 Mon Sep 17 00:00:00 2001
@@ -771,7 +771,7 @@ index e7fe54a..4093c3b 100644
      vars_with_opt = tasks_lib.filter_vars_for_grad_or_opt(
          mdl_vars, excluded_for_learner
 -- 
-2.43.0
+2.25.1
 
 
 From 2a8233302c7e42b7dc7628c41abb637518d15c29 Mon Sep 17 00:00:00 2001
@@ -808,7 +808,7 @@ index ef20305..fed1601 100644
          finally:
              pass
 -- 
-2.43.0
+2.25.1
 
 
 From 2a6e5a960f438653b4c9cbeb0c016225af853279 Mon Sep 17 00:00:00 2001
@@ -975,7 +975,7 @@ index fed1601..5914e54 100644
      def update_fp8_metas_if_needed(mdl_vars, grads):
          return TransformerEngineHelper.get_helper().update_fp8_metas_if_needed(mdl_vars, grads)
 -- 
-2.43.0
+2.25.1
 
 
 From b57188225e7890dfc54d70db7d89fcb32e61e762 Mon Sep 17 00:00:00 2001
@@ -1136,7 +1136,7 @@ index 4093c3b..2e8fc35 100644
          grads, states.opt_states[0], vars_with_opt, wps_with_opt
      )
 -- 
-2.43.0
+2.25.1
 
 
 From c43766ee2e8cda686176a3895e87150b10d5de5e Mon Sep 17 00:00:00 2001
@@ -1528,7 +1528,7 @@ index fd482df..b271258 100644
      @contextmanager
      def fp8_autocast(dp_mesh_axis="replica", tp_mesh_axis="mdl", fsdp_mesh_axis="data"):
 -- 
-2.43.0
+2.25.1
 
 
 From abc0fabc3e2ffb42d1f62254ad42448a39cbd128 Mon Sep 17 00:00:00 2001
@@ -1563,5 +1563,5 @@ index b271258..cbac7cf 100644
  
  class TransformerEngineHelperBase:
 -- 
-2.43.0
+2.25.1
 

--- a/.github/container/patches/praxis/PR-27.patch
+++ b/.github/container/patches/praxis/PR-27.patch
@@ -34,5 +34,5 @@ index a35ce8b..52886bc 100644
        self.add_summary('attention_mask', atten_mask)
      if self.attention_extra_logit is None:
 -- 
-2.43.0
+2.25.1
 

--- a/.github/container/patches/praxis/PR-36.patch
+++ b/.github/container/patches/praxis/PR-36.patch
@@ -247,7 +247,7 @@ index ab6cff3..c79dac9 100644
        # Annotate the inputs before the pipeline to prevent unexpected
        # propagation from earlier layers.
 -- 
-2.43.0
+2.25.1
 
 
 From ff1745796009cf1ec59f463f8e776c66f1286938 Mon Sep 17 00:00:00 2001
@@ -358,5 +358,5 @@ index e3b2f7c..b31526e 100644
            trans_in_fn=_get_to_f32_converter(bf16_vars_to_convert),
            trans_out_fn=_get_to_bf16_converter(bf16_vars_to_convert),
 -- 
-2.43.0
+2.25.1
 

--- a/.github/container/patches/t5x/mirror-patch-dali-support.patch
+++ b/.github/container/patches/t5x/mirror-patch-dali-support.patch
@@ -1,15 +1,15 @@
-From 29cb12a419a5897d735073ef11f5d5da12021cd6 Mon Sep 17 00:00:00 2001
+From 01c2f2e6dedce10beb4ff7175a60f1526b026ae6 Mon Sep 17 00:00:00 2001
 From: ashors1 <ashors@nvidia.com>
 Date: Tue, 16 May 2023 11:53:31 -0700
 Subject: [PATCH 1/2] add support for DALI datasets
 
 ---
- t5x/train.py   |  86 ++++++++++++++++++++++++-----
+ t5x/train.py   |  88 +++++++++++++++++++++++------
  t5x/trainer.py | 146 +++++++++++++++++++++++++++++++++++++++++++++++++
- 2 files changed, 217 insertions(+), 15 deletions(-)
+ 2 files changed, 218 insertions(+), 16 deletions(-)
 
 diff --git a/t5x/train.py b/t5x/train.py
-index 06cd0a3..c0263ca 100644
+index e85d37c..e6027ce 100644
 --- a/t5x/train.py
 +++ b/t5x/train.py
 @@ -116,10 +116,13 @@ def train(
@@ -47,7 +47,7 @@ index 06cd0a3..c0263ca 100644
      train_state_initializer_cls: t5x.utils.TrainStateInitializer class for
        initializing partitioned TrainState from checkpoints or scratch.
      use_orbax: if True, uses Orbax for checkpointing. Experimental feature.
-@@ -300,12 +308,15 @@ def train(
+@@ -299,12 +307,15 @@ def train(
    train_iter = get_dataset_fn(
        train_dataset_cfg, ds_shard_id, num_ds_shards, model.FEATURE_CONVERTER_CLS
    )
@@ -69,7 +69,7 @@ index 06cd0a3..c0263ca 100644
    input_shapes = jax.tree_map(
        lambda x: (data_layout.batch_size, *x.shape[1:]),
        train_iter.element_spec,
-@@ -321,6 +332,12 @@ def train(
+@@ -320,6 +331,12 @@ def train(
          eval_steps,
          model.FEATURE_CONVERTER_CLS,
      )  # type: Mapping[str, tf.data.Dataset]
@@ -82,11 +82,13 @@ index 06cd0a3..c0263ca 100644
      if not train_eval_datasets:
        logging.warning(
            'No train_eval datasets loaded from config `train_eval_dataset_cfg`: '
-@@ -507,12 +524,19 @@ def train(
+@@ -506,9 +523,16 @@ def train(
    def _run_training_eval(first_run: bool = False):
      if first_run:
        logging.info('Compiling training eval loop.')
--      trainer.compile_eval(
+-      trainer.compile_eval({  # pytype: disable=wrong-arg-types  # jax-ndarray
+-          task: utils.get_zeros_batch_like_dataset(ds)
+-          for task, ds in train_eval_datasets.items()
 +      if run_dali_eval:
 +        trainer.compile_eval_dali({
 +            task: utils.get_zeros_batch_like_dataset(ds)
@@ -94,17 +96,13 @@ index 06cd0a3..c0263ca 100644
 +            jnp.ones((train_eval_dataset_cfg.batch_size,)).astype(jnp.bool_)
 +        )
 +      else:
-+        trainer.compile_eval(
-           {  # pytype: disable=wrong-arg-types  # jax-ndarray
-               task: utils.get_zeros_batch_like_dataset(ds)
-               for task, ds in train_eval_datasets.items()
-           }
--      )
-+        )
++        trainer.compile_eval({  # pytype: disable=wrong-arg-types  # jax-ndarray
++            task: utils.get_zeros_batch_like_dataset(ds)
++            for task, ds in train_eval_datasets.items()
+       })
      logging.info('Computing training evaluation metrics.')
      eval_batch_iters = {}
-     for task, ds in train_eval_datasets.items():
-@@ -521,13 +545,20 @@ def train(
+@@ -518,13 +542,20 @@ def train(
        else:
          eval_batch_iters[task] = ds
  
@@ -132,7 +130,7 @@ index 06cd0a3..c0263ca 100644
  
    def _run_inference_eval():
      """Run prediction based inference eval."""
-@@ -556,6 +587,19 @@ def train(
+@@ -553,6 +584,19 @@ def train(
      if train_eval_datasets:
        logging.info('Running training eval before training.')
        _run_training_eval(first_run=True)
@@ -152,7 +150,7 @@ index 06cd0a3..c0263ca 100644
      if evaluator is not None:
        logging.info('Running inference eval before training.')
        _run_inference_eval()
-@@ -792,6 +836,18 @@ def train(
+@@ -793,6 +837,18 @@ def train(
        # Maybe less if final step < period.
        first_run = step_offset // eval_period <= 1
        _run_training_eval(first_run and not run_eval_before_training)
@@ -172,10 +170,10 @@ index 06cd0a3..c0263ca 100644
      # Inference Evaluation (i.e., with decoding or scoring).
      if is_eval_epoch and evaluator is not None:
 diff --git a/t5x/trainer.py b/t5x/trainer.py
-index 752beb3..5475376 100644
+index 3d592d8..7a321cd 100644
 --- a/t5x/trainer.py
 +++ b/t5x/trainer.py
-@@ -34,6 +34,7 @@ import clu.metrics
+@@ -35,6 +35,7 @@ import clu.metrics
  import clu.values
  from flax.core import FrozenDict
  import jax
@@ -183,7 +181,7 @@ index 752beb3..5475376 100644
  import jax.lax
  import jax.numpy as jnp
  import jax.random
-@@ -596,6 +597,99 @@ class BaseTrainer(abc.ABC):
+@@ -648,6 +649,99 @@ class BaseTrainer(abc.ABC):
      # TODO(adarob): Return futures.
      return {k: v.result() for k, v in eval_summaries.items()}
  
@@ -283,9 +281,9 @@ index 752beb3..5475376 100644
    def compile_eval(self, batches: Mapping[str, BatchType]) -> None:
      """Pre-compiles eval step (if not yet compiled).
  
-@@ -633,6 +727,44 @@ class BaseTrainer(abc.ABC):
-       self.eval_metrics_managers[eval_name].write_scalar(  # pytype: disable=wrong-arg-types  # jax-ndarray
-           "timing/compilation_seconds", tock - tick, self.train_state.step)
+@@ -688,6 +782,44 @@ class BaseTrainer(abc.ABC):
+           "timing/compilation_seconds", tock - tick, self.train_state.step
+       )
  
 +  def compile_eval_dali(self,
 +                        batches: Mapping[str, BatchType],
@@ -328,7 +326,7 @@ index 752beb3..5475376 100644
    @property
    @abc.abstractmethod
    def _partitioned_train_step(self) -> PartitionedTrainCallable:
-@@ -828,6 +960,10 @@ def eval_step(model: models.BaseModel, train_state: train_state_lib.TrainState,
+@@ -916,6 +1048,10 @@ def eval_step(
      # pytype: enable=wrong-arg-types
    return metrics
  
@@ -339,9 +337,9 @@ index 752beb3..5475376 100644
  
  def train_with_lr(
      train_state: train_state_lib.TrainState,
-@@ -940,6 +1076,16 @@ class Trainer(BaseTrainer):
-                            self._partitioner.data_partition_spec),
-         out_axis_resources=None)
+@@ -1050,6 +1186,16 @@ class Trainer(BaseTrainer):
+         out_axis_resources=None,
+     )
  
 +  @cached_property
 +  def _partitioned_score_step(self) -> PartitionedEvalCallable:
@@ -357,10 +355,10 @@ index 752beb3..5475376 100644
  def _warn_action_not_run(action, task, metric):
    logging.warning(
 -- 
-2.43.0
+2.25.1
 
 
-From fbb093fa5851499289804594078b473696c52476 Mon Sep 17 00:00:00 2001
+From 79d36a39921b83271ff75748a211185884744f8b Mon Sep 17 00:00:00 2001
 From: ashors1 <ashors@nvidia.com>
 Date: Wed, 1 Nov 2023 11:17:53 -0700
 Subject: [PATCH 2/2] fix bug in rebase
@@ -370,10 +368,10 @@ Subject: [PATCH 2/2] fix bug in rebase
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/t5x/train.py b/t5x/train.py
-index c0263ca..600e3a4 100644
+index e6027ce..ec1c2fa 100644
 --- a/t5x/train.py
 +++ b/t5x/train.py
-@@ -310,7 +310,7 @@ def train(
+@@ -309,7 +309,7 @@ def train(
    )
  
    if prepare_train_iter_fn:
@@ -383,5 +381,5 @@ index c0263ca..600e3a4 100644
          checkpoint_cfg=checkpoint_cfg,
          partitioner=partitioner,
 -- 
-2.43.0
+2.25.1
 

--- a/.github/container/patches/t5x/mirror-patch-partial-checkpoint-restore.patch
+++ b/.github/container/patches/t5x/mirror-patch-partial-checkpoint-restore.patch
@@ -25,5 +25,5 @@ index 61682ed..77e0860 100644
    ]
    # 2. From a checkpoint specified by `checkpoint_cfg.restore.path`, if set.
 -- 
-2.43.0
+2.25.1
 

--- a/.github/container/patches/t5x/mirror-patch-t5x_te_in_contrib_noindent.patch
+++ b/.github/container/patches/t5x/mirror-patch-t5x_te_in_contrib_noindent.patch
@@ -1,4 +1,4 @@
-From 6ac19ca55511e08e8751ab95e312df0399c19c5b Mon Sep 17 00:00:00 2001
+From b2d91d822285202f833ad507366f49559a52a5b8 Mon Sep 17 00:00:00 2001
 From: Terry Kong <terryk@nvidia.com>
 Date: Mon, 24 Apr 2023 10:18:29 -0700
 Subject: [PATCH 01/18] Added transformer engine support and GPU optimizations
@@ -39,9 +39,9 @@ Co-authored-by: Reese Wang <rewang@nvidia.com>
  t5x/partitioning.py                           |   3 +
  t5x/te_helper.py                              | 284 ++++++++++++++++++
  t5x/train.py                                  |  59 ++++
- t5x/train_state.py                            |   3 +-
- t5x/trainer.py                                |  45 +--
- 28 files changed, 1045 insertions(+), 323 deletions(-)
+ t5x/train_state.py                            |   2 +-
+ t5x/trainer.py                                |  46 +--
+ 28 files changed, 1044 insertions(+), 324 deletions(-)
  create mode 100644 t5x/contrib/gpu/T5X_TE_README.md
  create mode 100644 t5x/te_helper.py
 
@@ -1439,7 +1439,7 @@ index 6a4c7b2..a1f50db 100644
  INITIAL_CHECKPOINT_PATH = "gs://t5-data/pretrained_models/t5x/t5_1_1_xl/checkpoint_1000000"
  # `LOSS_NORMALIZING_FACTOR`: When fine-tuning a model that was pre-trained
 diff --git a/t5x/models.py b/t5x/models.py
-index f31d39f..fcd9fd5 100644
+index b58f579..8a45977 100644
 --- a/t5x/models.py
 +++ b/t5x/models.py
 @@ -43,6 +43,8 @@ from t5x import optimizers
@@ -1561,7 +1561,7 @@ index f31d39f..fcd9fd5 100644
    def _compute_metrics(
        self,
        logits: jnp.ndarray,
-@@ -461,15 +497,18 @@ class EncoderDecoderModel(BaseTransformerModel):
+@@ -459,15 +495,18 @@ class EncoderDecoderModel(BaseTransformerModel):
        batch: Mapping[str, jnp.ndarray],
        dropout_rng: Optional[jax.Array] = None,
        mutable: flax_scope.CollectionFilter = False,
@@ -1584,7 +1584,7 @@ index f31d39f..fcd9fd5 100644
          batch['encoder_input_tokens'],
          batch['decoder_input_tokens'],
          batch['decoder_target_tokens'],
-@@ -490,17 +529,25 @@ class EncoderDecoderModel(BaseTransformerModel):
+@@ -488,17 +527,25 @@ class EncoderDecoderModel(BaseTransformerModel):
        encoded_inputs: jnp.ndarray,
        raw_inputs: jnp.ndarray,
        max_decode_length: int,
@@ -1611,7 +1611,7 @@ index f31d39f..fcd9fd5 100644
          encoded_inputs,
          raw_inputs,  # only needed for encoder padding mask
          flat_ids,
-@@ -523,6 +570,7 @@ class EncoderDecoderModel(BaseTransformerModel):
+@@ -521,6 +568,7 @@ class EncoderDecoderModel(BaseTransformerModel):
        encoder_input_tokens: jnp.ndarray,
        decoder_input_tokens: jnp.ndarray,
        prefill_decoder_prompt: bool = False,
@@ -1619,7 +1619,7 @@ index f31d39f..fcd9fd5 100644
    ) -> Tuple[PyTree, Optional[jnp.ndarray]]:
      """Initialize the key/value cache, with optional prompt.
  
-@@ -541,8 +589,14 @@ class EncoderDecoderModel(BaseTransformerModel):
+@@ -539,8 +587,14 @@ class EncoderDecoderModel(BaseTransformerModel):
        initial_index: The index of the next position following prefill or None if
          `prefill_decoder_prompt` is False.
      """
@@ -1635,7 +1635,7 @@ index f31d39f..fcd9fd5 100644
          encoder_input_tokens=jnp.ones_like(encoder_input_tokens),
          decoder_input_tokens=jnp.ones_like(decoder_input_tokens),
          decoder_target_tokens=jnp.ones_like(decoder_input_tokens),
-@@ -583,6 +637,24 @@ class EncoderDecoderModel(BaseTransformerModel):
+@@ -581,6 +635,24 @@ class EncoderDecoderModel(BaseTransformerModel):
  
      return cache, inputs_lengths
  
@@ -1660,7 +1660,7 @@ index f31d39f..fcd9fd5 100644
    def predict_batch_with_aux(
        self,
        params: PyTree,
-@@ -592,6 +664,7 @@ class EncoderDecoderModel(BaseTransformerModel):
+@@ -590,6 +662,7 @@ class EncoderDecoderModel(BaseTransformerModel):
        return_all_decodes: bool = None,
        num_decodes: int = None,  # pytype:disable=annotation-type-mismatch
        prompt_with_targets: bool = False,
@@ -1668,7 +1668,7 @@ index f31d39f..fcd9fd5 100644
    ) -> Tuple[jnp.ndarray, Mapping[str, jnp.ndarray]]:
      """Predict with fast decoding beam search on a batch.
  
-@@ -648,11 +721,30 @@ class EncoderDecoderModel(BaseTransformerModel):
+@@ -646,11 +719,30 @@ class EncoderDecoderModel(BaseTransformerModel):
        return_all_decodes = self._default_decoder_params.return_all_decodes
      if num_decodes is None:
        num_decodes = self._default_decoder_params.num_decodes
@@ -1699,7 +1699,7 @@ index f31d39f..fcd9fd5 100644
      # `decoder_prompt_inputs` is initialized from the batch's
      # `decoder_input_tokens`. The EOS is stripped to avoid decoding to stop
      # after the prompt by matching to `output_vocabulary.eos_id`.
-@@ -693,6 +785,7 @@ class EncoderDecoderModel(BaseTransformerModel):
+@@ -691,6 +783,7 @@ class EncoderDecoderModel(BaseTransformerModel):
          encoder_input_tokens=encoder_input_tokens,
          decoder_input_tokens=decoder_prompt_inputs,
          prefill_decoder_prompt=prefill_decoder_prompt,
@@ -1707,7 +1707,7 @@ index f31d39f..fcd9fd5 100644
      )
  
      # Prepare transformer fast-decoder call for beam search: for beam search, we
-@@ -714,6 +807,7 @@ class EncoderDecoderModel(BaseTransformerModel):
+@@ -712,6 +805,7 @@ class EncoderDecoderModel(BaseTransformerModel):
              encoder_input_tokens, num_decodes
          ),
          max_decode_length=decoder_input_tokens.shape[1],
@@ -1715,7 +1715,7 @@ index f31d39f..fcd9fd5 100644
      )
  
      if decoder_params is None:
-@@ -739,6 +833,7 @@ class EncoderDecoderModel(BaseTransformerModel):
+@@ -737,6 +831,7 @@ class EncoderDecoderModel(BaseTransformerModel):
      # decodes: [batch, num_decodes, max_decode_len + 1]
      # scores: [batch, num_decodes]
      scanned = hasattr(self.module, 'scan_layers') and self.module.scan_layers
@@ -1723,7 +1723,7 @@ index f31d39f..fcd9fd5 100644
  
      if 'eos_id' not in decoder_params:
        decoder_params['eos_id'] = self.output_vocabulary.eos_id
-@@ -747,8 +842,8 @@ class EncoderDecoderModel(BaseTransformerModel):
+@@ -745,8 +840,8 @@ class EncoderDecoderModel(BaseTransformerModel):
          cache=cache,
          tokens_to_logits=tokens_ids_to_logits,
          num_decodes=num_decodes,
@@ -1734,7 +1734,7 @@ index f31d39f..fcd9fd5 100644
      )
  
      # Beam search returns [n_batch, n_beam, n_length] with beam dimension sorted
-@@ -764,6 +859,7 @@ class EncoderDecoderModel(BaseTransformerModel):
+@@ -762,6 +857,7 @@ class EncoderDecoderModel(BaseTransformerModel):
        params: PyTree,
        batch: Mapping[str, jnp.ndarray],
        return_intermediates: bool = False,
@@ -1742,7 +1742,7 @@ index f31d39f..fcd9fd5 100644
    ) -> Union[jnp.ndarray, Tuple[jnp.ndarray, Mapping[str, Any]]]:
      """Compute log likelihood score on a batch."""
      weights = batch['decoder_loss_weights']
-@@ -771,7 +867,8 @@ class EncoderDecoderModel(BaseTransformerModel):
+@@ -769,7 +865,8 @@ class EncoderDecoderModel(BaseTransformerModel):
  
      if return_intermediates:
        logits, modified_variables = self._compute_logits(
@@ -1752,7 +1752,7 @@ index f31d39f..fcd9fd5 100644
        )
  
        # Inside self.module, we called nn.Module.sow to track various
-@@ -789,7 +886,7 @@ class EncoderDecoderModel(BaseTransformerModel):
+@@ -787,7 +884,7 @@ class EncoderDecoderModel(BaseTransformerModel):
        # `intermediates` should be tuples tracking all instantiations of a value.
        # These values each have just one instantiation, hence singletons.
      else:
@@ -1761,7 +1761,7 @@ index f31d39f..fcd9fd5 100644
  
      # Purposefully don't use config.z_loss because that term is for training
      # stability and shouldn't affect our reported scores.
-@@ -900,16 +997,19 @@ class DecoderOnlyModel(BaseTransformerModel):
+@@ -896,16 +993,19 @@ class DecoderOnlyModel(BaseTransformerModel):
        batch: Mapping[str, jnp.ndarray],
        dropout_rng: Optional[jax.Array] = None,
        mutable: flax_scope.CollectionFilter = False,
@@ -1785,7 +1785,7 @@ index f31d39f..fcd9fd5 100644
          batch['decoder_input_tokens'],
          batch['decoder_target_tokens'],
          decoder_segment_ids=batch.get('decoder_segment_ids', None),
-@@ -926,6 +1026,7 @@ class DecoderOnlyModel(BaseTransformerModel):
+@@ -922,6 +1022,7 @@ class DecoderOnlyModel(BaseTransformerModel):
        decoding_state: decoding.DecodingState,
        params: PyTree,
        max_decode_length: int,
@@ -1793,7 +1793,7 @@ index f31d39f..fcd9fd5 100644
    ) -> Tuple[jnp.ndarray, Mapping[str, jnp.ndarray]]:
      """Token slice to logits from decoder model."""
      flat_ids = decoding_state.cur_token
-@@ -936,7 +1037,11 @@ class DecoderOnlyModel(BaseTransformerModel):
+@@ -932,7 +1033,11 @@ class DecoderOnlyModel(BaseTransformerModel):
      # flat_cache['cache_index']: [batch]
      # flat_logits: [batch, seq_len=1, vocab]
      flat_logits, new_vars = self.module.apply(
@@ -1806,7 +1806,7 @@ index f31d39f..fcd9fd5 100644
          flat_ids,
          flat_ids,
          enable_dropout=False,
-@@ -954,6 +1059,7 @@ class DecoderOnlyModel(BaseTransformerModel):
+@@ -950,6 +1055,7 @@ class DecoderOnlyModel(BaseTransformerModel):
        params: PyTree,
        batch: Mapping[str, jnp.ndarray],
        return_intermediates: bool = False,
@@ -1814,7 +1814,7 @@ index f31d39f..fcd9fd5 100644
    ) -> jnp.ndarray:
      """Compute log likelihood score on a batch."""
  
-@@ -966,6 +1072,7 @@ class DecoderOnlyModel(BaseTransformerModel):
+@@ -962,6 +1068,7 @@ class DecoderOnlyModel(BaseTransformerModel):
            batch=batch,
            dropout_rng=None,
            mutable=['intermediates'],
@@ -1822,7 +1822,7 @@ index f31d39f..fcd9fd5 100644
        )
  
        # Inside self.module, we called nn.Module.sow to track various
-@@ -984,7 +1091,7 @@ class DecoderOnlyModel(BaseTransformerModel):
+@@ -980,7 +1087,7 @@ class DecoderOnlyModel(BaseTransformerModel):
        # These values each have just one instantiation, hence singletons.
      else:
        logits = self._compute_logits(
@@ -1831,7 +1831,7 @@ index f31d39f..fcd9fd5 100644
        )
  
      token_scores = (
-@@ -1012,6 +1119,7 @@ class DecoderOnlyModel(BaseTransformerModel):
+@@ -1008,6 +1115,7 @@ class DecoderOnlyModel(BaseTransformerModel):
        params: PyTree,
        inputs: jnp.ndarray,
        causal_attention_mask: jnp.ndarray,
@@ -1839,7 +1839,7 @@ index f31d39f..fcd9fd5 100644
    ) -> Tuple[PyTree, jnp.ndarray]:
      """Compute the key/value cache on the input prompt.
  
-@@ -1025,12 +1133,17 @@ class DecoderOnlyModel(BaseTransformerModel):
+@@ -1021,12 +1129,17 @@ class DecoderOnlyModel(BaseTransformerModel):
        cache: The prefilled cache.
        initial_index: The index of the next position following prefill.
      """
@@ -1858,7 +1858,7 @@ index f31d39f..fcd9fd5 100644
          jnp.ones_like(inputs),
          jnp.ones_like(inputs),
          enable_dropout=False,
-@@ -1068,7 +1181,11 @@ class DecoderOnlyModel(BaseTransformerModel):
+@@ -1064,7 +1177,11 @@ class DecoderOnlyModel(BaseTransformerModel):
      )
  
      _, variables_with_cache = self.module.apply(
@@ -1871,7 +1871,7 @@ index f31d39f..fcd9fd5 100644
          decoder_input_tokens=inputs,
          # Use the `decoder_causal_attention`, which has 1 for all input
          # positions, including the BOS token, as the targets so when the
-@@ -1095,6 +1212,7 @@ class DecoderOnlyModel(BaseTransformerModel):
+@@ -1091,6 +1208,7 @@ class DecoderOnlyModel(BaseTransformerModel):
        return_all_decodes: bool = False,
        num_decodes: int = 1,
        decoder_params: Optional[MutableMapping[str, Any]] = None,
@@ -1879,7 +1879,7 @@ index f31d39f..fcd9fd5 100644
    ) -> Tuple[jnp.ndarray, Mapping[str, jnp.ndarray]]:
      """Predict with prefix.
  
-@@ -1193,7 +1311,7 @@ class DecoderOnlyModel(BaseTransformerModel):
+@@ -1189,7 +1307,7 @@ class DecoderOnlyModel(BaseTransformerModel):
      inputs = batch['decoder_input_tokens'] * batch['decoder_causal_attention']
  
      prefilled_cache, initial_index = self._compute_kv_cache(
@@ -1888,7 +1888,7 @@ index f31d39f..fcd9fd5 100644
      )
  
      target_shape = batch['decoder_input_tokens'].shape
-@@ -1203,6 +1321,7 @@ class DecoderOnlyModel(BaseTransformerModel):
+@@ -1199,6 +1317,7 @@ class DecoderOnlyModel(BaseTransformerModel):
          self._compute_logits_from_slice,
          params=params,
          max_decode_length=max_decode_length,
@@ -1897,10 +1897,10 @@ index f31d39f..fcd9fd5 100644
  
      if decoder_params is None:
 diff --git a/t5x/partitioning.py b/t5x/partitioning.py
-index 910f666..2ae6e7a 100644
+index 7165ac7..4920866b 100644
 --- a/t5x/partitioning.py
 +++ b/t5x/partitioning.py
-@@ -34,6 +34,7 @@ from jax.sharding import Mesh
+@@ -35,6 +35,7 @@ from jax.sharding import Mesh
  from jax.sharding import PartitionSpec
  import numpy as np
  from t5x import train_state as train_state_lib
@@ -1908,7 +1908,7 @@ index 910f666..2ae6e7a 100644
  
  JaxDevice = jax.Device
  TpuMesh = Tuple[int, int, int, int]  # (x, y, z, num_cores).
-@@ -522,6 +523,8 @@ def standard_logical_axis_rules(
+@@ -621,6 +622,8 @@ def standard_logical_axis_rules(
    if additional_rules:
      rules.extend(additional_rules)
  
@@ -2208,10 +2208,10 @@ index 0000000..fb5f48f
 +  def get_decoder_layer(config, relative_embedding, name, original_cls):
 +    return TransformerEngineHelper.get_helper().get_decoder_layer(config, relative_embedding, name, original_cls)
 diff --git a/t5x/train.py b/t5x/train.py
-index d6bfd6a..e7ee77d 100644
+index e85d37c..972fb9c 100644
 --- a/t5x/train.py
 +++ b/t5x/train.py
-@@ -45,6 +45,8 @@ from t5x import partitioning
+@@ -46,6 +46,8 @@ from t5x import partitioning
  from t5x import train_state as train_state_lib
  from t5x import trainer as trainer_lib
  from t5x import utils
@@ -2220,7 +2220,7 @@ index d6bfd6a..e7ee77d 100644
  import tensorflow as tf
  # pylint:enable=g-import-not-at-top
  
-@@ -107,6 +109,7 @@ def train(
+@@ -108,6 +110,7 @@ def train(
      total_steps: int,
      eval_steps: int,
      eval_period: int,
@@ -2228,7 +2228,7 @@ index d6bfd6a..e7ee77d 100644
      stats_period: Optional[int] = None,
      random_seed: Optional[int],
      use_hardware_rng: bool = False,
-@@ -127,6 +130,7 @@ def train(
+@@ -128,6 +131,7 @@ def train(
          Callable[[utils.DatasetConfig, models.BaseTransformerModel], None]
      ] = utils.verify_matching_vocabs,
      gc_period: int = 0,
@@ -2236,7 +2236,7 @@ index d6bfd6a..e7ee77d 100644
  ) -> Tuple[int, train_state_lib.TrainState]:
    """Train function.
  
-@@ -188,6 +192,12 @@ def train(
+@@ -189,6 +193,12 @@ def train(
        instance. Should raise an exception on error.
      gc_period: The number of train steps between runs of the garbage collector.
        If 0, the garbage collector will run at the normal frequency.
@@ -2332,7 +2332,7 @@ index d6bfd6a..e7ee77d 100644
      evaluator = eval_lib.InferenceEvaluator(
          infer_eval_dataset_cfg=infer_eval_dataset_cfg,
          inference_evaluator_cls=inference_evaluator_cls,
-@@ -800,6 +858,7 @@ def train(
+@@ -806,6 +864,7 @@ def train(
      # the same interpreter.
      gc.enable()
  
@@ -2341,24 +2341,23 @@ index d6bfd6a..e7ee77d 100644
  
  
 diff --git a/t5x/train_state.py b/t5x/train_state.py
-index 5ac52af..95cdd99 100644
+index abcbc79..b2eff93 100644
 --- a/t5x/train_state.py
 +++ b/t5x/train_state.py
-@@ -222,7 +222,8 @@ class FlaxOptimTrainState(flax.struct.PyTreeNode):
-         _optimizer=self._optimizer.optimizer_def.derive_logical_axes(
-             self._optimizer,
-             flax_partitioning.get_axis_names(self.params_axes)),
--        flax_mutables=flax_partitioning.get_axis_names(flax_mutables_axes))
-+        flax_mutables=flax_partitioning.get_axis_names(flax_mutables_axes),
+@@ -228,7 +228,7 @@ class FlaxOptimTrainState(flax.struct.PyTreeNode):
+             self._optimizer, flax_partitioning.get_axis_names(self.params_axes)
+         ),
+         flax_mutables=flax_partitioning.get_axis_names(flax_mutables_axes),
+-    )
 +        flax_mutables_axes=self.flax_mutables_axes)
  
  
  class InferenceState(flax.struct.PyTreeNode):
 diff --git a/t5x/trainer.py b/t5x/trainer.py
-index 752beb3..4eae811 100644
+index 3d592d8..7b3bab7 100644
 --- a/t5x/trainer.py
 +++ b/t5x/trainer.py
-@@ -43,6 +43,7 @@ from t5x import models
+@@ -44,6 +44,7 @@ from t5x import models
  from t5x import partitioning
  from t5x import train_state as train_state_lib
  from t5x import utils
@@ -2366,7 +2365,7 @@ index 752beb3..4eae811 100644
  import typing_extensions
  
  
-@@ -675,7 +676,7 @@ def accumulate_grads_microbatched(
+@@ -731,7 +732,7 @@ def accumulate_grads_microbatched(
    """
    batch_size = next(iter(batch.values())).shape[0]
  
@@ -2375,7 +2374,7 @@ index 752beb3..4eae811 100644
  
    # We assume that the model loss_fn supports flax mutables if and only if
    # the train state includes non-empty flax mutables.
-@@ -683,19 +684,13 @@ def accumulate_grads_microbatched(
+@@ -739,18 +740,13 @@ def accumulate_grads_microbatched(
    # them and return flax_mutables from `get_initial_variables` and `loss_fn`.
  
    initial_flax_mutables = (
@@ -2389,58 +2388,59 @@ index 752beb3..4eae811 100644
 -      (_, metrics), grad_accum = grad_fn(train_state.params, batch, dropout_rng)
 -      flax_mutables = None
 -    else:
--      (_, (metrics,
--           flax_mutables)), grad_accum = grad_fn(train_state.params, batch,
--                                                 dropout_rng,
--                                                 initial_flax_mutables)
+-      (_, (metrics, flax_mutables)), grad_accum = grad_fn(
+-          train_state.params, batch, dropout_rng, initial_flax_mutables
+-      )
 +    (_, metrics), grad_accum = grad_fn(train_state.params, batch,
 +                                       dropout_rng, initial_flax_mutables)
 +    flax_mutables=initial_flax_mutables
    else:
-     assert batch_size % num_microbatches == 0, (
-         "Batch size isn't divided evenly by num_microbatches.")
-@@ -722,13 +717,9 @@ def accumulate_grads_microbatched(
-           lambda x: partitioning.with_sharding_constraint(  # pylint: disable=g-long-lambda
-               x, data_partition_spec),
-           mbatch)
+     assert (
+         batch_size % num_microbatches == 0
+@@ -783,14 +779,9 @@ def accumulate_grads_microbatched(
+           ),
+           mbatch,
+       )
 -      if flax_mutables is None:
--        (_, metrics), grad = grad_fn(train_state.params, mbatch,
--                                     sub_dropout_rng)
+-        (_, metrics), grad = grad_fn(
+-            train_state.params, mbatch, sub_dropout_rng
+-        )
 -      else:
--        (_, (metrics, flax_mutables)), grad = grad_fn(train_state.params,
--                                                      mbatch, sub_dropout_rng,
--                                                      flax_mutables)
+-        (_, (metrics, flax_mutables)), grad = grad_fn(
+-            train_state.params, mbatch, sub_dropout_rng, flax_mutables
+-        )
 +      (_, metrics), grad = grad_fn(train_state.params, mbatch,
 +                                   sub_dropout_rng, flax_mutables)
 +
        return metrics, grad, flax_mutables
  
      def per_microbatch_train_step(
-@@ -741,7 +732,9 @@ def accumulate_grads_microbatched(
-       metrics, grad, flax_mutables = metrics_and_grad(loop_cnt, dropout_rng,
-                                                       flax_mutables)
+@@ -812,7 +803,9 @@ def accumulate_grads_microbatched(
+           loop_cnt, dropout_rng, flax_mutables
+       )
  
 -      grad_accum = jax.tree_util.tree_map(jnp.add, grad_accum, grad)
 +      grad_accum[0] = jax.tree_map(jnp.add, grad_accum[0], grad[0])
 +      grad_accum[1] = TransformerEngineHelper.update_fp8_metas(grad[1], flax_mutables)
 +      flax_mutables = grad_accum[1]
-       metrics = jax.lax.cond(loop_cnt == 0, lambda _: metrics,
-                              lambda _: merge_metrics(prev_metrics, metrics),
-                              None)
-@@ -749,8 +742,10 @@ def accumulate_grads_microbatched(
+       metrics = jax.lax.cond(
+           loop_cnt == 0,
+           lambda _: metrics,
+@@ -823,9 +816,10 @@ def accumulate_grads_microbatched(
  
      # Initialize gradient accumulation loop state.
      accum_dtype = jnp.float32
 -    grad_accum_init = jax.tree_util.tree_map(
--        lambda x: jnp.zeros(x.shape, accum_dtype), train_state.params)
-+    grad_accum_init = [jax.tree_map(lambda x: jnp.zeros(x.shape, accum_dtype),
+-        lambda x: jnp.zeros(x.shape, accum_dtype), train_state.params
+-    )
++    grad_accum_init = [jax.tree_util.tree_map(lambda x: jnp.zeros(x.shape, accum_dtype),
 +                                   train_state.params),
-+                       jax.tree_map(lambda x: jnp.zeros(x.shape, accum_dtype),
++                       jax.tree_util.tree_map(lambda x: jnp.zeros(x.shape, accum_dtype),
 +                                   train_state.flax_mutables)]
      initial_metrics_shape, _, _ = jax.eval_shape(
          metrics_and_grad,
          loop_cnt=0,
-@@ -769,6 +764,9 @@ def accumulate_grads_microbatched(
+@@ -849,6 +843,9 @@ def accumulate_grads_microbatched(
  
      del new_dropout_rng
  
@@ -2450,7 +2450,7 @@ index 752beb3..4eae811 100644
    return grad_accum, metrics, flax_mutables
  
  
-@@ -797,9 +795,12 @@ def apply_grads(
+@@ -877,9 +874,12 @@ def apply_grads(
    """
    if other_state_variables is None:
      other_state_variables = {}
@@ -2459,16 +2459,16 @@ index 752beb3..4eae811 100644
 +
    # Update optimizer using accumulated gradient.
    new_train_state = train_state.apply_gradient(
--      grad_accum, learning_rate=learning_rate, **other_state_variables)
-+      grad_accum[0], learning_rate=learning_rate, **other_state_variables)
+-      grad_accum, learning_rate=learning_rate, **other_state_variables
++      grad_accum[0], learning_rate=learning_rate, **other_state_variables
+   )
    metrics["learning_rate"] = clu.metrics.Average.from_model_output(
-       jnp.asarray([learning_rate]))
-   metrics["learning_rate/current"] = clu.metrics.LastValue.from_model_output(
+       jnp.asarray([learning_rate])
 -- 
-2.43.0
+2.25.1
 
 
-From 325f0e38720581c4f2535f3da23f40f425560138 Mon Sep 17 00:00:00 2001
+From 799af4ba3a3e974810b3b6f60dac59722d5fa0cc Mon Sep 17 00:00:00 2001
 From: Terry Kong <terryk@nvidia.com>
 Date: Tue, 11 Jul 2023 12:10:33 -0700
 Subject: [PATCH 02/18] UNINSTALL_TE in fine-tuning scripts now defaults to
@@ -2500,10 +2500,10 @@ index 388d2ec..135ecf6 100755
  # Global batch size
  BSIZE=$(( GPUS_PER_NODE * BSIZE_PER_GPU * SLURM_JOB_NUM_NODES / TP_SIZE))
 -- 
-2.43.0
+2.25.1
 
 
-From f75aa370fe5c82dc8cf2f5a3ef3bdba407b60628 Mon Sep 17 00:00:00 2001
+From 1ccdc5f74017c0e6d7f3b31a6fbace9231954eed Mon Sep 17 00:00:00 2001
 From: Terry Kong <terryk@nvidia.com>
 Date: Wed, 12 Jul 2023 20:26:28 -0700
 Subject: [PATCH 03/18] remove use_gda from LegacyCheckpointManager in train.py
@@ -2514,7 +2514,7 @@ Subject: [PATCH 03/18] remove use_gda from LegacyCheckpointManager in train.py
  1 file changed, 1 insertion(+), 2 deletions(-)
 
 diff --git a/t5x/train.py b/t5x/train.py
-index e7ee77d..7fe705c 100644
+index 972fb9c..6c9e0fa 100644
 --- a/t5x/train.py
 +++ b/t5x/train.py
 @@ -464,8 +464,7 @@ def train(
@@ -2528,10 +2528,10 @@ index e7ee77d..7fe705c 100644
    # Start warming up the input pipeline in the background. This must happen
    # after input pipeline checkpoints were restored.
 -- 
-2.43.0
+2.25.1
 
 
-From 395cf5bcca9c26f7fdaabca8541aa8368bcb8f91 Mon Sep 17 00:00:00 2001
+From 550bdc324f0e1736245e8c84dd71c95bd376d406 Mon Sep 17 00:00:00 2001
 From: Terry Kong <terryk@nvidia.com>
 Date: Tue, 18 Jul 2023 15:55:01 -0700
 Subject: [PATCH 04/18] Allow singlenode scripts to tee to stdout for better
@@ -2565,10 +2565,10 @@ index def1a1a..0d12f30 100755
 +  2>&1 | tee \
    ${LOG_DIR}/${T5_SIZE}_gpu_${NUM_GPUS}_${PREC}_gbs_${BSIZE}_fp8_${ENABLE_FP8}_fuseqkv_${FUSE_QKV}_transbs_${TRANSPOSE_BS}.log
 -- 
-2.43.0
+2.25.1
 
 
-From 7cc636157b1afd8496baea7977876124b205db9e Mon Sep 17 00:00:00 2001
+From c8622f8058a8ce2d1ba0c2547aef2115854ffa91 Mon Sep 17 00:00:00 2001
 From: Reese Wang <rewang@nvidia.com>
 Date: Fri, 14 Jul 2023 05:00:58 -0700
 Subject: [PATCH 05/18] Explicit specify self_attn_mask_type
@@ -2606,10 +2606,10 @@ index fb5f48f..f3750ca 100644
  
  class TransformerEngineHelper(TransformerEngineHelperBase):
 -- 
-2.43.0
+2.25.1
 
 
-From d17222e423d83ea2faba226fad5f6a2b1bc9307f Mon Sep 17 00:00:00 2001
+From 68d04aef4068dfe9aaa19ebe5c6acc23a0f12d57 Mon Sep 17 00:00:00 2001
 From: Terry Kong <terryk@nvidia.com>
 Date: Thu, 3 Aug 2023 14:25:22 -0700
 Subject: [PATCH 06/18] Disables check for packing by the te_helper util since
@@ -2633,10 +2633,10 @@ index f3750ca..f585752 100644
          "Transformer Engine does not support dataset.packing, please turn it off."
  
 -- 
-2.43.0
+2.25.1
 
 
-From c0448f9284bf910699dc7ecba202c2f213fa7481 Mon Sep 17 00:00:00 2001
+From 0b0f86cdf6b85980c19c9c79e3b751e401c03860 Mon Sep 17 00:00:00 2001
 From: Terry Kong <terryk@nvidia.com>
 Date: Sat, 26 Aug 2023 16:13:11 -0700
 Subject: [PATCH 07/18] Corrected T5x large baselines
@@ -2660,10 +2660,10 @@ index a9974e1..660df3a 100644
  | [T5-v1.1-xl](../t5/t5_1_1/xl.gin)       | A100 80G SXM     | bf16      | 256   | 1     | 8        | ~4322         | 16.9        | 5.5 days      | 1,408   | 91.15%             | 89.36 / 95.29      | [log](https://tensorboard.dev/experiment/vuRoEYgkRgWiEtbvgxlOqw/#scalars&_smoothingWeight=0) |[pile](../t5/t5_1_1/examples/xl_pile_pretrain.gin)
  | [T5-v1.1-xxl](../t5/t5_1_1/xxl.gin)     | A100 80G SXM     | bf16      | 512   | 8     | 36       | ~1887         | 3.69        | 12.6 days     | 6,431  |N/A(partial run)   | N/A(partial run)   |                  |[pile](../t5/t5_1_1/examples/xxl_pile_pretrain.gin)
 -- 
-2.43.0
+2.25.1
 
 
-From 443df5e4414dcbac5482fc2672e1484a554c1bd2 Mon Sep 17 00:00:00 2001
+From 5cdb9d714d95c2339052a144f86124ce1f6b3bbb Mon Sep 17 00:00:00 2001
 From: Terry Kong <terryk@nvidia.com>
 Date: Fri, 8 Sep 2023 15:09:08 -0700
 Subject: [PATCH 08/18] Add t5-large FP8 logs
@@ -2686,10 +2686,10 @@ index 660df3a..c31094d 100644
  | [T5-v1.1-xl](../t5/t5_1_1/xl.gin)       | **H100 80G SXM** | TE-fp8    | 256   | 1     | 8        | ~9688         | **37.8**    | **2.4 days**  | **614** | N/A (perf test)    | N/A (perf test)    |                 |[pile](../t5/t5_1_1/examples/xl_pile_pretrain.gin)
  
 -- 
-2.43.0
+2.25.1
 
 
-From 8494e0ba9683f1776500d0a401f29633f6b6130b Mon Sep 17 00:00:00 2001
+From cafe7f4dd662f7d8e479a0330ddc64fd864f8331 Mon Sep 17 00:00:00 2001
 From: Ming-Xu Huang <mingh@nvidia.com>
 Date: Fri, 20 Oct 2023 14:26:09 +0800
 Subject: [PATCH 09/18] Fix missing fp8_meta_collection in the eval stage.
@@ -2699,10 +2699,10 @@ Subject: [PATCH 09/18] Fix missing fp8_meta_collection in the eval stage.
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/t5x/models.py b/t5x/models.py
-index fcd9fd5..a4276ec 100644
+index 8a45977..e13cc05 100644
 --- a/t5x/models.py
 +++ b/t5x/models.py
-@@ -758,7 +758,7 @@ class EncoderDecoderModel(BaseTransformerModel):
+@@ -756,7 +756,7 @@ class EncoderDecoderModel(BaseTransformerModel):
        decoder_prompt_inputs = jnp.zeros_like(decoder_input_tokens)
  
      encoded_inputs = self.module.apply(
@@ -2712,10 +2712,10 @@ index fcd9fd5..a4276ec 100644
          enable_dropout=False,
          method=self.module.encode,
 -- 
-2.43.0
+2.25.1
 
 
-From 181087dbc71a268e4d96fbd3adb429ab630f0486 Mon Sep 17 00:00:00 2001
+From f460f4aa094dfe9e74699dcfd0e9238079363740 Mon Sep 17 00:00:00 2001
 From: Ming-Xu Huang <mingh@nvidia.com>
 Date: Fri, 20 Oct 2023 14:48:40 +0800
 Subject: [PATCH 10/18] Remove redundant code.
@@ -2725,10 +2725,10 @@ Subject: [PATCH 10/18] Remove redundant code.
  1 file changed, 17 deletions(-)
 
 diff --git a/t5x/models.py b/t5x/models.py
-index a4276ec..faeb6d0 100644
+index e13cc05..d4d2146 100644
 --- a/t5x/models.py
 +++ b/t5x/models.py
-@@ -728,23 +728,6 @@ class EncoderDecoderModel(BaseTransformerModel):
+@@ -726,23 +726,6 @@ class EncoderDecoderModel(BaseTransformerModel):
      encoder_input_tokens = batch['encoder_input_tokens']
      decoder_input_tokens = batch['decoder_input_tokens']
  
@@ -2753,10 +2753,10 @@ index a4276ec..faeb6d0 100644
      # `decoder_input_tokens`. The EOS is stripped to avoid decoding to stop
      # after the prompt by matching to `output_vocabulary.eos_id`.
 -- 
-2.43.0
+2.25.1
 
 
-From 4d051703078985ca95b23def87672513dbce9daa Mon Sep 17 00:00:00 2001
+From 90f3fb1974cf903f3ac6e2cda25b3e0bd061c566 Mon Sep 17 00:00:00 2001
 From: Ming-Xu Huang <mingh@nvidia.com>
 Date: Fri, 20 Oct 2023 15:05:40 +0800
 Subject: [PATCH 11/18] Fix deprecating warning about TE.
@@ -2805,10 +2805,10 @@ index f585752..568f596 100644
          name=name)
  
 -- 
-2.43.0
+2.25.1
 
 
-From 5fff9dc6557e084378d24fc9c14376331e7f3d3a Mon Sep 17 00:00:00 2001
+From 179b456131c43f8c21548fa0765c639b47299f9f Mon Sep 17 00:00:00 2001
 From: Terry Kong <terryk@nvidia.com>
 Date: Fri, 27 Oct 2023 09:08:10 -0700
 Subject: [PATCH 12/18] Updates TE api from te.extend_* to te.flax.extend_*
@@ -2833,10 +2833,10 @@ index 568f596..05c5f6b 100644
    @staticmethod
    def update_fp8_metas(grad_accum, flax_mutables):
 -- 
-2.43.0
+2.25.1
 
 
-From e36be07a36c476545a5bbbb59e5c7a44419deb02 Mon Sep 17 00:00:00 2001
+From ddade2beb9db4df05161a7dca26012b94ba9c4c6 Mon Sep 17 00:00:00 2001
 From: Terry Kong <terryk@nvidia.com>
 Date: Tue, 31 Oct 2023 21:52:22 -0700
 Subject: [PATCH 13/18] Adds ENABLE_TE env var and renames TEConfig.enabled ->
@@ -2996,10 +2996,10 @@ index 05c5f6b..7657c52 100644
      return TENotInstalledHelper
  
 -- 
-2.43.0
+2.25.1
 
 
-From 4b8a1ad34509a5f62dea7ce0d3efef87e2a4e9d1 Mon Sep 17 00:00:00 2001
+From 539af9ab177d2eafcb493b0800d1a3c76991accb Mon Sep 17 00:00:00 2001
 From: Ming-Xu Huang <mingh@nvidia.com>
 Date: Tue, 7 Nov 2023 10:57:34 +0800
 Subject: [PATCH 14/18] Adapting to TE/JAX/Custom_partitioning.
@@ -3032,10 +3032,10 @@ index 7657c52..b064d2b 100644
  
    @staticmethod
 -- 
-2.43.0
+2.25.1
 
 
-From d08a6847857b6549ed8bfe1441d3742a6a13ac08 Mon Sep 17 00:00:00 2001
+From a4cb6d657dd22520a36238706f18bee9a78ff3ca Mon Sep 17 00:00:00 2001
 From: Ming-Xu Huang <mingh@nvidia.com>
 Date: Wed, 22 Nov 2023 13:53:49 +0800
 Subject: [PATCH 15/18] Running Partitioner.compile within Mesh context-manager
@@ -3045,10 +3045,10 @@ Subject: [PATCH 15/18] Running Partitioner.compile within Mesh context-manager
  1 file changed, 8 insertions(+), 1 deletion(-)
 
 diff --git a/t5x/partitioning.py b/t5x/partitioning.py
-index 2ae6e7a..d9ba8bd 100644
+index 4920866b..b74c667 100644
 --- a/t5x/partitioning.py
 +++ b/t5x/partitioning.py
-@@ -783,6 +783,13 @@ class PjittedFnWithContext(PartitionedCallable):
+@@ -960,6 +960,13 @@ class PjittedFnWithContext(PartitionedCallable):
                    self._logical_axis_rules):
        return self._pjitted_fn.lower(*args, **kwargs)
  
@@ -3062,7 +3062,7 @@ index 2ae6e7a..d9ba8bd 100644
  
  class BasePjitPartitioner(BasePartitioner):
    """Partitioner that uses T5X version of jax.pjit."""
-@@ -816,7 +823,7 @@ class BasePjitPartitioner(BasePartitioner):
+@@ -998,7 +1005,7 @@ class BasePjitPartitioner(BasePartitioner):
  
    def compile(self, partitioned_fn: PjittedFnWithContext,
                *args) -> CompiledPartitionedCallable:
@@ -3072,10 +3072,10 @@ index 2ae6e7a..d9ba8bd 100644
  
  class PjitPartitioner(BasePjitPartitioner):
 -- 
-2.43.0
+2.25.1
 
 
-From a08b8bf78e14c288d6d7a66ad17a9bea69044cd7 Mon Sep 17 00:00:00 2001
+From 7d57626b2e365de38cff67d64057391607245da6 Mon Sep 17 00:00:00 2001
 From: Terry Kong <terryk@nvidia.com>
 Date: Tue, 14 Nov 2023 23:42:35 -0800
 Subject: [PATCH 16/18] Updates multiprocessing scripts to use SLURM output
@@ -3549,10 +3549,10 @@ index d083540..56919a5 100755
 -set +x
 +echo Finished
 -- 
-2.43.0
+2.25.1
 
 
-From 74d742f053dabbe594637ad1f481237a23065512 Mon Sep 17 00:00:00 2001
+From 5f2eb486f184427a0cdff3052aa574a74c67f742 Mon Sep 17 00:00:00 2001
 From: ashors1 <71393111+ashors1@users.noreply.github.com>
 Date: Wed, 6 Dec 2023 14:56:45 -0800
 Subject: [PATCH 17/18] Force initial flax mutables to be a frozen dict (#11)
@@ -3562,10 +3562,10 @@ Subject: [PATCH 17/18] Force initial flax mutables to be a frozen dict (#11)
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/t5x/trainer.py b/t5x/trainer.py
-index 4eae811..6dcce29 100644
+index 7b3bab7..e297ab8 100644
 --- a/t5x/trainer.py
 +++ b/t5x/trainer.py
-@@ -684,7 +684,7 @@ def accumulate_grads_microbatched(
+@@ -740,7 +740,7 @@ def accumulate_grads_microbatched(
    # them and return flax_mutables from `get_initial_variables` and `loss_fn`.
  
    initial_flax_mutables = (
@@ -3575,10 +3575,10 @@ index 4eae811..6dcce29 100644
  
    if num_microbatches is None or num_microbatches <= 1:
 -- 
-2.43.0
+2.25.1
 
 
-From 4d5ec2fe4a665142de514ad08544c54ab4be6133 Mon Sep 17 00:00:00 2001
+From 79bf05301611a4b72df3535e40677bb6c722bdd1 Mon Sep 17 00:00:00 2001
 From: ashors1 <ashors@nvidia.com>
 Date: Thu, 28 Dec 2023 07:24:33 -0800
 Subject: [PATCH 18/18] update rng dtype in predict_batch
@@ -3588,10 +3588,10 @@ Subject: [PATCH 18/18] update rng dtype in predict_batch
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/t5x/models.py b/t5x/models.py
-index faeb6d0..a48b068 100644
+index d4d2146..64565b1 100644
 --- a/t5x/models.py
 +++ b/t5x/models.py
-@@ -640,7 +640,7 @@ class EncoderDecoderModel(BaseTransformerModel):
+@@ -638,7 +638,7 @@ class EncoderDecoderModel(BaseTransformerModel):
    def predict_batch(self,
                      params: PyTreeDef,
                      batch: Mapping[str, jnp.ndarray],
@@ -3601,5 +3601,5 @@ index faeb6d0..a48b068 100644
      """Predicts a batch of outputs from the model.
  
 -- 
-2.43.0
+2.25.1
 


### PR DESCRIPTION
Replaces `mirror/ashors/fix_rng_dtype` with `mirror/patch/t5x_te_in_contrib_noindent` and updates the manifest