### PR TITLE
Use Clang when building JAX via build/build.py

### DIFF
--- a/.github/container/build-jax.sh
+++ b/.github/container/build-jax.sh
@@ -277,7 +277,8 @@ pushd $SRC_PATH_JAX
 # Delete old wheel if one already exist.
 rm -rf dist/j*.whl
 
-time CC=clang CXX=clang++ python build/build.py \
+time python build/build.py \
+    --use_clang \
     --enable_cuda \
     --cuda_path=$TF_CUDA_PATHS \
     --cudnn_path=$TF_CUDNN_PATHS \

--- a/.github/container/manifest.yaml
+++ b/.github/container/manifest.yaml
@@ -2,31 +2,31 @@
 jax:
   url: https://github.com/google/jax.git
   tracking_ref: main
-  latest_verified_commit: 9e76e380cc47f28c5f08be7497293f51e1c1d167
+  latest_verified_commit: f2613387bd7421bd1fedbed15257b9841717b34a
   mode: git-clone
 xla:
   url: https://github.com/openxla/xla.git
   tracking_ref: main
-  latest_verified_commit: 0dc5563a97d6fa4584b85cb29b4bfcf289604f0b
+  latest_verified_commit: 5ea80986813c3eef73c4d53ee881c203839f2c16
   mode: git-clone
 flax:
   url: https://github.com/google/flax.git
   mirror_url: https://github.com/nvjax-svc-0/flax.git
   tracking_ref: main
-  latest_verified_commit: 12b3db0cffd521c707ca959818b7ab1a274a98fd
+  latest_verified_commit: d9585e0a6ba6c4a4ebc93d0707add573420703df
   mode: git-clone
   patches:
     pull/3340/head: file://patches/flax/PR-3340.patch # Add Sharding Annotations to Flax Modules
 transformer-engine:
   url: https://github.com/NVIDIA/TransformerEngine.git
   tracking_ref: main
-  latest_verified_commit: 44574def7f34fb61bebd458b74c47fe33acec57d
+  latest_verified_commit: d68028c872186cd3df604e2ee2f60e09784d955c
   mode: git-clone
 t5x:
   url: https://github.com/google-research/t5x.git
   mirror_url: https://github.com/nvjax-svc-0/t5x.git
   tracking_ref: main
-  latest_verified_commit: 4ff4291b208cfbc199409e25990e2c01183eacb1
+  latest_verified_commit: cd94b76f53244914660e83a8f813d8e809ba05e4
   mode: git-clone
   patches:
     mirror/patch/partial-checkpoint-restore: file://patches/t5x/mirror-patch-partial-checkpoint-restore.patch # pull/1392/head  # https://github.com/google-research/t5x/pull/1392: Add support for partial checkpoint restore
@@ -36,7 +36,7 @@ paxml:
   url: https://github.com/google/paxml.git
   mirror_url: https://github.com/nvjax-svc-0/paxml.git
   tracking_ref: main
-  latest_verified_commit: d7b78d39d04c03ff45c5fe0f74f6d281ab36bb69
+  latest_verified_commit: e6cbcb9990a14d6a166166d822dc8e929b6bab0d
   mode: git-clone
   patches:
     pull/46/head: file://patches/paxml/PR-46.patch # adds Transformer Engine support
@@ -44,7 +44,7 @@ praxis:
   url: https://github.com/google/praxis.git
   mirror_url: https://github.com/nvjax-svc-0/praxis.git
   tracking_ref: main
-  latest_verified_commit: 8a25c60f003ab7cdd5e305b88bd677b2d2c0ee00
+  latest_verified_commit: d2d3bb89770de2b3af666981295c23defb38bd2f
   mode: git-clone
   patches:
     pull/27/head: file://patches/praxis/PR-27.patch # This PR allows XLA:GPU to detect the MHA pattern more easily to call fused kernels from cublas.
@@ -53,7 +53,7 @@ lingvo:
   # Used only in ARM pax builds
   url: https://github.com/tensorflow/lingvo.git
   tracking_ref: master
