### PR TITLE
Unify JAX and Pallas unit test workflows to overcome the 20-workflow limit in CI

### DIFF
--- a/.github/workflows/_ci.yaml
+++ b/.github/workflows/_ci.yaml
@@ -201,9 +201,12 @@ jobs:
   test-jax:
     needs: build-jax
     if: inputs.ARCHITECTURE == 'amd64' # arm64 runners n/a
-    uses: ./.github/workflows/_test_jax.yaml
+    uses: ./.github/workflows/_test_unit.yaml
     with:
-      JAX_IMAGE: ${{ needs.build-jax.outputs.DOCKER_TAG_FINAL }}
+      IMAGE: ${{ needs.build-jax.outputs.DOCKER_TAG_FINAL }}
+      TEST_NAME: jax
+      ARTIFACT_NAME: artifact-jax-unit-test
+      BADGE_FILENAME: badge-jax-unit-test
     secrets: inherit
 
   test-te:
@@ -230,14 +233,16 @@ jobs:
       T5X_IMAGE: ${{ needs.build-rosetta-t5x.outputs.DOCKER_TAG_FINAL }}
     secrets: inherit
 
-  # TODO: re-activate after 20-workflow limit resolved
-  # test-pallas:
-  #   needs: build-pallas
-  #   if: inputs.ARCHITECTURE == 'amd64' # no images for arm64
-  #   uses: ./.github/workflows/_test_pallas.yaml
-  #   with:
-  #     PALLAS_IMAGE: ${{ needs.build-pallas.outputs.DOCKER_TAG_FINAL }}
-  #   secrets: inherit
+  test-pallas:
+    needs: build-pallas
+    if: inputs.ARCHITECTURE == 'amd64' # no images for arm64
+    uses: ./.github/workflows/_test_unit.yaml
+    with:
+      IMAGE: ${{ needs.build-pallas.outputs.DOCKER_TAG_FINAL }}
+      TEST_NAME: pallas
+      ARTIFACT_NAME: artifact-pallas-unit-test
+      BADGE_FILENAME: badge-pallas-unit-test
+    secrets: inherit
 
   test-upstream-pax:
     needs: build-pax

--- a/.github/workflows/_sandbox.yaml
+++ b/.github/workflows/_sandbox.yaml
@@ -1,29 +1,41 @@
 name: "~Sandbox"
 
 on:
-  push:
-
-permissions:
-  contents: read  # to fetch code
-  actions:  write # to cancel previous workflows
-  packages: write # to upload container
+  workflow_dispatch:
 
 jobs:
+  sandbox:
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
-  test-jax:
-    uses: ./.github/workflows/_test_unit.yaml
-    with:
-      IMAGE: ghcr.io/nvidia/jax:nightly-2024-02-05
-      TEST_NAME: jax
-      ARTIFACT_NAME: artifact-jax-unit-test
-      BADGE_FILENAME: badge-jax-unit-test
-    secrets: inherit
+      - name: Print usage
+        run: |
+          cat << EOF
+          This is an empty workflow file located in the main branch of your
+          repository. It serves as a testing ground for new GitHub Actions on
+          development branches before merging them to the main branch. By
+          defining and overloading this workflow on your development branch,
+          you can test new actions without affecting your main branch, ensuring
+          a smooth integration process once the changes are ready to be merged.
 
-  test-pallas:
-    uses: ./.github/workflows/_test_unit.yaml
-    with:
-      IMAGE: ghcr.io/nvidia/jax:nightly-pallas-2024-02-05
-      TEST_NAME: pallas
-      ARTIFACT_NAME: artifact-pallas-unit-test
-      BADGE_FILENAME: badge-pallas-unit-test
-    secrets: inherit
+          Usage:
+          
+          1. In your development branch, modify the sandbox.yml workflow file
+             to include the new actions you want to test. Make sure to commit
+             the changes to the development branch.
+          2. Navigate to the 'Actions' tab in your repository, select the
+             '~Sandbox' workflow, and choose your development branch from the
+             branch dropdown menu. Click on 'Run workflow' to trigger the
+             workflow on your development branch.
+          3. Once you have tested and verified the new actions in the Sandbox
+             workflow, you can incorporate them into your main workflow(s) and
+             merge the development branch into the main branch. Remember to
+             revert the changes to the sandbox.yml file in the main branch to
+             keep it empty for future testing.
+          EOF

