### PR TITLE
Adds a build arg to allow overriding TE when building rosetta images

### DIFF
--- a/rosetta/Dockerfile.pax
+++ b/rosetta/Dockerfile.pax
@@ -7,7 +7,7 @@ ARG GIT_USER_NAME=NVIDIA
 # the way up to the jax build.
 ARG UPDATE_PATCHES=false
 # It is common for TE developers to test a different TE against the LLM application. This is a knob to override what's in the manifest
-# Accepts are git-ref's from NVIDIA/TransformerEngine or pull requests (pull/$number/head)
+# Accepts git-ref's from NVIDIA/TransformerEngine or pull requests (pull/$number/head)
 ARG UPDATED_TE_REF=""
 
 # Rosetta and optionally patches are pulled from this

--- a/rosetta/Dockerfile.pax
+++ b/rosetta/Dockerfile.pax
@@ -6,6 +6,9 @@ ARG GIT_USER_NAME=NVIDIA
 # This is useful for development if you run `./bump.sh -i manifest.yaml` manually and do not want to trigger a full rebuild all
 # the way up to the jax build.
 ARG UPDATE_PATCHES=false
+# It is common for TE developers to test a different TE against the LLM application. This is a knob to override what's in the manifest
+# Accepts are git-ref's from NVIDIA/TransformerEngine or pull requests (pull/$number/head)
+ARG UPDATED_TE_REF=""
 
 # Rosetta and optionally patches are pulled from this
 FROM scratch AS jax-toolbox
@@ -18,6 +21,7 @@ FROM ${BASE_IMAGE} AS mealkit
 ARG GIT_USER_EMAIL
 ARG GIT_USER_NAME
 ARG UPDATE_PATCHES
+ARG UPDATED_TE_REF
 
 ENV ENABLE_TE=1
 
@@ -35,6 +39,21 @@ if [[ "${UPDATE_PATCHES}" == "true" ]]; then
   cp /mnt/jax-toolbox/.github/container/pip-finalize.sh /usr/local/bin/
 fi
 cp -r /mnt/jax-toolbox/rosetta /opt/rosetta
+
+if [[ -n "${UPDATED_TE_REF}" ]]; then
+  TE_INSTALL_DIR=/opt/transformer-engine
+  yq e ".transformer-engine.latest_verified_commit = \"${UPDATED_TE_REF}\"" -i $MANIFEST_FILE
+  # Install from source instead of pre-built wheel
+  sed -i -E 's@( file:///opt/transformer-engine)/dist/[^ ]*@\1@' /opt/pip-tools.d/requirements-te.in
+  git -C $TE_INSTALL_DIR fetch -a
+  if [[ "${UPDATED_TE_REF}" =~ ^pull/ ]]; then
+    PR_ID=$(cut -d/ -f2 <<<"${UPDATED_TE_REF}")
+    git -C $TE_INSTALL_DIR fetch origin ${UPDATED_TE_REF}:PR-${PR_ID}
+    git -C $TE_INSTALL_DIR checkout PR-${PR_ID}
+  else
+    git -C $TE_INSTALL_DIR checkout ${UPDATED_TE_REF}
+  fi
+fi
 
 # Setting the username/email is required to author commits from patches
 git config --global user.email "${GIT_USER_EMAIL}"

--- a/rosetta/Dockerfile.t5x
+++ b/rosetta/Dockerfile.t5x
@@ -7,7 +7,7 @@ ARG GIT_USER_NAME=NVIDIA
 # the way up to the jax build.
 ARG UPDATE_PATCHES=false
 # It is common for TE developers to test a different TE against the LLM application. This is a knob to override what's in the manifest
-# Accepts are git-ref's from NVIDIA/TransformerEngine or pull requests (pull/$number/head)
+# Accepts git-ref's from NVIDIA/TransformerEngine or pull requests (pull/$number/head)
 ARG UPDATED_TE_REF=""
 
 # Rosetta and optionally patches are pulled from this

--- a/rosetta/Dockerfile.t5x
+++ b/rosetta/Dockerfile.t5x
@@ -6,6 +6,9 @@ ARG GIT_USER_NAME=NVIDIA
 # This is useful for development if you run `./bump.sh -i manifest.yaml` manually and do not want to trigger a full rebuild all
 # the way up to the jax build.
 ARG UPDATE_PATCHES=false
+# It is common for TE developers to test a different TE against the LLM application. This is a knob to override what's in the manifest
+# Accepts are git-ref's from NVIDIA/TransformerEngine or pull requests (pull/$number/head)
+ARG UPDATED_TE_REF=""
 
 # Rosetta and optionally patches are pulled from this
 FROM scratch AS jax-toolbox
@@ -18,6 +21,7 @@ FROM ${BASE_IMAGE} AS mealkit
 ARG GIT_USER_EMAIL
 ARG GIT_USER_NAME
 ARG UPDATE_PATCHES