-  latest_verified_commit: c3fc4d7a50f2e2c2e189a2ef29b7b65da1597420
+  latest_verified_commit: 8bb7652184c6c895def36e9fb242a9751705fa0e
   mode: git-clone
 tensorflow-text:
   # Used only in ARM pax and t5x builds
@@ -74,12 +74,12 @@ fiddle:
 airio:
   url: https://github.com/google/airio.git
   tracking_ref: main
-  latest_verified_commit: 6a98fbe27a9b23954748bed7181b913ab8d20753
+  latest_verified_commit: bb9be6d0510aada879d5d6b978e02f2ed4fd1a7a
   mode: pip-vcs
 clu:
   url: https://github.com/google/CommonLoopUtils.git
   tracking_ref: main
-  latest_verified_commit: f30bc441a14f0ccf8eaff79800f486a846613a8c
+  latest_verified_commit: 1368e52d0876dd0c90894793e8e9e97fc6f98adc
   mode: pip-vcs
 dllogger:
   url: https://github.com/NVIDIA/dllogger.git
@@ -94,12 +94,12 @@ jestimator:
 optax:
   url: https://github.com/google-deepmind/optax.git
   tracking_ref: main
-  latest_verified_commit: dff502082bfd902db6dd079f3bf754887c87f3ca
+  latest_verified_commit: c86b9a99eea69c5f2bb81bd526a579b3f6b5f4d0
   mode: pip-vcs
 seqio:
   url: https://github.com/google/seqio.git
   tracking_ref: main
-  latest_verified_commit: 713c5f153239e965962d79ce12d1041c624d24b4
+  latest_verified_commit: 763998620c2071b3b05b3bbf94cf02305746ab9f
   mode: pip-vcs
 # used by Pallas
 openxla-triton:
@@ -115,12 +115,12 @@ jax-triton:
 maxtext:
   url: https://github.com/google/maxtext.git
   tracking_ref: main
-  latest_verified_commit: b8da9af13d5f010c2e4d4b5e865b6e907228aaa6
+  latest_verified_commit: 2fdf8a2dfa553b928d52052711219ca9cbcf4ec7
   mode: git-clone
 levanter:
   url: https://github.com/stanford-crfm/levanter.git
   tracking_ref: main
-  latest_verified_commit: 0e1f2dcb39a33d251992438360357b65c53de941
+  latest_verified_commit: c1e7b24aa47e073af0aa48606581f817b59e1b45
   mode: git-clone
 haliax:
   url: https://github.com/stanford-crfm/haliax.git
@@ -130,21 +130,21 @@ haliax:
 mujoco:
   url: https://github.com/google-deepmind/mujoco.git
   tracking_ref: main
-  latest_verified_commit: fae1f3e56d5a1df93da510462a17432b7b91b0a0
+  latest_verified_commit: ced37ffbb237584512311b041bce3124e3b2cc2a
   mode: git-clone
 grain:
   # Used only in ARM t5x builds
   url: https://github.com/google/grain.git
   tracking_ref: main
-  latest_verified_commit: fa79b9dea81ffb00555a6c2ae2898be4bdd5e564
+  latest_verified_commit: 41f80fb540547ec3aefe7cec57fe43228560b1cf
   mode: git-clone
 mujoco-mpc:
-  url:  https://github.com/google-deepmind/mujoco_mpc.git
+  url: https://github.com/google-deepmind/mujoco_mpc.git
   tracking_ref: main
-  latest_verified_commit: a8bdcc1d968addf0d334243ce9bd6dbb07e1d781
+  latest_verified_commit: 73633d7da1900c428a7315d2ffe1120c5393a7d8
   mode: git-clone
 language-to-reward-2023:
-  url:  https://github.com/google-deepmind/language_to_reward_2023.git
+  url: https://github.com/google-deepmind/language_to_reward_2023.git
   tracking_ref: main
   latest_verified_commit: abb8e5125e4ecd0da378490b73448c05a694def5
   mode: git-clone