--- a/.github/workflows/_sandbox.yaml
+++ b/.github/workflows/_sandbox.yaml
@@ -1,41 +1,29 @@
 name: "~Sandbox"
 
 on:
-  workflow_dispatch:
+  push:
+
+permissions:
+  contents: read  # to fetch code
+  actions:  write # to cancel previous workflows
+  packages: write # to upload container
 
 jobs:
-  sandbox:
-    runs-on: ubuntu-22.04
-    steps:
-      - name: Login to GitHub Container Registry
-        uses: docker/login-action@v2
-        with:
-          registry: ghcr.io
-          username: ${{ github.repository_owner }}
-          password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Print usage
-        run: |
-          cat << EOF
-          This is an empty workflow file located in the main branch of your
-          repository. It serves as a testing ground for new GitHub Actions on
-          development branches before merging them to the main branch. By
-          defining and overloading this workflow on your development branch,
-          you can test new actions without affecting your main branch, ensuring
-          a smooth integration process once the changes are ready to be merged.
+  test-jax:
+    uses: ./.github/workflows/_test_unit.yaml
+    with:
+      IMAGE: ghcr.io/nvidia/jax:nightly-2024-02-05
+      TEST_NAME: jax
+      ARTIFACT_NAME: artifact-jax-unit-test
+      BADGE_FILENAME: badge-jax-unit-test
+    secrets: inherit
 
-          Usage:
-          
-          1. In your development branch, modify the sandbox.yml workflow file
-             to include the new actions you want to test. Make sure to commit
-             the changes to the development branch.
-          2. Navigate to the 'Actions' tab in your repository, select the
-             '~Sandbox' workflow, and choose your development branch from the
-             branch dropdown menu. Click on 'Run workflow' to trigger the
-             workflow on your development branch.
-          3. Once you have tested and verified the new actions in the Sandbox
-             workflow, you can incorporate them into your main workflow(s) and
-             merge the development branch into the main branch. Remember to
-             revert the changes to the sandbox.yml file in the main branch to
-             keep it empty for future testing.
-          EOF
+  test-pallas:
+    uses: ./.github/workflows/_test_unit.yaml
+    with:
+      IMAGE: ghcr.io/nvidia/jax:nightly-pallas-2024-02-05
+      TEST_NAME: pallas
+      ARTIFACT_NAME: artifact-pallas-unit-test
+      BADGE_FILENAME: badge-pallas-unit-test
+    secrets: inherit

--- a/.github/workflows/_test_unit.yaml
+++ b/.github/workflows/_test_unit.yaml
@@ -5,24 +5,22 @@ on:
     inputs:
       IMAGE:
         type: string
-        description: 'Docker image to be tested'
+        description: 'Image to be tested'
         required: true
-      TEST_COMMANDS:
+      TEST_NAME:
         type: string
-        description: 'Test commands to run'
-        required: true
-      POSTPROC_COMMANDS:
-        type: string
-        description: 'Postprocessing commands, e.g. for generating sitreps'
+        description: 'Name of the test, must be jax or pallas'
         required: true
       ARTIFACT_NAME:
         type: string
         description: 'Name of the artifact zip file'
         required: true
-      ARTIFACT_FILES:
+        # default: 'artifact-jax-unit-test'
+      BADGE_FILENAME:
         type: string
-        description: a list/glob pattern of files to upload as artifacts
-        required: true
+        description: 'Name of the endpoint JSON file for shields.io badge'
+        required: false
+        # default: 'badge-jax-unit-test'
 
 jobs:
   runner:
@@ -33,7 +31,103 @@ jobs:
       TIME: "01:00:00"
     secrets: inherit
 
