### PR TITLE
Install TRT-LLM/TRT OSS

### DIFF
--- a/.github/container/Dockerfile.base
+++ b/.github/container/Dockerfile.base
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1-labs
-ARG BASE_IMAGE=nvidia/cuda:12.3.0-devel-ubuntu22.04
+ARG BASE_IMAGE=nvidia/cuda:12.2.2-devel-ubuntu22.04
 ARG GIT_USER_NAME="JAX Toolbox"
 ARG GIT_USER_EMAIL=jax@nvidia.com
 ARG SRC_MANIFEST_FILE=manifest.yaml

--- a/.github/container/Dockerfile.trt
+++ b/.github/container/Dockerfile.trt
@@ -1,0 +1,30 @@
+# syntax=docker/dockerfile:1-labs
+
+ARG BASE_IMAGE=ghcr.io/nvidia/jax:mealkit
+
+FROM ${BASE_IMAGE} as mealkit
+
+# Install system dependencies
+RUN <<"EOF" bash -ex
+apt-get update
+apt-get install -y \
+    openmpi-bin \
+    libopenmpi-dev
+apt-get clean
+rm -rf /var/lib/apt/lists/*
+EOF
+
+# Specify installation targets
+RUN <<"EOF" bash -ex
+echo "--extra-index-url https://pypi.nvidia.com" >> /opt/pip-tools.d/requirements-trt.in
+echo "--pre" >> /opt/pip-tools.d/requirements-trt.in
+echo "tensorrt_llm" >> /opt/pip-tools.d/requirements-trt.in
+EOF
+
+###############################################################################
+## Install accumulated packages from the base image and the previous stage
+###############################################################################
+
+FROM mealkit as final
+
+RUN pip-finalize.sh

--- a/.github/workflows/_ci.yaml
+++ b/.github/workflows/_ci.yaml
@@ -44,6 +44,19 @@ jobs:
       BASE_IMAGE: ${{ needs.build-base.outputs.DOCKER_TAG }}
     secrets: inherit
 
+  build-trt:
+    needs: [build-jax]
+    uses: ./.github/workflows/_build.yaml
+    with:
+      ARCHITECTURE: ${{ inputs.ARCHITECTURE }}
+      ARTIFACT_NAME: "artifact-trt-build"
+      BADGE_FILENAME: "badge-trt-build"
+      BUILD_DATE: ${{ inputs.BUILD_DATE }}
+      BASE_IMAGE: ${{ needs.build-jax.outputs.DOCKER_TAG_MEALKIT }}
+      CONTAINER_NAME: trt
+      DOCKERFILE: .github/container/Dockerfile.trt
+    secrets: inherit
+
   build-t5x:
     needs: build-jax
     uses: ./.github/workflows/_build.yaml


### PR DESCRIPTION
While the current Dockerfile does add TRT and TRT-LLM to the container, there are several issues:
- PyTorch is installed as a dependency of TRT-LLM. In fact, the Python component of TRT-LLM cannot start with PyTorch due to the use of it to convert from fp32 to bf16 in `functional.py`. Since we don't need PyTorch in this container, this can potentially bloat the image size by several GB. The real question is: do we need the Python frontend of TRT-LLM, or do we just need the C++ runtime?
- Currently, the pre-release version of TRT-LLM at 9.2/9.3 only support CUDA 12.2. As such, I had to roll back the CUDA version in this branch.


PyTorch usage
```
    # Note that for bfloat16, we cannot case numpy tensor from float32 to bfloat16
    # because numpy does not support bfloat16. Even if we use custom type to define
    # the np_bfloat16, the "astype" here would be undefined.
    # So, we must use torch to cast tensor from float32 to bfloat16, and then use torch_to_numpy
    # to cast the tensor back.
    slopes = torch.from_numpy(slopes)
    slopes = slopes.to(trt_dtype_to_torch(dtype))
    slopes = torch_to_numpy(slopes)
    slopes = constant(slopes.reshape(1, (end_head_id - start_head_id), 1, 1))
    return slopes
```