--- a/.github/container/patches/flax/PR-3340.patch
+++ b/.github/container/patches/flax/PR-3340.patch
@@ -1,27 +1,35 @@
-From 6b8bcac6234f156a763f7e535670cb094509c350 Mon Sep 17 00:00:00 2001
+From a563a57ca081e87b537bf724e2e29b138a14bb3f Mon Sep 17 00:00:00 2001
 From: ashors1 <ashors@nvidia.com>
 Date: Fri, 2 Jun 2023 15:01:21 -0700
-Subject: [PATCH 1/2] add t5x sharding annotations to flax layers
+Subject: [PATCH 1/3] add t5x sharding annotations to flax layers
 
 ---
- flax/linen/attention.py     | 33 +++++++++++++++++++++++------
+ flax/linen/attention.py     | 34 +++++++++++++++++++++++-------
  flax/linen/linear.py        | 41 ++++++++++++++++++++++++++++---------
  flax/linen/normalization.py | 25 ++++++++++++++++++----
- 3 files changed, 79 insertions(+), 20 deletions(-)
+ 3 files changed, 79 insertions(+), 21 deletions(-)
 
 diff --git a/flax/linen/attention.py b/flax/linen/attention.py
-index f5a388a2..20537921 100644
+index e10a02d1..2827119f 100644
 --- a/flax/linen/attention.py
 +++ b/flax/linen/attention.py
-@@ -32,6 +32,7 @@ from flax.linen.linear import (
+@@ -30,6 +30,7 @@ from flax.linen.linear import (
  )
  from flax.linen.module import Module, compact, merge_param
  from flax.linen.normalization import LayerNorm
 +from flax.linen.partitioning import variable_with_axes
+ from flax.typing import (
+   Array,
+   PRNGKey,
+@@ -40,7 +41,6 @@ from flax.typing import (
+   DotGeneralT,
+ )
  
- PRNGKey = jax.Array
- Shape = Tuple[int, ...]
-@@ -223,6 +224,17 @@ class MultiHeadDotProductAttention(Module):
+-
+ def dot_product_attention_weights(
+   query: Array,
+   key: Array,
+@@ -287,6 +287,17 @@ class MultiHeadDotProductAttention(Module):
        num_heads, value_channels]``
      decode: whether to prepare and use an autoregressive cache.
      normalize_qk: should QK normalization be applied (arxiv.org/abs/2302.05442).
@@ -39,7 +47,7 @@ index f5a388a2..20537921 100644
    """
  
    num_heads: int
-@@ -247,6 +259,11 @@ class MultiHeadDotProductAttention(Module):
+@@ -309,6 +320,11 @@ class MultiHeadDotProductAttention(Module):
    out_dot_general: Optional[DotGeneralT] = None
    qkv_dot_general_cls: Any = None
    out_dot_general_cls: Any = None
@@ -51,7 +59,7 @@ index f5a388a2..20537921 100644
  
    @overload
    def __call__(
-@@ -378,6 +395,8 @@ class MultiHeadDotProductAttention(Module):
+@@ -447,6 +463,8 @@ class MultiHeadDotProductAttention(Module):
        precision=self.precision,
        dot_general=self.qkv_dot_general,
        dot_general_cls=self.qkv_dot_general_cls,
@@ -60,7 +68,7 @@ index f5a388a2..20537921 100644
      )
      # project inputs_q to multi-headed q/k/v
      # dimensions are then [batch..., length, n_heads, n_features_per_head]
-@@ -398,14 +417,14 @@ class MultiHeadDotProductAttention(Module):
+@@ -467,14 +485,14 @@ class MultiHeadDotProductAttention(Module):
      if self.decode:
        # detect if we're initializing by absence of existing cache data.
        is_initialized = self.has_variable('cache', 'cached_key')
@@ -81,7 +89,7 @@ index f5a388a2..20537921 100644
        )
        if is_initialized:
          (
-@@ -483,6 +502,8 @@ class MultiHeadDotProductAttention(Module):
+@@ -568,6 +586,8 @@ class MultiHeadDotProductAttention(Module):
        dot_general=self.out_dot_general,
        dot_general_cls=self.out_dot_general_cls,
        name='out',  # type: ignore[call-arg]
@@ -91,27 +99,27 @@ index f5a388a2..20537921 100644
      return out
  
 diff --git a/flax/linen/linear.py b/flax/linen/linear.py
-index f4afd805..999acf2c 100644
+index 36365ea1..4656abf9 100644
 --- a/flax/linen/linear.py
 +++ b/flax/linen/linear.py
-@@ -36,6 +36,7 @@ from flax.core import meta
+@@ -35,6 +35,7 @@ from flax.core import meta
  from flax.linen import initializers
  from flax.linen.dtypes import promote_dtype
  from flax.linen.module import Module, compact
 +from flax.linen.partitioning import param_with_axes
- 
- PRNGKey = Any
- Shape = Tuple[int, ...]
-@@ -81,6 +82,8 @@ class DenseGeneral(Module):
+ from flax.typing import (
+   Array,
+   PRNGKey as PRNGKey,
+@@ -97,6 +98,8 @@ class DenseGeneral(Module):
      bias_init: initializer function for the bias.
-     precision: numerical precision of the computation see `jax.lax.Precision`
+     precision: numerical precision of the computation see ``jax.lax.Precision``
        for details.
 +    kernel_axes: a tuple of axes associated with the kernel.
 +    bias_axes: a tuple of axes associated with the bias.
    """
  
    features: Union[int, Sequence[int]]
-@@ -97,6 +100,8 @@ class DenseGeneral(Module):
+@@ -111,6 +114,8 @@ class DenseGeneral(Module):
    # Deprecated. Will be removed.
    dot_general: Optional[DotGeneralT] = None
    dot_general_cls: Any = None
@@ -120,7 +128,7 @@ index f4afd805..999acf2c 100644
  
    @compact
    def __call__(self, inputs: Array) -> Array:
-@@ -145,8 +150,9 @@ class DenseGeneral(Module):
+@@ -159,8 +164,9 @@ class DenseGeneral(Module):
        if ax not in axis
      )
      kernel_shape = tuple(inputs.shape[ax] for ax in axis) + features
@@ -132,7 +140,7 @@ index f4afd805..999acf2c 100644
      )
  
      batch_ind = tuple(range(n_batch_dims))
