### PR TITLE
Cancel CI workflow if it is triggered by a draft PR

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -4,6 +4,11 @@ on:
   schedule:
     - cron: '30 9 * * *'  # Pacific Time 01:30 AM in UTC
   pull_request:
+    types:
+      - opened
+      - reopened
+      - ready_for_review
+      - synchronize
     paths-ignore:
       - '**.md'
   workflow_dispatch:
@@ -38,23 +43,14 @@ jobs:
       BUMP_MANIFEST: ${{ steps.if-bump-manifest.outputs.BUMP_MANIFEST }}
     steps:
       - name: Cancel workflow run if triggered by a draft PR
-        id: check-pr
-        if: github.event_name == 'pull_request'
+        id: is-draft
+        if: github.event_name == 'pull_request' && github.event.pull_request.draft == true
         run: |
-          is_draft=$(
-            curl -s \
-              -H "Authorization: token ${{ github.token }}" \
-              -H "Accept: application/vnd.github.v3+json" \
-              https://api.github.com/repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }} |\
-            jq '.draft'  
-          )
-          if [[ $is_draft == "true" ]]; then
-            echo "PR is a draft, cancelling this workflow"
-            curl -X POST -H "Authorization: token ${{ github.token }}" \
-                 -H "Accept: application/vnd.github.v3+json" \
-                 "https://api.github.com/repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/cancel"
-            cat  # blocks execution in case workflow cancellation takes time
-          fi
+          echo "Cancelling workflow for draft PR"
+          curl -X POST -H "Authorization: token ${{ github.token }}" \
+                -H "Accept: application/vnd.github.v3+json" \
+                "https://api.github.com/repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/cancel"
+          cat  # blocks execution in case workflow cancellation takes time
 
       - name: Set build date
         id: date

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -39,17 +39,22 @@ jobs:
     steps:
       - name: Cancel workflow run if triggered by a draft PR
         id: check-pr
-        if: github.event_name == 'pull_request' && github.event.pull_request.draft == true
+        if: github.event_name == 'pull_request'
         run: |
-          echo ${{ github.event_name }}
-          echo ${{ github.event.pull_request.draft }}
-          echo ${{ github.event.pull_request.draft == true }}
-          echo ${{ github.event.pull_request.draft == 'true' }}
-          echo "PR is a draft, cancelling this workflow"
-          curl -X POST -H "Authorization: token ${{ github.token }}" \
-               -H "Accept: application/vnd.github.v3+json" \
-               "https://api.github.com/repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/cancel"
-          cat  # blocks execution in case workflow cancellation takes time
+          is_draft=$(
+            curl -s \
+              -H "Authorization: token ${{ github.token }}" \
+              -H "Accept: application/vnd.github.v3+json" \
+              https://api.github.com/repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }} |\
+            jq '.draft'  
+          )
+          if [[ $is_draft == "true" ]]; then
+            echo "PR is a draft, cancelling this workflow"
+            curl -X POST -H "Authorization: token ${{ github.token }}" \
+                 -H "Accept: application/vnd.github.v3+json" \
+                 "https://api.github.com/repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/cancel"
+            cat  # blocks execution in case workflow cancellation takes time
+          fi
 
       - name: Set build date
         id: date

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -37,6 +37,16 @@ jobs:
       PUBLISH: ${{ steps.if-publish.outputs.PUBLISH }}
       BUMP_MANIFEST: ${{ steps.if-bump-manifest.outputs.BUMP_MANIFEST }}
     steps:
+      - name: Cancel workflow run if triggered by a draft PR
+        id: check-pr
+        if: github.event_name == 'pull_request' && github.event.pull_request.draft == true
+        run: |
+          echo "PR is a draft, cancelling this workflow"
+          curl -X POST -H "Authorization: token ${{ github.token }}" \
+               -H "Accept: application/vnd.github.v3+json" \
+               "https://api.github.com/repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/cancel"
+          cat  # blocks execution in case workflow cancellation takes time
+
       - name: Set build date
         id: date
         shell: bash -x -e {0}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,5 +1,5 @@
 name: CI
-run-name: CI - ${{ github.event_name == 'schedule' && format('nightly {0}', github.event.workflow_run.created_at) || format('{0} @ {1}', github.event_name, github.ref_name) }}
+run-name: CI${{ github.event_name == 'workflow_dispatch' && format(' PUBLISH={0} BUMP_MANIFEST={1}', inputs.PUBLISH, inputs.BUMP_MANIFEST) || '' }}
 
 on:
   schedule:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,5 +1,5 @@
 name: CI
-run-name: CI - ${{ github.event_name == 'schedule' && format('nightly {0}', github.event.workflow_run.created_at) || github.event_name }}
+run-name: CI - ${{ github.event_name == 'schedule' && format('nightly {0}', github.event.workflow_run.created_at) || format('{0} @ {1}', github.event_name, github.ref_name) }}
 
 on:
   schedule:
@@ -43,15 +43,15 @@ jobs:
       PUBLISH: ${{ steps.if-publish.outputs.PUBLISH }}
       BUMP_MANIFEST: ${{ steps.if-bump-manifest.outputs.BUMP_MANIFEST }}
     steps:
-      - name: Cancel workflow run if triggered by a draft PR
-        id: is-draft
+      - name: Cancel workflow run if the trigger is a draft PR
+        id: cancel-if-draft
         if: github.event_name == 'pull_request' && github.event.pull_request.draft == true
         run: |
           echo "Cancelling workflow for draft PR"
           curl -X POST -H "Authorization: token ${{ github.token }}" \
                 -H "Accept: application/vnd.github.v3+json" \
                 "https://api.github.com/repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/cancel"
-          cat  # blocks execution in case workflow cancellation takes time
+          while true; do sleep 1; done  # blocks execution in case workflow cancellation takes time
 
       - name: Set build date
         id: date

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -41,6 +41,10 @@ jobs:
         id: check-pr
         if: github.event_name == 'pull_request' && github.event.pull_request.draft == true
         run: |
+          echo ${{ github.event_name }}
+          echo ${{ github.event.pull_request.draft }}
+          echo ${{ github.event.pull_request.draft == true }}
+          echo ${{ github.event.pull_request.draft == 'true' }}
           echo "PR is a draft, cancelling this workflow"
           curl -X POST -H "Authorization: token ${{ github.token }}" \
                -H "Accept: application/vnd.github.v3+json" \


### PR DESCRIPTION
Example of the workflow that is cancelled when this draft PR is opened: 
- draft: https://github.com/NVIDIA/JAX-Toolbox/actions/runs/7835375902/attempts/1
- rerun after ready for review: https://github.com/NVIDIA/JAX-Toolbox/actions/runs/7835375902/attempts/2