### PR TITLE
Fix base build frequency

### DIFF
--- a/.github/workflows/_build_base.yaml
+++ b/.github/workflows/_build_base.yaml
@@ -37,6 +37,10 @@ on:
         description: 'User email in GIT to perform git pull/push'
         required: false
         default: 'jax@nvidia.com'
+      TRIAL_BRANCH:
+        type: string
+        description: 'Name of branch with bumped manifest and patches'
+        required: true
 
     outputs:
       DOCKER_TAG:
@@ -65,6 +69,9 @@ jobs:
 
       - name: Check out the repository under ${GITHUB_WORKSPACE}
         uses: actions/checkout@v3
+        with:
+          ref: ${{ inputs.TRIAL_BRANCH }}
+
 
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v2

--- a/.github/workflows/_build_jax.yaml
+++ b/.github/workflows/_build_jax.yaml
@@ -37,10 +37,6 @@ on:
         description: 'User email in GIT to perform git pull/push'
         required: false
         default: 'jax@nvidia.com'
-      TRIAL_BRANCH:
-        type: string
-        description: 'Name of branch with bumped manifest and patches'
-        required: true
     outputs:
       DOCKER_TAG_MEALKIT:
         description: "Tags of the 'mealkit' image built"
@@ -87,8 +83,6 @@ jobs:
 
       - name: Check out the repository under ${GITHUB_WORKSPACE}
         uses: actions/checkout@v3
-        with:
-          ref: ${{ inputs.TRIAL_BRANCH }}
 
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v2

--- a/.github/workflows/_ci.yaml
+++ b/.github/workflows/_ci.yaml
@@ -1,4 +1,4 @@
-name: CI
+name: ~CI, single-arch
 run-name: CI-${{ inputs.ARCHITECTURE }}
 
 on:

--- a/.github/workflows/_ci.yaml
+++ b/.github/workflows/_ci.yaml
@@ -56,6 +56,7 @@ jobs:
     with:
       ARCHITECTURE: ${{ inputs.ARCHITECTURE }}
       BUILD_DATE: ${{ needs.metadata.outputs.BUILD_DATE }}
+      TRIAL_BRANCH: ${{ inputs.TRIAL_BRANCH }}
     secrets: inherit
 
   build-jax:
@@ -65,7 +66,6 @@ jobs:
       ARCHITECTURE: ${{ inputs.ARCHITECTURE }}
       BUILD_DATE: ${{ needs.metadata.outputs.BUILD_DATE }}
       BASE_IMAGE: ${{ needs.build-base.outputs.DOCKER_TAG }}
-      TRIAL_BRANCH: ${{ inputs.TRIAL_BRANCH }}
     secrets: inherit
 
   build-t5x:

--- a/.github/workflows/nightly-base-build.yaml
+++ b/.github/workflows/nightly-base-build.yaml
@@ -38,20 +38,62 @@ jobs:
         run: |
           echo "PUBLISH=${{ github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && inputs.PUBLISH) }}" >> $GITHUB_OUTPUT
 
-  amd64:
+  bump-world-state:
     needs: metadata
+    outputs:
+      TRIAL_BRANCH: ${{ steps.trial-meta.outputs.TRIAL_BRANCH }}
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Check out the repository under ${GITHUB_WORKSPACE}
+        uses: actions/checkout@v3
+      - name: Update manifest and patches in-place - show diff
+        working-directory: .github/container
+        shell: bash -x -e {0}
+        run: |
+          bash bump.sh --input-manifest manifest.yaml
+          git diff
+      - name: Push trial branch
+        id: trial-meta
+        if: needs.metadata.outputs.PUBLISH == 'true'
+        shell: bash -x -e {0}
+        run: |
+          git config user.name "JAX-Toolbox CI"
+          git config user.email "jax@nvidia.com"
+          # Prepend trial branch with "z" to make it appear at the end
+          trial_branch=znightly-${{ needs.metadata.outputs.BUILD_DATE }}-${{ github.run_id }}
+          git switch -c $trial_branch
+          git status
+          git add -u
+          git add .github/container/patches/
+          git status
+          git commit -m "generated ${{github.run_id }}"
+          git push --set-upstream origin $trial_branch
+
+          echo "$trial_branch" > ./trial-branch.txt
+          echo TRIAL_BRANCH=$trial_branch | tee $GITHUB_OUTPUT
+      - name: 'Upload trial branch artifact'
+        if: needs.metadata.outputs.PUBLISH == 'true'
+        uses: actions/upload-artifact@v3
+        with:
+          name: trial-branch
+          path: trial-branch.txt
+
+  amd64:
+    needs: [metadata, bump-world-state]
     uses: ./.github/workflows/_build_base.yaml
     with:
       ARCHITECTURE: amd64
       BUILD_DATE: ${{ needs.metadata.outputs.BUILD_DATE }}
+      TRIAL_BRANCH: ${{ needs.bump-world-state.outputs.TRIAL_BRANCH }}
     secrets: inherit
 
   arm64:
-    needs: metadata
+    needs: [metadata, bump-world-state]
     uses: ./.github/workflows/_build_base.yaml
     with:
       ARCHITECTURE: arm64
       BUILD_DATE: ${{ needs.metadata.outputs.BUILD_DATE }}
+      TRIAL_BRANCH: ${{ needs.bump-world-state.outputs.TRIAL_BRANCH }}
     secrets: inherit
 
   publish:

--- a/.github/workflows/nightly-base-build.yaml
+++ b/.github/workflows/nightly-base-build.yaml
@@ -1,9 +1,9 @@
-name: Weekly base container build
-run-name: Weekly base container build (${{ github.event_name == 'workflow_run' && format('nightly {0}', github.event.workflow_run.created_at) || github.event_name }})
+name: Nightly base container build
+run-name: Nightly base container build (${{ github.event_name == 'workflow_run' && format('nightly {0}', github.event.workflow_run.created_at) || github.event_name }})
 
 on:
   schedule:
-    - cron: '30 13 * * 5'  # 5:30 AM every Friday
+    - cron: '30 9 * * *'  # Pacific Time 01:30 AM in UTC
   workflow_dispatch:
     inputs:
       PUBLISH:

--- a/.github/workflows/nightly-jax-build.yaml
+++ b/.github/workflows/nightly-jax-build.yaml
@@ -45,46 +45,6 @@ jobs:
         run: |
           echo "PUBLISH=${{ github.event_name == 'workflow_run' || (github.event_name == 'workflow_dispatch' && inputs.PUBLISH) }}" >> $GITHUB_OUTPUT
 
-  bump-world-state:
-    needs: metadata
-    outputs:
-      TRIAL_BRANCH: ${{ steps.trial-meta.outputs.TRIAL_BRANCH }}
-    runs-on: ubuntu-22.04
-    steps:
-      - name: Check out the repository under ${GITHUB_WORKSPACE}
-        uses: actions/checkout@v3
-      - name: Update manifest and patches in-place - show diff
-        working-directory: .github/container
-        shell: bash -x -e {0}
-        run: |
-          bash bump.sh --input-manifest manifest.yaml
-          git diff
-      - name: Push trial branch
-        id: trial-meta
-        if: needs.metadata.outputs.PUBLISH == 'true'
-        shell: bash -x -e {0}
-        run: |
-          git config user.name "JAX-Toolbox CI"
-          git config user.email "jax@nvidia.com"
-          # Prepend trial branch with "z" to make it appear at the end
-          trial_branch=znightly-${{ needs.metadata.outputs.BUILD_DATE }}-${{ github.run_id }}
-          git switch -c $trial_branch
-          git status
-          git add -u
-          git add .github/container/patches/
-          git status
-          git commit -m "generated ${{github.run_id }}"
-          git push --set-upstream origin $trial_branch
-
-          echo "$trial_branch" > ./trial-branch.txt
-          echo TRIAL_BRANCH=$trial_branch | tee $GITHUB_OUTPUT
-      - name: 'Upload trial branch artifact'
-        if: needs.metadata.outputs.PUBLISH == 'true'
-        uses: actions/upload-artifact@v3
-        with:
-          name: trial-branch
-          path: trial-branch.txt
-
   amd64:
     needs: [metadata, bump-world-state]
     uses: ./.github/workflows/_build_jax.yaml
@@ -92,7 +52,6 @@ jobs:
       ARCHITECTURE: amd64
       BASE_IMAGE: ${{ inputs.BASE_IMAGE || 'ghcr.io/nvidia/jax-toolbox:base' }}
       BUILD_DATE: ${{ needs.metadata.outputs.BUILD_DATE }}
-      TRIAL_BRANCH: ${{ needs.bump-world-state.outputs.TRIAL_BRANCH }}
     secrets: inherit
 
   arm64:
@@ -102,7 +61,6 @@ jobs:
       ARCHITECTURE: arm64
       BASE_IMAGE: ${{ inputs.BASE_IMAGE || 'ghcr.io/nvidia/jax-toolbox:base' }}
       BUILD_DATE: ${{ needs.metadata.outputs.BUILD_DATE }}
-      TRIAL_BRANCH: ${{ needs.bump-world-state.outputs.TRIAL_BRANCH }}
     secrets: inherit
 
   publish-mealkit:

--- a/.github/workflows/nightly-jax-build.yaml
+++ b/.github/workflows/nightly-jax-build.yaml
@@ -2,8 +2,10 @@ name: Nightly JAX build
 run-name: Nightly JAX build (${{ github.event_name == 'workflow_run' && format('nightly {0}', github.event.workflow_run.created_at) || github.event_name }})
 
 on:
-  schedule:
-    - cron: '30 9 * * *'  # Pacific Time 01:30 AM in UTC
+  workflow_run:
+    workflows: [Nightly base container build]
+    types: [completed]
+    branches: [main]
   workflow_dispatch:
     inputs:
       BASE_IMAGE:
@@ -41,7 +43,7 @@ jobs:
         id: if-publish
         shell: bash -x -e {0}
         run: |
-          echo "PUBLISH=${{ github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && inputs.PUBLISH) }}" >> $GITHUB_OUTPUT
+          echo "PUBLISH=${{ github.event_name == 'workflow_run' || (github.event_name == 'workflow_dispatch' && inputs.PUBLISH) }}" >> $GITHUB_OUTPUT
 
   bump-world-state:
     needs: metadata


### PR DESCRIPTION
As we moved manifest file to base container (https://github.com/NVIDIA/JAX-Toolbox/pull/456), we need to build a base container nightly (and make it as a trigger for other nightly builds), bump manifest file and create a trial branch in the nightly base build.