-@@ -164,9 +170,11 @@ class DenseGeneral(Module):
+@@ -178,9 +184,11 @@ class DenseGeneral(Module):
            return meta.replace_boxed(bias, jnp.reshape(bias.unbox(), shape))
          return jnp.reshape(bias, shape)
  
@@ -146,7 +154,7 @@ index f4afd805..999acf2c 100644
      else:
        bias = None
  
-@@ -204,6 +212,8 @@ class Dense(Module):
+@@ -228,6 +236,8 @@ class Dense(Module):
        for details.
      kernel_init: initializer function for the weight matrix.
      bias_init: initializer function for the bias.
@@ -155,7 +163,7 @@ index f4afd805..999acf2c 100644
    """
  
    features: int
-@@ -218,6 +228,8 @@ class Dense(Module):
+@@ -240,6 +250,8 @@ class Dense(Module):
    # Deprecated. Will be removed.
    dot_general: Optional[DotGeneralT] = None
    dot_general_cls: Any = None
@@ -164,7 +172,7 @@ index f4afd805..999acf2c 100644
  
    @compact
    def __call__(self, inputs: Array) -> Array:
-@@ -229,15 +241,18 @@ class Dense(Module):
+@@ -251,15 +263,18 @@ class Dense(Module):
      Returns:
        The transformed input.
      """
@@ -186,7 +194,7 @@ index f4afd805..999acf2c 100644
        )
      else:
        bias = None
-@@ -331,6 +346,8 @@ class _Conv(Module):
+@@ -351,6 +366,8 @@ class _Conv(Module):
        for details.
      kernel_init: initializer for the convolutional kernel.
      bias_init: initializer for the bias.
