### PR TITLE
T5X arm64: Pin grain 0.0.4 source

### DIFF
--- a/.github/container/Dockerfile.t5x.arm64
+++ b/.github/container/Dockerfile.t5x.arm64
@@ -120,12 +120,13 @@ COPY --from=array_record-builder /tmp/array_record/all_dist/array_record*linux_a
             tensorflow-datasets
 # END
 
-RUN get-source.sh -l grain -m ${MANIFEST_FILE}
-
 RUN <<"EOT" bash -exu
 set -o pipefail
 
+# Check out source of grain-nightly 0.0.4
+git clone https://github.com/google/grain ${SRC_PATH_GRAIN}
 pushd ${SRC_PATH_GRAIN}
+git checkout fa79b9dea81ffb00555a6c2ae2898be4bdd5e564
 
 # Make bazel stop complaining about sharding and disable some tests with missing bazel build deps
 sed -i 's| bazel test | bazel test --test_sharding_strategy=disabled |' ./grain/oss/build_whl.sh

--- a/.github/container/manifest.yaml
+++ b/.github/container/manifest.yaml
@@ -132,12 +132,6 @@ mujoco:
   tracking_ref: main
   latest_verified_commit: ced37ffbb237584512311b041bce3124e3b2cc2a
   mode: git-clone
-grain:
-  # Used only in ARM t5x builds
-  url: https://github.com/google/grain.git
-  tracking_ref: main
-  latest_verified_commit: 41f80fb540547ec3aefe7cec57fe43228560b1cf
-  mode: git-clone
 mujoco-mpc:
   url: https://github.com/google-deepmind/mujoco_mpc.git
   tracking_ref: main


### PR DESCRIPTION
Grain's build script recently changed, breaking the way we currently call said script from the T5X arm64 build. I didn't find a quick way to fix this on the side of our Dockerfile (short of changing the base image). Instead, in the interest of unbreaking the T5X build, I pinned the grain sha corresponding to a recent, published version of the package, which still works. I'd suggest that going forward we focus on getting an arm64 wheel of grain published.