### PR TITLE
Provides a workaround for checkpointing, which doesn't work in 23.10 if you are using a sentencepiece tokenizer

### DIFF
--- a/rosetta/rosetta/projects/t5x/Dockerfile.fix-ckpt
+++ b/rosetta/rosetta/projects/t5x/Dockerfile.fix-ckpt
@@ -1,0 +1,4 @@
+FROM nvcr.io/nvidia/jax:23.10-t5x-py3
+
+RUN pip install tensorflow-cpu==2.12.0 tensorflow-text==2.12.1 chex==0.1.7 -e /opt/transformer-engine
+

--- a/rosetta/rosetta/projects/t5x/README.md
+++ b/rosetta/rosetta/projects/t5x/README.md
@@ -198,6 +198,8 @@ t5x/contrib/gpu/scripts_gpu/singlenode_ft_frompile.sh \
 # Known Issues
 * There is a known sporadic NCCL crash that happens when using the T5x container at node counts greater than or equal to 32 nodes. We will fix this in the next release. The issue is tracked [here](https://github.com/NVIDIA/JAX-Toolbox/issues/194).
 * The T5x nightlies disable `NCCL_NVLS_ENABLE=0` ([doc](https://docs.nvidia.com/deeplearning/nccl/user-guide/docs/env.html#nccl-nvls-enable)). Future releases will re-enable this feature.
+* Checkpointing in `nvcr.io/nvidia/jax:23.10-t5x.py3` does not work with the `tensorflow-cpu`/`tensorflow-text` version chosen by `pip`. This issue arises if you are
+using sentencepiece tokenizers, which is the case for the_pile. As a work around, you can build an image on top of the 23.10 container using [this dockerfile](Dockerfile.fix-ckpt).
 
 # Changelog
 - Added Transformer Engine + FP8 support


### PR DESCRIPTION
This issue was discovered when checkpointing was enabled. The tensorflow version was 2.14 in the 23.10 release container which did not work with the SentencepieceOp, so the WAR is to downgrade to 2.12. This PR backports this to the 23.10 docs and provides a dockerfile that downgrades TF.