-  run-test:
+  jax-unit-test:
+    if: ${{ inputs.TEST_NAME == 'jax' }}
+    strategy:
+      fail-fast: false
+      matrix:
+        GPU_ARCH: [V100, A100]
+    # ensures A100 job lands on dedicated runner for this particular job
+    runs-on: [self-hosted, "${{ matrix.GPU_ARCH == 'A100' && format('{0}:{1}', matrix.GPU_ARCH, github.run_id) || matrix.GPU_ARCH }}"]
+    env:
+      BADGE_FILENAME_FULL: ${{ inputs.BADGE_FILENAME }}-${{ matrix.GPU_ARCH }}.json
+    steps:
+      - name: Print environment variables
+        run: env
+
+      - name: Print GPU information
+        run: nvidia-smi  
+
+      - name: Check out repository
+        uses: actions/checkout@v3
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Pull JAX image
+        shell: bash -x -e {0}
+        run: |
+          docker pull ${{ inputs.IMAGE }}
+
+      - name: Backend-independent tests
+        shell: bash -x -e {0}
+        # todo: distinguish between test failures and errors
+        continue-on-error: true
+        run: |
+          docker run --gpus all ${{ inputs.IMAGE }} test-jax.sh -b backend-independent | tee test-backend-independent.log
+
+      - name: GPU-specific tests
+        shell: bash -x -e {0}
+        continue-on-error: true
+        run: |
+          docker run --gpus all ${{ inputs.IMAGE }} test-jax.sh -b gpu | tee test-gpu.log
+
+      - name: Generate sitrep
+        shell: bash -x -e {0}
+        run: |
+          # bring in utility functions
+          source .github/workflows/scripts/to_json.sh
+
+          badge_label='JAX ${{ matrix.GPU_ARCH }} Unit'
+
+          errors=$(cat test-*.log | grep -c 'ERROR:' || true)
+          failed_tests=$(cat test-*.log | grep -c 'FAILED in' || true)
+          passed_tests=$(cat test-*.log | grep -c 'PASSED in' || true)
+          total_tests=$((failed_tests + passed_tests))
+
+          if [[ ${errors} > 0 ]] || [[ ${total_tests} == 0 ]]; then
+            badge_message='error'
+            badge_color=red
+            summary='JAX unit test on ${{ matrix.GPU_ARCH }} did not complete due to errors.'
+          else
+            badge_message="${passed_tests}/${total_tests} passed"
+            if [[ ${failed_tests} == 0 ]]; then
+              badge_color=brightgreen
+            else
+              badge_color=yellow
+            fi
+            summary="JAX unit test on ${{ matrix.GPU_ARCH }}: $badge_message"
+          fi
+
+          to_json \
+            summary \
+            errors total_tests passed_tests failed_tests \
+            badge_label badge_color badge_message \
+          > sitrep.json
+
+          schemaVersion=1 \
+          label="${badge_label}" \
+          message="${badge_message}" \
+          color="${badge_color}" \
+          to_json schemaVersion label message color \
+          > ${{ env.BADGE_FILENAME_FULL }}
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: ${{ inputs.ARTIFACT_NAME }}-${{ matrix.GPU_ARCH }}
+          path: |
+            test-backend-independent.log
+            test-gpu.log
+            sitrep.json
+            ${{ env.BADGE_FILENAME_FULL }}
+
+  pallas-unit-test:
+    if: ${{ inputs.TEST_NAME == 'pallas' }}
     strategy:
       fail-fast: false
       matrix:
@@ -59,22 +153,64 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Pull image
+      - name: Pull Pallas image
         shell: bash -x -e {0}
         run: |
           docker pull ${{ inputs.IMAGE }}
 
-      - name: Run tests
-        shell: bash -exu -o pipefail {0}
+      - name: Run Pallas tests
+        shell: bash -x -e {0}
         continue-on-error: true
-        run: ${{ inputs.TEST_COMMANDS }}
+        run: |
+          docker run --shm-size=1g --gpus all --volume $PWD:/output ${{ inputs.IMAGE }} python /opt/jax/tests/pallas/pallas_test.py --xml_output_file /output/pallas_test.xml | tee test-pallas.log
 