+ARG UPDATED_TE_REF
 
 ENV ENABLE_TE=1
 
@@ -35,6 +39,21 @@ if [[ "${UPDATE_PATCHES}" == "true" ]]; then
   cp /mnt/jax-toolbox/.github/container/pip-finalize.sh /usr/local/bin/
 fi
 cp -r /mnt/jax-toolbox/rosetta /opt/rosetta
+
+if [[ -n "${UPDATED_TE_REF}" ]]; then
+  TE_INSTALL_DIR=/opt/transformer-engine
+  yq e ".transformer-engine.latest_verified_commit = \"${UPDATED_TE_REF}\"" -i $MANIFEST_FILE
+  # Install from source instead of pre-built wheel
+  sed -i -E 's@( file:///opt/transformer-engine)/dist/[^ ]*@\1@' /opt/pip-tools.d/requirements-te.in
+  git -C $TE_INSTALL_DIR fetch -a
+  if [[ "${UPDATED_TE_REF}" =~ ^pull/ ]]; then
+    PR_ID=$(cut -d/ -f2 <<<"${UPDATED_TE_REF}")
+    git -C $TE_INSTALL_DIR fetch origin ${UPDATED_TE_REF}:PR-${PR_ID}
+    git -C $TE_INSTALL_DIR checkout PR-${PR_ID}
+  else
+    git -C $TE_INSTALL_DIR checkout ${UPDATED_TE_REF}
+  fi
+fi
 
 # Setting the username/email is required to author commits from patches
 git config --global user.email "${GIT_USER_EMAIL}"

--- a/rosetta/README.md
+++ b/rosetta/README.md
@@ -17,14 +17,17 @@ docker buildx build --build-context jax-toolbox=. --tag rosetta-${ROSETTA_BASE}:
 ```
 
 ### Advanced use-cases
+
+#### Build with updated patches
 ```sh
-# If you want to build with updated patches
-cd JAX-Toolbox
-
-ROSETTA_BASE=pax
-
 bash .github/container/bump.sh -i .github/container/manifest.yaml
 docker buildx build --build-context jax-toolbox=. --tag rosetta-${ROSETTA_BASE}:latest -f rosetta/Dockerfile.${ROSETTA_BASE} --build-arg UPDATE_PATCHES=true .
+```
+
+#### Build and force update TE
+Updating TE supports any git-ref including pull requests (e.g., `pull/PR_NUM/head`)
+```sh
+docker buildx build --build-arg UPDATED_TE_REF=pull/609/head --build-context jax-toolbox=. --tag rosetta-${ROSETTA_BASE}:latest -f rosetta/Dockerfile.${ROSETTA_BASE} .
 ```
 
 ## Development

--- a/rosetta/README.md
+++ b/rosetta/README.md
@@ -25,7 +25,7 @@ docker buildx build --build-context jax-toolbox=. --tag rosetta-${ROSETTA_BASE}:
 ```
 
 #### Build and force update TE
-Updating TE supports any git-ref including pull requests (e.g., `pull/PR_NUM/head`)
+Supports any git-ref on [NVIDIA/TransformerEngine](https://github.com/NVIDIA/TransformerEngine) including pull requests (e.g., `pull/PR_NUM/head`)
 ```sh
 docker buildx build --build-arg UPDATED_TE_REF=pull/609/head --build-context jax-toolbox=. --tag rosetta-${ROSETTA_BASE}:latest -f rosetta/Dockerfile.${ROSETTA_BASE} .
 ```


### PR DESCRIPTION
This code path is not used in the nightly/presubmit CI and only used internally for testing new changes.

The instructions were updated to demonstrate how to use this, but here are example build invocations to validate:
```sh
ROSETTA_BASE=pax

# vanilla
docker buildx build --build-context jax-toolbox=. --tag rosetta-${ROSETTA_BASE}:latest -f rosetta/Dockerfile.${ROSETTA_BASE} --build-arg BASE_IMAGE=ghcr.io/nvidia/upstream-${ROSETTA_BASE}:mealkit-2024-01-13 .

# branch
docker buildx build --build-arg UPDATED_TE_REF=release_v1.3 --build-context jax-toolbox=. --tag rosetta-pax:test-te-branch -f rosetta/Dockerfile.${ROSETTA_BASE} --build-arg BASE_IMAGE=ghcr.io/nvidia/upstream-${ROSETTA_BASE}:mealkit-2024-01-13 .

# pull-request
docker buildx build --build-arg UPDATED_TE_REF=pull/609/head --build-context jax-toolbox=. --tag rosetta-pax:test-te-pr -f rosetta/Dockerfile.${ROSETTA_BASE} --build-arg BASE_IMAGE=ghcr.io/nvidia/upstream-${ROSETTA_BASE}:mealkit-2024-01-13 .

```