@@ -195,7 +203,7 @@ index f4afd805..999acf2c 100644
    """
  
    features: int
-@@ -352,6 +369,8 @@ class _Conv(Module):
+@@ -370,6 +387,8 @@ class _Conv(Module):
    # Deprecated. Will be removed.
    conv_general_dilated: Optional[ConvGeneralDilatedT] = None
    conv_general_dilated_cls: Any = None
@@ -204,7 +212,7 @@ index f4afd805..999acf2c 100644
  
    @property
    def shared_weights(self) -> bool:  # type: ignore
-@@ -496,8 +515,10 @@ class _Conv(Module):
+@@ -511,8 +530,10 @@ class _Conv(Module):
          f'Shapes are: {self.mask.shape}, {kernel_shape}'
        )
  
@@ -217,7 +225,7 @@ index f4afd805..999acf2c 100644
      )
  
      if self.mask is not None:
-@@ -511,7 +532,7 @@ class _Conv(Module):
+@@ -526,7 +547,7 @@ class _Conv(Module):
          # One bias weight per output entry, unshared betwen pixels.
          bias_shape = conv_output_shape[1:]
  
@@ -227,7 +235,7 @@ index f4afd805..999acf2c 100644
        bias = None
  
 diff --git a/flax/linen/normalization.py b/flax/linen/normalization.py
-index 076fd680..6eff2dd1 100644
+index cec8f508..e815f955 100644
 --- a/flax/linen/normalization.py
 +++ b/flax/linen/normalization.py
 @@ -24,6 +24,7 @@ from jax import lax
@@ -235,18 +243,18 @@ index 076fd680..6eff2dd1 100644
  
  from flax.linen import dtypes, module, transforms
 +from flax.linen.partitioning import param_with_axes
- 
- PRNGKey = Any
- Array = Any
-@@ -152,6 +153,7 @@ def _normalize(
+ from flax.typing import (
+   Array,
+   PRNGKey as PRNGKey,
+@@ -154,6 +155,7 @@ def _normalize(
    use_scale: bool,
-   bias_init: Callable[[PRNGKey, Shape, Dtype], Array],
-   scale_init: Callable[[PRNGKey, Shape, Dtype], Array],
+   bias_init: Initializer,
+   scale_init: Initializer,
 +  axes: Tuple[str, ...] = None,
  ):
    """Normalizes the input of a normalization layer and optionally applies a learned scale and bias.
  
