### PR TITLE
[Draft] Make the t5x container work on Aarch64 (v3)

### DIFF
--- a/.github/container/Dockerfile.t5x.arm64
+++ b/.github/container/Dockerfile.t5x.arm64
@@ -11,13 +11,25 @@ ARG SRC_PATH_T5X=/opt/t5x
 ###############################################################################
 
 #------------------------------------------------------------------------------
+# Install bazel (needed by some source builds) and expose the python version
+#------------------------------------------------------------------------------
+
+FROM ${BASE_IMAGE} as wheel-builder
+
+RUN wget https://github.com/bazelbuild/bazelisk/releases/download/v1.17.0/bazelisk-linux-arm64 -O /usr/bin/bazel && \
+    chmod a+x /usr/bin/bazel
+
+RUN python -c 'import sys; vi = sys.version_info; print(f"{vi.major}.{vi.minor}")'  > /mealkit-python-version
+
+
+#------------------------------------------------------------------------------
 # build array_record 0.5.0 from source
 #------------------------------------------------------------------------------
 # TODO: Remove this once array_record maintainers have published an arm64 wheel.
 
 FROM linaro/tensorflow-arm64-build:2.12-multipython as array_record-builder
-# TODO: Infer PYTHON_VERSION from our own $BASE_IMAGE?
-ARG PYTHON_VERSION="3.10"
+
+COPY --from=wheel-builder /mealkit-python-version /mealkit-python-version
 
 # The bazel build of array_record makes some strong assumptions on where the cpp toolchain lives.
 # We therefore replicate (part of) its Dockerfile, which ensures everything is in the right place:
@@ -25,10 +37,11 @@ ARG PYTHON_VERSION="3.10"
 #
 # BEGIN
     ENV DEBIAN_FRONTEND=noninteractive
-    ENV PYTHON_BIN_PATH=/usr/bin/python${PYTHON_VERSION}
+    ENV PYTHON_BIN_PATH=/usr/bin/python${MEALKIT_PYTHON_VERSION}
 
     # Install supplementary Python interpreters
-    RUN ln -s ${PYTHON_BIN_PATH} /usr/local/bin/python && \
+    RUN export PYTHON_BIN_PATH=/usr/bin/python$(cat /mealkit-python-version) && \
+        ln -s ${PYTHON_BIN_PATH} /usr/local/bin/python && \
         ln -s ${PYTHON_BIN_PATH} /usr/local/bin/python3 && \
         ln -s ${PYTHON_BIN_PATH} /usr/bin/python
 
@@ -40,8 +53,8 @@ ARG PYTHON_VERSION="3.10"
             libffi-dev
 
     # Install pip dependencies needed for array_record
-    RUN ${PYTHON_BIN_PATH} -m pip install -U pip && \
-        ${PYTHON_BIN_PATH} -m pip install -U \
+    RUN /usr/bin/python -m pip install -U pip && \
+        /usr/bin/python -m pip install -U \
             absl-py \
             auditwheel \
             etils[epath] \
@@ -65,23 +78,11 @@ EOT
 
 
 #------------------------------------------------------------------------------
-# intermediate stage that adds bazel (needed by both tftext and grain)
-#------------------------------------------------------------------------------
-
-ARG BASE_IMAGE
-FROM ${BASE_IMAGE} as wheel-builder
-
-RUN wget https://github.com/bazelbuild/bazelisk/releases/download/v1.17.0/bazelisk-linux-arm64 -O /usr/bin/bazel && \
-    chmod a+x /usr/bin/bazel
-
-
-#------------------------------------------------------------------------------
 # build grain from a manually-patched version
 #------------------------------------------------------------------------------
 # TODO: Remove this once grain maintainers have published an arm64 wheel.
 
 FROM wheel-builder as grain-builder
-ARG PYTHON_VERSION="3.10"
 
 # Setup bazel
 RUN  wget https://github.com/bazelbuild/bazelisk/releases/download/v1.17.0/bazelisk-linux-arm64 -O /usr/bin/bazel && \
@@ -92,11 +93,12 @@ RUN  wget https://github.com/bazelbuild/bazelisk/releases/download/v1.17.0/bazel
 #
 # BEGIN
     # Setup python