-      - name: Run postprocessing
-        shell: bash -exu -o pipefail {0}
-        run: ${{ inputs.POSTPROC_COMMANDS }}
+      - name: Generate sitrep
+        shell: bash -x -e {0}
+        run: |
+          # bring in utility functions
+          source .github/workflows/scripts/to_json.sh
+
+          curl -L -o yq https://github.com/mikefarah/yq/releases/latest/download/yq_linux_$(dpkg --print-architecture) && chmod 777 yq
+
+          badge_label='${{ matrix.GPU_ARCH }} Pallas'
+
+          total_tests=$(./yq '.testsuites."+@tests"' pallas_test.xml)
+          errors=$(./yq '.testsuites."+@errors"' pallas_test.xml)
+          failed_tests=$(./yq '.testsuites."+@failures"' pallas_test.xml)
+          passed_tests=$((total_tests - errors - failed_tests))
+
+          if [[ ${errors} > 0 ]] || [[ ${total_tests} == 0 ]]; then
+            badge_message='error'
+            badge_color=red
+            summary='Pallas test on ${{ matrix.GPU_ARCH }} did not complete due to errors.'
+          else
+            badge_message="${passed_tests}/${total_tests} passed"
+            if [[ ${failed_tests} == 0 ]]; then
+              badge_color=brightgreen
+            else
+              badge_color=yellow
+            fi
+            summary="Pallas unit test on ${{ matrix.GPU_ARCH }}: $badge_message"
+          fi
+
+          to_json \
+            summary \
+            errors total_tests passed_tests failed_tests \
+            badge_label badge_color badge_message \
+          > sitrep.json
+
+          schemaVersion=1 \
+          label="${badge_label}" \
+          message="${badge_message}" \
+          color="${badge_color}" \
+          to_json schemaVersion label message color \
+          > ${{ env.BADGE_FILENAME_FULL }}
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v3
         with:
           name: ${{ inputs.ARTIFACT_NAME }}-${{ matrix.GPU_ARCH }}
-          path: ${{ inputs.ARTIFACT_FILES }}
+          path: |
+            test-pallas.log
+            sitrep.json
+            ${{ env.BADGE_FILENAME_FULL }}

--- a/.github/workflows/_test_unit.yaml
+++ b/.github/workflows/_test_unit.yaml
@@ -1,0 +1,80 @@
+name: ~test, unit
+
+on:
+  workflow_call:
+    inputs:
+      IMAGE:
+        type: string
+        description: 'Docker image to be tested'
+        required: true
+      TEST_COMMANDS:
+        type: string
+        description: 'Test commands to run'
+        required: true
+      POSTPROC_COMMANDS:
+        type: string
+        description: 'Postprocessing commands, e.g. for generating sitreps'
+        required: true
+      ARTIFACT_NAME:
+        type: string
+        description: 'Name of the artifact zip file'
+        required: true
+      ARTIFACT_FILES:
+        type: string
+        description: a list/glob pattern of files to upload as artifacts
+        required: true
+
+jobs:
+  runner:
+    uses: ./.github/workflows/_runner_ondemand_slurm.yaml
+    with:
+      NAME: "A100-${{ github.run_id }}"
+      LABELS: "A100:${{ github.run_id }}"
+      TIME: "01:00:00"
+    secrets: inherit
+
+  run-test:
+    strategy:
+      fail-fast: false
+      matrix:
+        GPU_ARCH: [V100, A100]
+    # ensures A100 job lands on dedicated runner for this particular job
+    runs-on: [self-hosted, "${{ matrix.GPU_ARCH == 'A100' && format('{0}:{1}', matrix.GPU_ARCH, github.run_id) || matrix.GPU_ARCH }}"]
+    env:
+      BADGE_FILENAME_FULL: ${{ inputs.BADGE_FILENAME }}-${{ matrix.GPU_ARCH }}.json
+    steps:
+      - name: Print environment variables
+        run: env
+
+      - name: Print GPU information
+        run: nvidia-smi
+
+      - name: Check out repository
+        uses: actions/checkout@v3
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Pull image
+        shell: bash -x -e {0}
+        run: |
+          docker pull ${{ inputs.IMAGE }}
+
+      - name: Run tests
+        shell: bash -exu -o pipefail {0}
+        continue-on-error: true
+        run: ${{ inputs.TEST_COMMANDS }}
+
+      - name: Run postprocessing
+        shell: bash -exu -o pipefail {0}
+        run: ${{ inputs.POSTPROC_COMMANDS }}
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: ${{ inputs.ARTIFACT_NAME }}-${{ matrix.GPU_ARCH }}
+          path: ${{ inputs.ARTIFACT_FILES }}


### PR DESCRIPTION
This is currently done in a sort of 'brute-force' way by stitching together the two test files and use a workflow input to conditionally run one of the tests. A more systematic approach can be done in the future.