-@@ -171,6 +173,7 @@ def _normalize(
+@@ -173,6 +175,7 @@ def _normalize(
      use_scale: If true, scale the output.
      bias_init: Initialization function for the bias term.
      scale_init: Initialization function for the scaling function.
@@ -254,7 +262,7 @@ index 076fd680..6eff2dd1 100644
  
    Returns:
      The normalized input.
-@@ -189,15 +192,17 @@ def _normalize(
+@@ -191,15 +194,17 @@ def _normalize(
    mul = lax.rsqrt(var + epsilon)
    args = [x]
    if use_scale:
@@ -276,7 +284,7 @@ index 076fd680..6eff2dd1 100644
      ).reshape(feature_shape)
      y += bias
      args.append(bias)
-@@ -280,6 +285,7 @@ class BatchNorm(Module):
+@@ -283,6 +288,7 @@ class BatchNorm(Module):
        more details.
      use_fast_variance: If true, use a faster, but less numerically stable,
        calculation for the variance.
@@ -284,7 +292,7 @@ index 076fd680..6eff2dd1 100644
    """
  
    use_running_average: Optional[bool] = None
-@@ -295,6 +301,7 @@ class BatchNorm(Module):
+@@ -298,6 +304,7 @@ class BatchNorm(Module):
    axis_name: Optional[str] = None
    axis_index_groups: Any = None
    use_fast_variance: bool = True
@@ -292,7 +300,7 @@ index 076fd680..6eff2dd1 100644
  
    @compact
    def __call__(self, x, use_running_average: Optional[bool] = None, mask=None):
-@@ -368,6 +375,7 @@ class BatchNorm(Module):
+@@ -371,6 +378,7 @@ class BatchNorm(Module):
        self.use_scale,
        self.bias_init,
        self.scale_init,
@@ -300,7 +308,7 @@ index 076fd680..6eff2dd1 100644
      )
  
  
-@@ -405,6 +413,7 @@ class LayerNorm(Module):
+@@ -433,6 +441,7 @@ class LayerNorm(Module):
        more details.
      use_fast_variance: If true, use a faster, but less numerically stable,
        calculation for the variance.
@@ -308,15 +316,15 @@ index 076fd680..6eff2dd1 100644
    """
  
    epsilon: float = 1e-6
-@@ -419,6 +428,7 @@ class LayerNorm(Module):
+@@ -447,6 +456,7 @@ class LayerNorm(Module):
    axis_name: Optional[str] = None
    axis_index_groups: Any = None
    use_fast_variance: bool = True
 +  pjit_axis_name: Tuple[str, ...] = None
  
    @compact
-   def __call__(self, x):
-@@ -453,6 +463,7 @@ class LayerNorm(Module):
+   def __call__(self, x, mask=None):
+@@ -484,6 +494,7 @@ class LayerNorm(Module):
        self.use_scale,
        self.bias_init,
        self.scale_init,
@@ -324,23 +332,23 @@ index 076fd680..6eff2dd1 100644
      )
  
  
-@@ -497,6 +508,7 @@ class RMSNorm(Module):
-       example, `[[0, 1], [2, 3]]` would independently batch-normalize over the
-       examples on the first two and last two devices. See `jax.lax.psum` for
+@@ -530,6 +541,7 @@ class RMSNorm(Module):
+       example, ``[[0, 1], [2, 3]]`` would independently batch-normalize over the
+       examples on the first two and last two devices. See ``jax.lax.psum`` for
        more details.
 +    pjit_axis_names: A tuple of axis names.
    """
  
    epsilon: float = 1e-6
-@@ -508,6 +520,7 @@ class RMSNorm(Module):
+@@ -541,6 +553,7 @@ class RMSNorm(Module):
    feature_axes: Axes = -1
    axis_name: Optional[str] = None
    axis_index_groups: Any = None
 +  pjit_axis_name: Tuple[str, ...] = None
  
    @compact
-   def __call__(self, x):
-@@ -542,6 +555,7 @@ class RMSNorm(Module):
+   def __call__(self, x, mask=None):
+@@ -578,6 +591,7 @@ class RMSNorm(Module):
        self.use_scale,
        initializers.zeros,
        self.scale_init,
@@ -348,7 +356,7 @@ index 076fd680..6eff2dd1 100644
      )
  
  
-@@ -582,6 +596,7 @@ class GroupNorm(Module):
+@@ -647,6 +661,7 @@ class GroupNorm(Module):
        more details.
      use_fast_variance: If true, use a faster, but less numerically stable,
        calculation for the variance.
@@ -356,15 +364,15 @@ index 076fd680..6eff2dd1 100644
    """
  
    num_groups: Optional[int] = 32
-@@ -596,6 +611,7 @@ class GroupNorm(Module):
+@@ -662,6 +677,7 @@ class GroupNorm(Module):
    axis_name: Optional[str] = None
    axis_index_groups: Any = None
    use_fast_variance: bool = True
 +  pjit_axis_name: Tuple[str, ...] = None
  
    @compact
-   def __call__(self, x):
-@@ -668,6 +684,7 @@ class GroupNorm(Module):
+   def __call__(self, x, mask=None):
+@@ -875,6 +891,7 @@ class InstanceNorm(Module):
        self.use_scale,
        self.bias_init,
        self.scale_init,
@@ -376,10 +384,10 @@ index 076fd680..6eff2dd1 100644
 2.25.1
 
 
-From d1f3ec337b85b5c5377aab72d814adfc89dd4af5 Mon Sep 17 00:00:00 2001
+From 4ddde2bc878d9ff841f34e3826bbd1bce705766d Mon Sep 17 00:00:00 2001
 From: Terry Kong <terrycurtiskong@gmail.com>
 Date: Mon, 2 Oct 2023 16:10:05 -0700
-Subject: [PATCH 2/2] Added ConvTranspose sharding annotations (#3)
+Subject: [PATCH 2/3] Added ConvTranspose sharding annotations (#3)
 
 Co-authored-by: sahilj <sahilj@nvidia.com>
 ---
@@ -387,11 +395,11 @@ Co-authored-by: sahilj <sahilj@nvidia.com>
  1 file changed, 20 insertions(+), 4 deletions(-)
 
 diff --git a/flax/linen/linear.py b/flax/linen/linear.py
-index 999acf2c..8e031c77 100644
+index 4656abf9..187ab6f5 100644
 --- a/flax/linen/linear.py
 +++ b/flax/linen/linear.py
-@@ -708,6 +708,21 @@ class ConvTranspose(Module):
-   ] = initializers.zeros_init()
+@@ -796,6 +796,21 @@ class ConvTranspose(Module):
+   bias_init: Initializer = initializers.zeros_init()
    transpose_kernel: bool = False
  
 +  def param_with_axes(
@@ -412,7 +420,7 @@ index 999acf2c..8e031c77 100644
    @compact
    def __call__(self, inputs: Array) -> Array:
      """Applies a transposed convolution to the inputs.
-@@ -764,8 +779,9 @@ class ConvTranspose(Module):
+@@ -852,8 +867,9 @@ class ConvTranspose(Module):
          f'Shapes are: {self.mask.shape}, {kernel_shape}'
        )
  
@@ -424,7 +432,7 @@ index 999acf2c..8e031c77 100644
      )
  
      if self.mask is not None:
-@@ -776,8 +792,8 @@ class ConvTranspose(Module):
+@@ -864,8 +880,8 @@ class ConvTranspose(Module):
        padding_lax = 'VALID'
  
      if self.use_bias:
@@ -435,6 +443,57 @@ index 999acf2c..8e031c77 100644
        )
      else:
        bias = None
+-- 
+2.25.1
+
+
+From 9e68f4758d8a87553f3989e0a014974813e12390 Mon Sep 17 00:00:00 2001
+From: ashors1 <ashors@nvidia.com>
+Date: Thu, 1 Feb 2024 09:54:25 -0800
+Subject: [PATCH 3/3] Add missing import
+
+---
+ flax/linen/attention.py     | 1 +
+ flax/linen/linear.py        | 1 +
+ flax/linen/normalization.py | 1 +
+ 3 files changed, 3 insertions(+)
+
+diff --git a/flax/linen/attention.py b/flax/linen/attention.py
+index 2827119f..517ff2dc 100644
+--- a/flax/linen/attention.py
++++ b/flax/linen/attention.py
+@@ -39,6 +39,7 @@ from flax.typing import (
+   Initializer,
+   PrecisionLike,
+   DotGeneralT,
++  Tuple,
+ )
+ 
+ def dot_product_attention_weights(
+diff --git a/flax/linen/linear.py b/flax/linen/linear.py
+index 187ab6f5..759406ed 100644
+--- a/flax/linen/linear.py
++++ b/flax/linen/linear.py
+@@ -47,6 +47,7 @@ from flax.typing import (
+   ConvGeneralDilatedT,
+   PaddingLike,
+   LaxPadding,
++  Tuple,
+ )
+ 
+ 
+diff --git a/flax/linen/normalization.py b/flax/linen/normalization.py
+index e815f955..9e59e2be 100644
+--- a/flax/linen/normalization.py
++++ b/flax/linen/normalization.py
+@@ -32,6 +32,7 @@ from flax.typing import (
+   Shape as Shape,
+   Initializer,
+   Axes,
++  Tuple,
+ )
+ 
+ field = dataclasses.field
 -- 
 2.25.1
 


### PR DESCRIPTION
Previously the `CC=clang CXX=clang++` variables had no effect and we were building using GCC. Now that `build/build.py` has a supported `use_clang` flag, use that instead.

This PR can be merged after https://github.com/google/jax/pull/19633 is merged.