-    RUN apt-get update && apt-get install -y \
+    RUN export MEALKIT_PYTHON_VERSION=$(cat /mealkit-python-version) && \
+        apt-get update && apt-get install -y \
             python3-dev python3-pip python3-venv && \
             rm -rf /var/lib/apt/lists/* && \
-            python${PYTHON_VERSION} -m pip install pip --upgrade && \
-            update-alternatives --install /usr/bin/python python /usr/bin/python${PYTHON_VERSION} 0
+            python${MEALKIT_PYTHON_VERSION} -m pip install pip --upgrade && \
+            update-alternatives --install /usr/bin/python python /usr/bin/python${MEALKIT_PYTHON_VERSION} 0
 
     # Install pip dependencies needed for grain
     # NOTE: We are ignoring the fact that "array_record" will actually resolve to the wrong version
@@ -132,6 +134,7 @@ git clone https://github.com/gspschmid/grain /opt/grain
 cd /opt/grain
 git checkout external-arm64-build-poc
 
+export PYTHON_VERSION=$(cat /mealkit-python-version)
 chmod a+x ./grain/oss/build_whl.sh
 ./grain/oss/build_whl.sh
 

--- a/.github/container/Dockerfile.t5x.arm64
+++ b/.github/container/Dockerfile.t5x.arm64
@@ -3,10 +3,11 @@
 #   docker buildx build -f Dockerfile.t5x.arm64 --tag t5x --build-arg BASE_IMAGE=ghcr.io/nvidia/jax:mealkit-2024-01-22 .
 
 ARG BASE_IMAGE=ghcr.io/nvidia/jax:mealkit
+ARG SRC_PATH_TFTEXT=/opt/tensorflow-text
 ARG SRC_PATH_T5X=/opt/t5x
 
 ###############################################################################
-## build array_record and grain which do not have working arm64 pip wheels
+## build several packages which do not have working arm64 pip wheels
 ###############################################################################
 
 #------------------------------------------------------------------------------
@@ -64,11 +65,22 @@ EOT
 
 
 #------------------------------------------------------------------------------
+# intermediate stage that adds bazel (needed by both tftext and grain)
+#------------------------------------------------------------------------------
+
+ARG BASE_IMAGE
+FROM ${BASE_IMAGE} as wheel-builder
+
+RUN wget https://github.com/bazelbuild/bazelisk/releases/download/v1.17.0/bazelisk-linux-arm64 -O /usr/bin/bazel && \
+    chmod a+x /usr/bin/bazel
+
+
+#------------------------------------------------------------------------------
 # build grain from a manually-patched version
 #------------------------------------------------------------------------------
 # TODO: Remove this once grain maintainers have published an arm64 wheel.
 
-FROM ${BASE_IMAGE} as grain-builder
+FROM wheel-builder as grain-builder
 ARG PYTHON_VERSION="3.10"
 
 # Setup bazel
@@ -127,47 +139,36 @@ ls /tmp/grain/all_dist/*.whl
 EOT
 
 
-###############################################################################
-## T5X for AArch64
-###############################################################################
+#------------------------------------------------------------------------------
+# build tensorflow-text 2.13.0 from source
+#------------------------------------------------------------------------------
 
-ARG BASE_IMAGE
-FROM ${BASE_IMAGE} as mealkit
-ARG SRC_PATH_T5X
-
-COPY --from=array_record-builder /tmp/array_record/all_dist/array_record*linux_aarch64.whl /opt/
-RUN echo "array_record @ file://$(ls /opt/array_record*.whl)" >> /opt/pip-tools.d/requirements-t5x.in
-
-COPY --from=grain-builder /tmp/grain/all_dist/grain*.whl /opt/
-RUN echo "grain @ file://$(ls /opt/grain*.whl)" >> /opt/pip-tools.d/requirements-t5x.in
-
-
-### --- TO BE REFACTORED? (everything below is as in @nouiz's original PR) ---
-
-# force a recent version to have latest protobuf dep
-# Install now as some build need them.
-RUN pip install "tensorflow_datasets==4.9.2"
-RUN pip install "tensorflow==2.13.0"
-RUN pip install "chex==0.1.7"
-RUN <<"EOF" bash -ex
-cd /opt
-git clone http://github.com/tensorflow/text.git
-cd text
-git checkout v2.13.0
-EOF
-
-RUN <<"EOF" bash -ex
-cd /opt/text
-
-wget https://github.com/bazelbuild/bazelisk/releases/download/v1.17.0/bazelisk-linux-arm64 -O /usr/bin/bazel ;
-chmod a+x /usr/bin/bazel
-
+FROM wheel-builder as tftext-builder
+ARG SRC_PATH_TFTEXT
+RUN <<"EOF" bash -exu -o pipefail
+pip install tensorflow_datasets==4.9.2 auditwheel tensorflow==2.13.0
+get-source.sh -l tensorflow-text -m ${MANIFEST_FILE}
+cd ${SRC_PATH_TFTEXT}
 ./oss_scripts/run_build.sh
-find * | grep '.whl$'
 EOF
-RUN pip install /opt/text/tensorflow_text-*.whl
-#RUN echo "-e file:///opt/text/tensorflow_text-*.whl"  >> /opt/pip-tools.d/manifest.t5x
-RUN echo "tensorflow-text @  file://$(ls /opt/text/tensorflow_text-*.whl)" >> /opt/pip-tools.d/requirements-t5x.in
+
+
+#------------------------------------------------------------------------------
+# build t5 from source
+#------------------------------------------------------------------------------
+
+FROM wheel-builder as t5-builder
+ARG SRC_PATH_TFTEXT
+RUN <<"EOF" bash -exu -o pipefail
+pip install tensorflow_datasets==4.9.2 auditwheel tensorflow==2.13.0
+get-source.sh -l tensorflow-text -m ${MANIFEST_FILE}
+cd ${SRC_PATH_TFTEXT}
+./oss_scripts/run_build.sh
+EOF
+
+COPY --from=tftext-builder ${SRC_PATH_TFTEXT}/tensorflow_text*.whl /opt/
+
+RUN pip install /opt/tensorflow_text-*.whl
 
 # Install T5 now, Pip will build the wheel from source, it needs Rust.
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs > /tmp/rustup.sh && \
@@ -184,6 +185,29 @@ RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs > /tmp/rustup.sh &
     rm /root/.bashrc.save && \
         rm -Rf /root/.cache /tmp/*
 
+RUN pip wheel --no-deps -w /opt/ t5
+
+
+###############################################################################
+## T5X for AArch64
+###############################################################################
+
+FROM wheel-builder as mealkit
+ARG SRC_PATH_TFTEXT
+ARG SRC_PATH_T5X
+
+COPY --from=array_record-builder /tmp/array_record/all_dist/array_record*linux_aarch64.whl /opt/
+RUN echo "array_record @ file://$(ls /opt/array_record*.whl)" >> /opt/pip-tools.d/requirements-t5x.in
+
+COPY --from=grain-builder /tmp/grain/all_dist/grain*.whl /opt/
+RUN echo "grain @ file://$(ls /opt/grain*.whl)" >> /opt/pip-tools.d/requirements-t5x.in
+
+COPY --from=tftext-builder ${SRC_PATH_TFTEXT}/tensorflow_text*.whl /opt/
+RUN echo "tensorflow-text @ file://$(ls /opt/tensorflow_text*.whl)" >> /opt/pip-tools.d/requirements-t5x.in
+
+# COPY --from=t5-builder /opt/t5-*.whl /opt/
+# RUN echo "t5 @ file://$(ls /opt/t5-*.whl)" >> /opt/pip-tools.d/requirements-t5x.in
+
 RUN <<"EOF" bash -ex
 get-source.sh -l t5x -m ${MANIFEST_FILE}
 echo "-e file://${SRC_PATH_T5X}[gpu]" >> /opt/pip-tools.d/requirements-t5x.in
@@ -191,16 +215,16 @@ echo "-e file://${SRC_PATH_T5X}[gpu]" >> /opt/pip-tools.d/requirements-t5x.in
 # remove head-of-tree specs from select dependencies
 pushd ${SRC_PATH_T5X}
 sed -i "s| @ git+https://github.com/google/flax#egg=flax||g" setup.py
+
 # for ARM64 build
-sed -i "s/tensorflow/#tensorflow/" setup.py
-sed -i "s/t5=/#t5=/" setup.py
-sed -i "s/^jax/#jax/" setup.py
+sed -i "s/'tensorflow/#'tensorflow/" setup.py
+sed -i "s/'t5=/#'t5=/" setup.py
 
 sed -i "s/f'jax/#f'jax/" setup.py
 sed -i "s/'tpu/#'tpu/" setup.py
 
-sed -i 's/protobuf/#protobuf/' setup.py
-sed -i 's/numpy/#numpy/' setup.py
+sed -i "s/'protobuf/#'protobuf/" setup.py
+sed -i "s/'numpy/#'numpy/" setup.py
 
 if git diff --quiet; then
     echo "URL specs no longer present in select dependencies of t5x"
@@ -214,7 +238,7 @@ EOF
 ADD test-t5x.sh /usr/local/bin
 
 ###############################################################################
-## Install accumulated packages from the base image and the previous stage
+## Install accumulated packages from the base image and the previous[] stage
 ###############################################################################
 
 FROM mealkit as final

--- a/.github/container/Dockerfile.t5x.arm64
+++ b/.github/container/Dockerfile.t5x.arm64
@@ -1,11 +1,9 @@
 # syntax=docker/dockerfile:1-labs
 # Example command to build manually:
-#   docker buildx build -f Dockerfile.t5x.arm64 --tag t5x --build-arg BASE_IMAGE=ghcr.io/nvidia/jax:mealkit-2023-12-12 .
+#   docker buildx build -f Dockerfile.t5x.arm64 --tag t5x --build-arg BASE_IMAGE=ghcr.io/nvidia/jax:mealkit-2024-01-22 .
 
 ARG BASE_IMAGE=ghcr.io/nvidia/jax:mealkit
-ARG REPO_T5X=https://github.com/google-research/t5x.git
-ARG REF_T5X=main
-ARG SRC_PATH_T5X=/opt/paxml
+ARG SRC_PATH_T5X=/opt/t5x
 
 ###############################################################################
 ## build array_record and grain which do not have working arm64 pip wheels
@@ -135,15 +133,13 @@ EOT
 
 ARG BASE_IMAGE
 FROM ${BASE_IMAGE} as mealkit
-ARG REPO_T5X
-ARG REF_T5X
 ARG SRC_PATH_T5X
 
 COPY --from=array_record-builder /tmp/array_record/all_dist/array_record*linux_aarch64.whl /opt/
-RUN echo "array_record @ file://$(ls /opt/array_record*.whl)" >> /opt/pip-tools.d/manifest.pax
+RUN echo "array_record @ file://$(ls /opt/array_record*.whl)" >> /opt/pip-tools.d/requirements-t5x.in
 
 COPY --from=grain-builder /tmp/grain/all_dist/grain*.whl /opt/
-RUN echo "grain @ file://$(ls /opt/grain*.whl)" >> /opt/pip-tools.d/manifest.pax
+RUN echo "grain @ file://$(ls /opt/grain*.whl)" >> /opt/pip-tools.d/requirements-t5x.in
 
 
 ### --- TO BE REFACTORED? (everything below is as in @nouiz's original PR) ---
@@ -171,7 +167,7 @@ find * | grep '.whl$'
 EOF
 RUN pip install /opt/text/tensorflow_text-*.whl
 #RUN echo "-e file:///opt/text/tensorflow_text-*.whl"  >> /opt/pip-tools.d/manifest.t5x
-RUN echo "tensorflow-text @  file://$(ls /opt/text/tensorflow_text-*.whl)" >> /opt/pip-tools.d/manifest.t5x
+RUN echo "tensorflow-text @  file://$(ls /opt/text/tensorflow_text-*.whl)" >> /opt/pip-tools.d/requirements-t5x.in
 
 # Install T5 now, Pip will build the wheel from source, it needs Rust.
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs > /tmp/rustup.sh && \
@@ -188,12 +184,9 @@ RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs > /tmp/rustup.sh &
     rm /root/.bashrc.save && \
         rm -Rf /root/.cache /tmp/*
 
-# NOTE(gspschmid): Broken? Should've been "echo t5"?
-# RUN "t5 >> /opt/pip-tools.d/manifest.t5x"
-
 RUN <<"EOF" bash -ex
-get-source.sh -f ${REPO_T5X} -r ${REF_T5X} -d ${SRC_PATH_T5X}
-echo "-e file://${SRC_PATH_T5X}[gpu]" >> /opt/pip-tools.d/manifest.t5x
+get-source.sh -l t5x -m ${MANIFEST_FILE}
+echo "-e file://${SRC_PATH_T5X}[gpu]" >> /opt/pip-tools.d/requirements-t5x.in
 
 # remove head-of-tree specs from select dependencies
 pushd ${SRC_PATH_T5X}
@@ -228,6 +221,6 @@ FROM mealkit as final
 
 RUN pip uninstall -y tensorflow-text
 
-RUN echo "tensorflow_datasets==4.9.2" >> /opt/pip-tools.d/manifest.t5x
+RUN echo "tensorflow_datasets==4.9.2" >> /opt/pip-tools.d/requirements-t5x.in
 
 RUN pip-finalize.sh

--- a/.github/container/Dockerfile.t5x.arm64
+++ b/.github/container/Dockerfile.t5x.arm64
@@ -37,7 +37,6 @@ COPY --from=wheel-builder /mealkit-python-version /mealkit-python-version
 #
 # BEGIN
     ENV DEBIAN_FRONTEND=noninteractive
-    ENV PYTHON_BIN_PATH=/usr/bin/python${MEALKIT_PYTHON_VERSION}
 
     # Install supplementary Python interpreters
     RUN export PYTHON_BIN_PATH=/usr/bin/python$(cat /mealkit-python-version) && \

--- a/.github/container/Dockerfile.t5x.arm64
+++ b/.github/container/Dockerfile.t5x.arm64
@@ -11,54 +11,46 @@ ARG SRC_PATH_T5X=/opt/paxml
 ## build array_record and grain which do not have working arm64 pip wheels
 ###############################################################################
 
-ARG BASE_IMAGE
-FROM ${BASE_IMAGE} as wheel-builder
-
-# grain build needs bazel
-RUN wget https://github.com/bazelbuild/bazelisk/releases/download/v1.17.0/bazelisk-linux-arm64 -O /usr/bin/bazel && \
-    chmod a+x /usr/bin/bazel
-
 #------------------------------------------------------------------------------
 # build array_record 0.5.0 from source
 #------------------------------------------------------------------------------
 # TODO: Remove this once array_record maintainers have published an arm64 wheel.
 
-# The bazel build of array_record makes some strong assumptions on where the cpp toolchain lives.
-# We therefore stick to its existing Dockerfile, which ensures everything is in the right place:
-#
-#   https://github.com/google/array_record/tree/v0.5.0/oss/build.Dockerfile.aarch64
-#
 FROM linaro/tensorflow-arm64-build:2.12-multipython as array_record-builder
 # TODO: Infer PYTHON_VERSION from our own $BASE_IMAGE?
 ARG PYTHON_VERSION="3.10"
 
-ENV DEBIAN_FRONTEND=noninteractive
-ENV PYTHON_BIN_PATH=/usr/bin/python${PYTHON_VERSION}
+# The bazel build of array_record makes some strong assumptions on where the cpp toolchain lives.
+# We therefore replicate (part of) its Dockerfile, which ensures everything is in the right place:
+#   https://github.com/google/array_record/tree/v0.5.0/oss/build.Dockerfile.aarch64
+#
+# BEGIN
+    ENV DEBIAN_FRONTEND=noninteractive
+    ENV PYTHON_BIN_PATH=/usr/bin/python${PYTHON_VERSION}
 
-# Install supplementary Python interpreters
-RUN ln -s ${PYTHON_BIN_PATH} /usr/local/bin/python && \
-    ln -s ${PYTHON_BIN_PATH} /usr/local/bin/python3 && \
-    ln -s ${PYTHON_BIN_PATH} /usr/bin/python
+    # Install supplementary Python interpreters
+    RUN ln -s ${PYTHON_BIN_PATH} /usr/local/bin/python && \
+        ln -s ${PYTHON_BIN_PATH} /usr/local/bin/python3 && \
+        ln -s ${PYTHON_BIN_PATH} /usr/bin/python
 
-RUN --mount=type=cache,target=/var/cache/apt \
-    apt update && \
-    apt install -yqq \
-        apt-utils \
-        build-essential \
-        checkinstall \
-        libffi-dev
+    RUN apt update && \
+        apt install -yqq \
+            apt-utils \
+            build-essential \
+            checkinstall \
+            libffi-dev
 
-# Install pip dependencies needed for array_record
-RUN --mount=type=cache,target=/root/.cache \
-    ${PYTHON_BIN_PATH} -m pip install -U pip && \
-    ${PYTHON_BIN_PATH} -m pip install -U \
-        absl-py \
-        auditwheel \
-        etils[epath] \
-        patchelf \
-        setuptools \
-        twine \
-        wheel;
+    # Install pip dependencies needed for array_record
+    RUN ${PYTHON_BIN_PATH} -m pip install -U pip && \
+        ${PYTHON_BIN_PATH} -m pip install -U \
+            absl-py \
+            auditwheel \
+            etils[epath] \
+            patchelf \
+            setuptools \
+            twine \
+            wheel
+# END
 
 RUN <<"EOT" bash -exu
 set -o pipefail
@@ -78,38 +70,53 @@ EOT
 #------------------------------------------------------------------------------
 # TODO: Remove this once grain maintainers have published an arm64 wheel.
 
-FROM wheel-builder as grain-builder
+FROM ${BASE_IMAGE} as grain-builder
 ARG PYTHON_VERSION="3.10"
+
+# Setup bazel
+RUN  wget https://github.com/bazelbuild/bazelisk/releases/download/v1.17.0/bazelisk-linux-arm64 -O /usr/bin/bazel && \
+    chmod a+x /usr/bin/bazel
+
+# The following setup steps are based on
+#   https://github.com/google/grain/blob/ab557c31672cc2ac6f9b31e33aea2df00a7da5bf/grain/oss/build.Dockerfile
+#
+# BEGIN
+    # Setup python
+    RUN apt-get update && apt-get install -y \
+            python3-dev python3-pip python3-venv && \
+            rm -rf /var/lib/apt/lists/* && \
+            python${PYTHON_VERSION} -m pip install pip --upgrade && \
+            update-alternatives --install /usr/bin/python python /usr/bin/python${PYTHON_VERSION} 0
+
+    # Install pip dependencies needed for grain
+    # NOTE: We are ignoring the fact that "array_record" will actually resolve to the wrong version
+    #   here. When we put it all together in the final image, we make sure that the right version is
+    #   already installed.
+    RUN pip install \
+            absl-py \
+            array_record \
+            build \
+            cloudpickle \
+            dm-tree \
+            etils[epath] \
+            "more-itertools>=9.1.0" \
+            numpy
+
+    # Install pip dependencies needed for grain tests
+    RUN pip install \
+            dill \
+            jax \
+            jaxlib \
+            tensorflow \
+            tensorflow-datasets
+# END
 
 RUN <<"EOT" bash -exu
 set -o pipefail
 
-# Setup python
-apt-get update && apt-get install -y \
-    python3-dev python3-pip python3-venv && \
-    rm -rf /var/lib/apt/lists/* && \
-    python${PYTHON_VERSION} -m pip install pip --upgrade && \
-    update-alternatives --install /usr/bin/python python /usr/bin/python${PYTHON_VERSION} 0
-
-# NOTE: We are ignoring the fact that "array_record" will actually resolve to the wrong version
-#   here. When we put it all together in the final image, we make sure that the right version is
-#   already installed.
-pip install \
-    absl-py \
-    array_record \
-    build \
-    cloudpickle \
-    dm-tree \
-    etils[epath] \
-    "more-itertools>=9.1.0" \
-    numpy;
-
-pip install \
-    dill \
-    jax \
-    jaxlib \
-    tensorflow \
-    tensorflow-datasets;
+# The open-source version of grain contains various references to Google-internal dependencies,
+# and does not contain build scripts compatible with arm64. We instead build a patched version,
+# based on https://github.com/google/grain/commit/6de2270cec0407d0011721b78461b344abe07704
 
 git clone https://github.com/gspschmid/grain /opt/grain
 cd /opt/grain

--- a/.github/container/Dockerfile.t5x.arm64
+++ b/.github/container/Dockerfile.t5x.arm64
@@ -153,41 +153,6 @@ cd ${SRC_PATH_TFTEXT}
 EOF
 
 
-#------------------------------------------------------------------------------
-# build t5 from source
-#------------------------------------------------------------------------------
-
-FROM wheel-builder as t5-builder
-ARG SRC_PATH_TFTEXT
-RUN <<"EOF" bash -exu -o pipefail
-pip install tensorflow_datasets==4.9.2 auditwheel tensorflow==2.13.0
-get-source.sh -l tensorflow-text -m ${MANIFEST_FILE}
-cd ${SRC_PATH_TFTEXT}
-./oss_scripts/run_build.sh
-EOF
-
-COPY --from=tftext-builder ${SRC_PATH_TFTEXT}/tensorflow_text*.whl /opt/
-
-RUN pip install /opt/tensorflow_text-*.whl
-
-# Install T5 now, Pip will build the wheel from source, it needs Rust.
-RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs > /tmp/rustup.sh && \
-    echo "be3535b3033ff5e0ecc4d589a35d3656f681332f860c5fd6684859970165ddcc /tmp/rustup.sh" | sha256sum --check && \
-    bash /tmp/rustup.sh -y && \
-    export PATH=$PATH:/root/.cargo/bin && \
-    pip install t5 && \
-    rm -Rf /root/.cargo /root/.rustup && \
-    mv /root/.profile /root/.profile.save && \
-    grep -v cargo /root/.profile.save > /root/.profile && \
-    rm /root/.profile.save && \
-    mv /root/.bashrc /root/.bashrc.save && \
-    grep -v cargo /root/.bashrc.save > /root/.bashrc && \
-    rm /root/.bashrc.save && \
-        rm -Rf /root/.cache /tmp/*
-
-RUN pip wheel --no-deps -w /opt/ t5
-
-
 ###############################################################################
 ## T5X for AArch64
 ###############################################################################
@@ -205,14 +170,12 @@ RUN echo "grain @ file://$(ls /opt/grain*.whl)" >> /opt/pip-tools.d/requirements
 COPY --from=tftext-builder ${SRC_PATH_TFTEXT}/tensorflow_text*.whl /opt/
 RUN echo "tensorflow-text @ file://$(ls /opt/tensorflow_text*.whl)" >> /opt/pip-tools.d/requirements-t5x.in
 
-# COPY --from=t5-builder /opt/t5-*.whl /opt/
-# RUN echo "t5 @ file://$(ls /opt/t5-*.whl)" >> /opt/pip-tools.d/requirements-t5x.in
-
 RUN <<"EOF" bash -ex
+# 1. Fetch T5X
 get-source.sh -l t5x -m ${MANIFEST_FILE}
 echo "-e file://${SRC_PATH_T5X}[gpu]" >> /opt/pip-tools.d/requirements-t5x.in
 
-# remove head-of-tree specs from select dependencies
+# 2. Remove head-of-tree specs from select dependencies
 pushd ${SRC_PATH_T5X}
 sed -i "s| @ git+https://github.com/google/flax#egg=flax||g" setup.py
 
@@ -242,9 +205,5 @@ ADD test-t5x.sh /usr/local/bin
 ###############################################################################
 
 FROM mealkit as final
-
-RUN pip uninstall -y tensorflow-text
-
-RUN echo "tensorflow_datasets==4.9.2" >> /opt/pip-tools.d/requirements-t5x.in
 
 RUN pip-finalize.sh

--- a/.github/container/Dockerfile.t5x.arm64
+++ b/.github/container/Dockerfile.t5x.arm64
@@ -1,0 +1,226 @@
+# syntax=docker/dockerfile:1-labs
+# Example command to build manually:
+#   docker buildx build -f Dockerfile.t5x.arm64 --tag t5x --build-arg BASE_IMAGE=ghcr.io/nvidia/jax:mealkit-2023-12-12 .
+
+ARG BASE_IMAGE=ghcr.io/nvidia/jax:mealkit
+ARG REPO_T5X=https://github.com/google-research/t5x.git
+ARG REF_T5X=main
+ARG SRC_PATH_T5X=/opt/paxml
+
+###############################################################################
+## build array_record and grain which do not have working arm64 pip wheels
+###############################################################################
+
+ARG BASE_IMAGE
+FROM ${BASE_IMAGE} as wheel-builder
+
+# grain build needs bazel
+RUN wget https://github.com/bazelbuild/bazelisk/releases/download/v1.17.0/bazelisk-linux-arm64 -O /usr/bin/bazel && \
+    chmod a+x /usr/bin/bazel
+
+#------------------------------------------------------------------------------
+# build array_record 0.5.0 from source
+#------------------------------------------------------------------------------
+# TODO: Remove this once array_record maintainers have published an arm64 wheel.
+
+# The bazel build of array_record makes some strong assumptions on where the cpp toolchain lives.
+# We therefore stick to its existing Dockerfile, which ensures everything is in the right place:
+#
+#   https://github.com/google/array_record/tree/v0.5.0/oss/build.Dockerfile.aarch64
+#
+FROM linaro/tensorflow-arm64-build:2.12-multipython as array_record-builder
+# TODO: Infer PYTHON_VERSION from our own $BASE_IMAGE?
+ARG PYTHON_VERSION="3.10"
+
+ENV DEBIAN_FRONTEND=noninteractive
+ENV PYTHON_BIN_PATH=/usr/bin/python${PYTHON_VERSION}
+
+# Install supplementary Python interpreters
+RUN ln -s ${PYTHON_BIN_PATH} /usr/local/bin/python && \
+    ln -s ${PYTHON_BIN_PATH} /usr/local/bin/python3 && \
+    ln -s ${PYTHON_BIN_PATH} /usr/bin/python
+
+RUN --mount=type=cache,target=/var/cache/apt \
+    apt update && \
+    apt install -yqq \
+        apt-utils \
+        build-essential \
+        checkinstall \
+        libffi-dev
+
+# Install pip dependencies needed for array_record
+RUN --mount=type=cache,target=/root/.cache \
+    ${PYTHON_BIN_PATH} -m pip install -U pip && \
+    ${PYTHON_BIN_PATH} -m pip install -U \
+        absl-py \
+        auditwheel \
+        etils[epath] \
+        patchelf \
+        setuptools \
+        twine \
+        wheel;
+
+RUN <<"EOT" bash -exu
+set -o pipefail
+
+git clone https://github.com/google/array_record.git /tmp/array_record
+cd /tmp/array_record
+git checkout v0.5.0
+
+export CROSSTOOL_TOP="@ml2014_aarch64_config_aarch64//crosstool:toolchain"
+export AUDITWHEEL_PLATFORM="manylinux2014_aarch64"
+./oss/build_whl.sh
+EOT
+
+
+#------------------------------------------------------------------------------
+# build grain from a manually-patched version
+#------------------------------------------------------------------------------
+# TODO: Remove this once grain maintainers have published an arm64 wheel.
+
+FROM wheel-builder as grain-builder
+ARG PYTHON_VERSION="3.10"
+
+RUN <<"EOT" bash -exu
+set -o pipefail
+
+# Setup python
+apt-get update && apt-get install -y \
+    python3-dev python3-pip python3-venv && \
+    rm -rf /var/lib/apt/lists/* && \
+    python${PYTHON_VERSION} -m pip install pip --upgrade && \
+    update-alternatives --install /usr/bin/python python /usr/bin/python${PYTHON_VERSION} 0
+
+# NOTE: We are ignoring the fact that "array_record" will actually resolve to the wrong version
+#   here. When we put it all together in the final image, we make sure that the right version is
+#   already installed.
+pip install \
+    absl-py \
+    array_record \
+    build \
+    cloudpickle \
+    dm-tree \
+    etils[epath] \
+    "more-itertools>=9.1.0" \
+    numpy;
+
+pip install \
+    dill \
+    jax \
+    jaxlib \
+    tensorflow \
+    tensorflow-datasets;
+
+git clone https://github.com/gspschmid/grain /opt/grain
+cd /opt/grain
+git checkout external-arm64-build-poc
+
+chmod a+x ./grain/oss/build_whl.sh
+./grain/oss/build_whl.sh
+
+ls /tmp/grain/all_dist/*.whl
+EOT
+
+
+###############################################################################
+## T5X for AArch64
+###############################################################################
+
+ARG BASE_IMAGE
+FROM ${BASE_IMAGE} as mealkit
+ARG REPO_T5X
+ARG REF_T5X
+ARG SRC_PATH_T5X
+
+COPY --from=array_record-builder /tmp/array_record/all_dist/array_record*linux_aarch64.whl /opt/
+RUN echo "array_record @ file://$(ls /opt/array_record*.whl)" >> /opt/pip-tools.d/manifest.pax
+
+COPY --from=grain-builder /tmp/grain/all_dist/grain*.whl /opt/
+RUN echo "grain @ file://$(ls /opt/grain*.whl)" >> /opt/pip-tools.d/manifest.pax
+
+
+### --- TO BE REFACTORED? (everything below is as in @nouiz's original PR) ---
+
+# force a recent version to have latest protobuf dep
+# Install now as some build need them.
+RUN pip install "tensorflow_datasets==4.9.2"
+RUN pip install "tensorflow==2.13.0"
+RUN pip install "chex==0.1.7"
+RUN <<"EOF" bash -ex
+cd /opt
+git clone http://github.com/tensorflow/text.git
+cd text
+git checkout v2.13.0
+EOF
+
+RUN <<"EOF" bash -ex
+cd /opt/text
+
+wget https://github.com/bazelbuild/bazelisk/releases/download/v1.17.0/bazelisk-linux-arm64 -O /usr/bin/bazel ;
+chmod a+x /usr/bin/bazel
+
+./oss_scripts/run_build.sh
+find * | grep '.whl$'
+EOF
+RUN pip install /opt/text/tensorflow_text-*.whl
+#RUN echo "-e file:///opt/text/tensorflow_text-*.whl"  >> /opt/pip-tools.d/manifest.t5x
+RUN echo "tensorflow-text @  file://$(ls /opt/text/tensorflow_text-*.whl)" >> /opt/pip-tools.d/manifest.t5x
+
+# Install T5 now, Pip will build the wheel from source, it needs Rust.
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs > /tmp/rustup.sh && \
+    echo "be3535b3033ff5e0ecc4d589a35d3656f681332f860c5fd6684859970165ddcc /tmp/rustup.sh" | sha256sum --check && \
+    bash /tmp/rustup.sh -y && \
+    export PATH=$PATH:/root/.cargo/bin && \
+    pip install t5 && \
+    rm -Rf /root/.cargo /root/.rustup && \
+    mv /root/.profile /root/.profile.save && \
+    grep -v cargo /root/.profile.save > /root/.profile && \
+    rm /root/.profile.save && \
+    mv /root/.bashrc /root/.bashrc.save && \
+    grep -v cargo /root/.bashrc.save > /root/.bashrc && \
+    rm /root/.bashrc.save && \
+        rm -Rf /root/.cache /tmp/*
+
+# NOTE(gspschmid): Broken? Should've been "echo t5"?
+# RUN "t5 >> /opt/pip-tools.d/manifest.t5x"
+
+RUN <<"EOF" bash -ex
+get-source.sh -f ${REPO_T5X} -r ${REF_T5X} -d ${SRC_PATH_T5X}
+echo "-e file://${SRC_PATH_T5X}[gpu]" >> /opt/pip-tools.d/manifest.t5x
+
+# remove head-of-tree specs from select dependencies
+pushd ${SRC_PATH_T5X}
+sed -i "s| @ git+https://github.com/google/flax#egg=flax||g" setup.py
+# for ARM64 build
+sed -i "s/tensorflow/#tensorflow/" setup.py
+sed -i "s/t5=/#t5=/" setup.py
+sed -i "s/^jax/#jax/" setup.py
+
+sed -i "s/f'jax/#f'jax/" setup.py
+sed -i "s/'tpu/#'tpu/" setup.py
+
+sed -i 's/protobuf/#protobuf/' setup.py
+sed -i 's/numpy/#numpy/' setup.py
+
+if git diff --quiet; then
+    echo "URL specs no longer present in select dependencies of t5x"
+    exit 1
+else
+    git commit -a -m "remove URL specs from select dependencies of t5x"
+fi
+popd
+EOF
+
+ADD test-t5x.sh /usr/local/bin
+
+###############################################################################
+## Install accumulated packages from the base image and the previous stage
+###############################################################################
+
+FROM mealkit as final
+
+RUN pip uninstall -y tensorflow-text
+
+RUN echo "tensorflow_datasets==4.9.2" >> /opt/pip-tools.d/manifest.t5x
+
+RUN pip-finalize.sh


### PR DESCRIPTION
This expands upon @nouiz's [earlier PR](https://github.com/NVIDIA/JAX-Toolbox/pull/421) aimed at getting an arm64 build for T5X.

I took a stab at resolving the remaining issues by building both `grain` and its dependency, `array_record`, from source.

Building the new dockerfile with
```bash
$ docker buildx build -f Dockerfile.t5x.arm64 --tag t5x --build-arg BASE_IMAGE=ghcr.io/nvidia/jax:mealkit-2023-12-12 .
```
gives me an image in which the import succeeds:
```bash
$ docker run --rm -it --shm-size=1g t5x python3 -c 'import t5x; print(t5x)'
(...)
<module 't5x' from '/opt/paxml/t5x/__init__.py'>
```
🥳 
---

The underlying issue was that both `array_record` and `grain` were at some point erroneously published as universal (arch-independent) wheels. For `grain` this is still the case, for `array_record` this was only the case until 0.4.1, whereas from 0.5.0 only an `x86_64` wheel was published, meaning pip ends up pulling the older (arm64-incompatible) wheel anyways.

The `array_record` build is essentially unchanged and replicates that repo's Dockerfile. I initially tried to use "mealkit" as a base image, but at least `array_record` seems to make some strong assumptions on where exactly the compiler toolchain is located.

For `grain` to build I had to make [some pretty heavy-handed changes](https://github.com/gspschmid/grain/commits/external-arm64-build-poc/) -- it seems like the export process from Google's internal monorepo through copybara left various parts mangled. Among other things, the bazel build currently refers to some Google-internal dependencies, and in two places the Python code just isn't syntactically valid ([#1](https://github.com/google/grain/blob/6de2270cec0407d0011721b78461b344abe07704/grain/_src/python/data_sources.py#L45-L47), [#2](https://github.com/google/grain/blob/6de2270cec0407d0011721b78461b344abe07704/grain/_src/python/data_loader.py#L181-L191)).

For both repos I'm hoping we can get the respective maintainers to take a look and eventually publish some arm64-specific wheels :-)