### PR TITLE
optax: fix default branch name

### DIFF
--- a/.github/container/bump.sh
+++ b/.github/container/bump.sh
@@ -82,7 +82,10 @@ for pkg in $(yq e 'keys | .[]' $MANIFEST_OUT); do
     if [[ $mode == git-clone || $mode == pip-vcs ]] && [[ $SKIP_BUMP_REFS -eq 0 ]]; then
         url=$(yq e ".${pkg}.url" $MANIFEST_OUT)
         tracking_ref=$(yq e ".${pkg}.tracking_ref" $MANIFEST_OUT)
-        new_ref=$(git ls-remote $url $tracking_ref | awk '{print $1}')
+        if ! new_ref=$(git ls-remote --exit-code $url $tracking_ref | awk '{print $1}'); then
+	    echo "Could not fetch $tracking_ref from $url"
+	    exit 1
+	fi
         yq e ".${pkg}.latest_verified_commit = \"$new_ref\"" -i $MANIFEST_OUT
     fi
 

--- a/.github/container/manifest.yaml
+++ b/.github/container/manifest.yaml
@@ -92,8 +92,8 @@ jestimator:
   latest_verified_commit: fa143d93e337ca8ab77c4510baf21ae52af24ab2
   mode: pip-vcs
 optax:
-  url: https://github.com/deepmind/optax.git
-  tracking_ref: master
+  url: https://github.com/google-deepmind/optax.git
+  tracking_ref: main
   latest_verified_commit: bc22961422eb2397a4639ec945da0bea73d624d6
   mode: pip-vcs
 seqio:


### PR DESCRIPTION
Also make `bump.sh` error out on this condition. This should fix nightly failures like https://github.com/NVIDIA/JAX-Toolbox/actions/runs/7554061462/job/20566150888#step:10:985 .