### PR TITLE
Reintroduce build args into Dockerfiles

### DIFF
--- a/.github/container/Dockerfile.base
+++ b/.github/container/Dockerfile.base
@@ -52,13 +52,6 @@ rm -rf /var/lib/apt/lists/*
 EOF
 
 # install custom version of pip for VCS versioning tweaks
-RUN mkdir -p /opt/pip-tools.d
-ADD --chmod=777 \
-    get-source.sh \
-    pip-finalize.sh \
-    /usr/local/bin/
-RUN wget https://github.com/mikefarah/yq/releases/latest/download/yq_linux_$(dpkg --print-architecture) -O /usr/local/bin/yq && \
-    chmod 777 /usr/local/bin/yq
 RUN git clone -b 23.3.1 https://github.com/pypa/pip.git /opt/pip
 # Patch is specific to 23.3.1
 # Generated via: "git diff > pip-vcs-equivalency.patch"
@@ -115,12 +108,17 @@ COPY check-shm.sh /opt/nvidia/entrypoint.d/
 ADD --chmod=777 create-distribution.sh ${DEST_MANIFEST_DIR}/
 
 ###############################################################################
-## Copy manifest file to the container
+## Set up manifest system
 ###############################################################################
 
-# Set the manifest env vars
 ENV MANIFEST_FILE=${DEST_MANIFEST_DIR}/${SRC_MANIFEST_FILE}
-# Copy all required files for manifestation
 COPY ${SRC_MANIFEST_FILE} ${DEST_MANIFEST_DIR}/${SRC_MANIFEST_FILE}
 COPY patches/ ${DEST_MANIFEST_DIR}/patches/
 
+RUN mkdir -p /opt/pip-tools.d
+ADD --chmod=777 \
+    get-source.sh \
+    pip-finalize.sh \
+    /usr/local/bin/
+RUN wget https://github.com/mikefarah/yq/releases/latest/download/yq_linux_$(dpkg --print-architecture) -O /usr/local/bin/yq && \
+    chmod 777 /usr/local/bin/yq

--- a/.github/container/Dockerfile.base
+++ b/.github/container/Dockerfile.base
@@ -1,17 +1,12 @@
 # syntax=docker/dockerfile:1-labs
 
 ARG BASE_IMAGE=nvidia/cuda:12.3.0-devel-ubuntu22.04
-ARG GIT_USER_NAME="JAX Toolbox"
-ARG GIT_USER_EMAIL=jax@nvidia.com
 ARG SRC_MANIFEST_FILE=manifest.yaml
 ARG DEST_MANIFEST_DIR=/opt/manifest.d
 
 FROM ${BASE_IMAGE}
-ARG GIT_USER_EMAIL
-ARG GIT_USER_NAME
 ARG SRC_MANIFEST_FILE
 ARG DEST_MANIFEST_DIR
-
 
 ###############################################################################
 ## Install Python and essential tools
@@ -60,9 +55,10 @@ RUN <<"EOF" bash -exu -o pipefail
 cd /opt/pip
 git apply </opt/pip/pip-vcs-equivalency.patch
 git add -u
-git config user.name "${GIT_USER_NAME}"
-git config user.email "${GIT_USER_EMAIL}"
+git config --global user.name "JAX Toolbox"
+git config --global user.email "jax@nvidia.com"
 git commit -m 'Adds JAX_TOOLBOX_VCS_EQUIVALENCY as a trigger to treat all github VCS installs for a package as equivalent. The spec of the last encountered version will be used'
+rm ~/.gitconfig
 EOF
 RUN pip install --upgrade --no-cache-dir -e /opt/pip pip-tools && rm -rf ~/.cache/*
 

--- a/.github/container/Dockerfile.base
+++ b/.github/container/Dockerfile.base
@@ -5,7 +5,6 @@ ARG GIT_USER_EMAIL=jax@nvidia.com
 ARG SRC_MANIFEST_FILE=manifest.yaml
 ARG DEST_MANIFEST_DIR=/opt/manifest.d
 
-
 FROM ${BASE_IMAGE}
 ARG GIT_USER_EMAIL
 ARG GIT_USER_NAME
@@ -51,10 +50,7 @@ apt-get clean
 rm -rf /var/lib/apt/lists/*
 EOF
 
-RUN <<"EOF" bash -ex
-git config --global user.name "${GIT_USER_NAME}"
-git config --global user.email "${GIT_USER_EMAIL}"
-EOF
+# install custom version of pip for VCS versioning tweaks
 RUN mkdir -p /opt/pip-tools.d
 ADD --chmod=777 \
     get-source.sh \
@@ -70,6 +66,8 @@ RUN <<EOF bash -e -x
 cd /opt/pip
 git apply </opt/pip/pip-vcs-equivalency.patch
 git add -u
+git config user.name "${GIT_USER_NAME}"
+git config user.email "${GIT_USER_EMAIL}"
 git commit -m 'Adds JAX_TOOLBOX_VCS_EQUIVALENCY as a trigger to treat all github VCS installs for a package as equivalent. The spec of the last encountered version will be used'
 EOF
 RUN pip install --upgrade --no-cache-dir -e /opt/pip pip-tools && rm -rf ~/.cache/*
@@ -108,6 +106,12 @@ ENV PATH=/opt/amazon/efa/bin:${PATH}
 ###############################################################################
 
 COPY check-shm.sh /opt/nvidia/entrypoint.d/
+
+###############################################################################
+## Copy utility scripts to the container
+###############################################################################
+
+ADD --chmod=777 create-distribution.sh ${DEST_MANIFEST_DIR}/
 
 ###############################################################################
 ## Copy manifest file to the container

--- a/.github/container/Dockerfile.base
+++ b/.github/container/Dockerfile.base
@@ -56,7 +56,7 @@ RUN git clone -b 23.3.1 https://github.com/pypa/pip.git /opt/pip
 # Patch is specific to 23.3.1
 # Generated via: "git diff > pip-vcs-equivalency.patch"
 ADD pip-vcs-equivalency.patch /opt/pip/
-RUN <<EOF bash -e -x
+RUN <<"EOF" bash -exu -o pipefail
 cd /opt/pip
 git apply </opt/pip/pip-vcs-equivalency.patch
 git add -u

--- a/.github/container/Dockerfile.base
+++ b/.github/container/Dockerfile.base
@@ -1,4 +1,5 @@
 # syntax=docker/dockerfile:1-labs
+
 ARG BASE_IMAGE=nvidia/cuda:12.3.0-devel-ubuntu22.04
 ARG GIT_USER_NAME="JAX Toolbox"
 ARG GIT_USER_EMAIL=jax@nvidia.com

--- a/.github/container/Dockerfile.jax
+++ b/.github/container/Dockerfile.jax
@@ -1,5 +1,10 @@
 # syntax=docker/dockerfile:1-labs
+
 ARG BASE_IMAGE=ghcr.io/nvidia/jax-toolbox:base
+ARG GIT_URLREF_JAX  # if not set, will use defaults from the manifest file
+ARG GIT_URLREF_XLA
+ARG GIT_URLREF_FLAX
+ARG GIT_URLREF_TE
 ARG SRC_PATH_JAX=/opt/jax
 ARG SRC_PATH_XLA=/opt/xla
 ARG SRC_PATH_FLAX=/opt/flax
@@ -13,14 +18,23 @@ ARG BUILD_DATE
 ###############################################################################
 
 FROM ${BASE_IMAGE} as builder
+ARG GIT_URLREF_JAX
+ARG GIT_URLREF_XLA
 ARG SRC_PATH_JAX
 ARG SRC_PATH_XLA
 ARG BAZEL_CACHE
 
-RUN get-source.sh -l jax -m ${MANIFEST_FILE}
+RUN <<"EOF" bash -exu -o pipefail
+DEFAULT_GIT_URLREF_JAX=$(yq '.jax | [(.url, .latest_verified_commit)] | join("#")' ${MANIFEST_FILE})
+get-source.sh -c ${SRC_PATH_JAX} -r ${GIT_URLREF_JAX:-$DEFAULT_GIT_URLREF_JAX}
+EOF
+
 RUN --mount=type=ssh \
     --mount=type=secret,id=SSH_KNOWN_HOSTS,target=/root/.ssh/known_hosts \
-    get-source.sh -l xla -m ${MANIFEST_FILE}
+    <<EOF bash -exu -o pipefail
+DEFAULT_GIT_URLREF_XLA=$(yq '.xla | [(.url, .latest_verified_commit)] | join("#")' ${MANIFEST_FILE})
+get-source.sh -c ${SRC_PATH_XLA} -r ${GIT_URLREF_XLA:-$DEFAULT_GIT_URLREF_XLA}
+EOF
 
 ADD build-jax.sh local_cuda_arch test-jax.sh /usr/local/bin/
 # TODO: move this patch into the manifest
@@ -39,8 +53,11 @@ RUN build-jax.sh \
 
 ARG BASE_IMAGE
 FROM ${BASE_IMAGE} as mealkit
+ARG GIT_URLREF_FLAX
+ARG GIT_URLREF_TE
 ARG SRC_PATH_JAX
 ARG SRC_PATH_XLA
+ARG SRC_PATH_FLAX
 ARG SRC_PATH_TE
 ARG BUILD_DATE
 
@@ -61,7 +78,7 @@ COPY --from=builder ${SRC_PATH_XLA} ${SRC_PATH_XLA}
 ADD build-jax.sh local_cuda_arch test-jax.sh /usr/local/bin/
 
 RUN mkdir -p /opt/pip-tools.d
-RUN <<"EOF" bash -ex
+RUN <<"EOF" bash -exu -o pipefail
 # Encourage a newer numpy so that pip's dependency resolver will allow newer
 # versions of other packages that rely on newer numpy, but also include fixes
 # for compatibility with newer JAX versions. e.g. chex.
@@ -71,17 +88,21 @@ echo "jaxlib @ file://$(ls ${SRC_PATH_JAX}/dist/*.whl)" >> /opt/pip-tools.d/requ
 EOF
 
 ## Flax
-RUN get-source.sh -l flax -m ${MANIFEST_FILE} -o /opt/pip-tools.d/requirements-flax.in
+RUN <<"EOF" bash -exu -o pipefail
+DEFAULT_GIT_URLREF_FLAX=$(yq '.flax | [(.url, .latest_verified_commit)] | join("#")' ${MANIFEST_FILE})
+get-source.sh -c ${SRC_PATH_FLAX} -r ${GIT_URLREF_FLAX:-$DEFAULT_GIT_URLREF_FLAX} -p /opt/pip-tools.d/requirements-flax.in
+EOF
 
 ## Transformer engine: check out source and build wheel
 ENV NVTE_FRAMEWORK=jax
 ENV SRC_PATH_TE=${SRC_PATH_TE}
-RUN <<"EOF" bash -ex -o pipefail
-pip install ninja && rm -rf ~/.cache/pip
-get-source.sh -l transformer-engine -m ${MANIFEST_FILE}
+RUN <<"EOF" bash -exu -o pipefail
+DEFAULT_GIT_URLREF_TE=$(yq '.transformer-engine | [(.url, .latest_verified_commit)] | join("#")' ${MANIFEST_FILE})
+get-source.sh -c ${SRC_PATH_TE} -r ${GIT_URLREF_TE:-$DEFAULT_GIT_URLREF_TE}
 pushd ${SRC_PATH_TE}
-python setup.py bdist_wheel && rm -rf build
+pip install ninja && python setup.py bdist_wheel && rm -rf build
 echo "transformer-engine @ file://$(ls ${SRC_PATH_TE}/dist/*.whl)" >> /opt/pip-tools.d/requirements-te.in
+rm -rf ~/.cache/pip
 EOF
 
 # TODO: properly configure entrypoint
@@ -93,4 +114,3 @@ EOF
 FROM mealkit as final
 
 RUN pip-finalize.sh
-

--- a/.github/container/Dockerfile.jax
+++ b/.github/container/Dockerfile.jax
@@ -26,14 +26,14 @@ ARG BAZEL_CACHE
 
 RUN <<"EOF" bash -exu -o pipefail
 DEFAULT_GIT_URLREF_JAX=$(yq '.jax | [(.url, .latest_verified_commit)] | join("#")' ${MANIFEST_FILE})
-get-source.sh -c ${SRC_PATH_JAX} -r ${GIT_URLREF_JAX:-$DEFAULT_GIT_URLREF_JAX}
+get-source.sh -c ${SRC_PATH_JAX} -u ${GIT_URLREF_JAX:-$DEFAULT_GIT_URLREF_JAX}
 EOF
 
 RUN --mount=type=ssh \
     --mount=type=secret,id=SSH_KNOWN_HOSTS,target=/root/.ssh/known_hosts \
     <<EOF bash -exu -o pipefail
 DEFAULT_GIT_URLREF_XLA=$(yq '.xla | [(.url, .latest_verified_commit)] | join("#")' ${MANIFEST_FILE})
-get-source.sh -c ${SRC_PATH_XLA} -r ${GIT_URLREF_XLA:-$DEFAULT_GIT_URLREF_XLA}
+get-source.sh -c ${SRC_PATH_XLA} -u ${GIT_URLREF_XLA:-$DEFAULT_GIT_URLREF_XLA}
 EOF
 
 ADD build-jax.sh local_cuda_arch test-jax.sh /usr/local/bin/
@@ -90,7 +90,7 @@ EOF
 ## Flax
 RUN <<"EOF" bash -exu -o pipefail
 DEFAULT_GIT_URLREF_FLAX=$(yq '.flax | [(.url, .latest_verified_commit)] | join("#")' ${MANIFEST_FILE})
-get-source.sh -c ${SRC_PATH_FLAX} -r ${GIT_URLREF_FLAX:-$DEFAULT_GIT_URLREF_FLAX} -p /opt/pip-tools.d/requirements-flax.in
+get-source.sh -c ${SRC_PATH_FLAX} -u ${GIT_URLREF_FLAX:-$DEFAULT_GIT_URLREF_FLAX} -p /opt/pip-tools.d/requirements-flax.in
 EOF
 
 ## Transformer engine: check out source and build wheel
@@ -98,7 +98,7 @@ ENV NVTE_FRAMEWORK=jax
 ENV SRC_PATH_TE=${SRC_PATH_TE}
 RUN <<"EOF" bash -exu -o pipefail
 DEFAULT_GIT_URLREF_TE=$(yq '.transformer-engine | [(.url, .latest_verified_commit)] | join("#")' ${MANIFEST_FILE})
-get-source.sh -c ${SRC_PATH_TE} -r ${GIT_URLREF_TE:-$DEFAULT_GIT_URLREF_TE}
+get-source.sh -c ${SRC_PATH_TE} -u ${GIT_URLREF_TE:-$DEFAULT_GIT_URLREF_TE}
 pushd ${SRC_PATH_TE}
 pip install ninja && python setup.py bdist_wheel && rm -rf build
 echo "transformer-engine @ file://$(ls ${SRC_PATH_TE}/dist/*.whl)" >> /opt/pip-tools.d/requirements-te.in

--- a/.github/container/Dockerfile.jax
+++ b/.github/container/Dockerfile.jax
@@ -1,12 +1,9 @@
 # syntax=docker/dockerfile:1-labs
 ARG BASE_IMAGE=ghcr.io/nvidia/jax-toolbox:base
-ARG DEST_MANIFEST_DIR=/opt/manifest.d
 ARG SRC_PATH_JAX=/opt/jax
 ARG SRC_PATH_XLA=/opt/xla
 ARG SRC_PATH_FLAX=/opt/flax
 ARG SRC_PATH_TE=/opt/transformer-engine
-ARG GIT_USER_NAME="JAX Toolbox"
-ARG GIT_USER_EMAIL=jax@nvidia.com
 
 ARG BAZEL_CACHE=/tmp
 ARG BUILD_DATE
@@ -16,14 +13,9 @@ ARG BUILD_DATE
 ###############################################################################
 
 FROM ${BASE_IMAGE} as builder
-ARG DEST_MANIFEST_DIR
 ARG SRC_PATH_JAX
 ARG SRC_PATH_XLA
 ARG BAZEL_CACHE
-ARG GIT_USER_NAME
-ARG GIT_USER_EMAIL
-
-ADD --chmod=777 create-distribution.sh ${DEST_MANIFEST_DIR}/
 
 RUN get-source.sh -l jax -m ${MANIFEST_FILE}
 RUN --mount=type=ssh \
@@ -47,7 +39,6 @@ RUN build-jax.sh \
 
 ARG BASE_IMAGE
 FROM ${BASE_IMAGE} as mealkit
-ARG DEST_MANIFEST_DIR
 ARG SRC_PATH_JAX
 ARG SRC_PATH_XLA
 ARG SRC_PATH_TE
@@ -64,8 +55,6 @@ ENV CUDA_DEVICE_MAX_CONNECTIONS=1
 ENV NCCL_IB_SL=1
 ENV NCCL_NVLS_ENABLE=0
 ENV CUDA_MODULE_LOADING=EAGER
-
-ADD --chmod=777 create-distribution.sh ${DEST_MANIFEST_DIR}/
 
 COPY --from=builder ${SRC_PATH_JAX} ${SRC_PATH_JAX}
 COPY --from=builder ${SRC_PATH_XLA} ${SRC_PATH_XLA}

--- a/.github/container/Dockerfile.jax
+++ b/.github/container/Dockerfile.jax
@@ -31,7 +31,7 @@ EOF
 
 RUN --mount=type=ssh \
     --mount=type=secret,id=SSH_KNOWN_HOSTS,target=/root/.ssh/known_hosts \
-    <<EOF bash -exu -o pipefail
+    <<"EOF" bash -exu -o pipefail
 DEFAULT_GIT_URLREF_XLA=$(yq '.xla | [(.url, .latest_verified_commit)] | join("#")' ${MANIFEST_FILE})
 get-source.sh -c ${SRC_PATH_XLA} -u ${GIT_URLREF_XLA:-$DEFAULT_GIT_URLREF_XLA}
 EOF

--- a/.github/container/Dockerfile.levanter
+++ b/.github/container/Dockerfile.levanter
@@ -1,6 +1,7 @@
 # syntax=docker/dockerfile:1-labs
 
 ARG BASE_IMAGE=ghcr.io/nvidia/jax:mealkit
+ARG GIT_URLREF_LEVANTER  # if not set, will use defaults from the manifest file
 ARG SRC_PATH_LEVANTER=/opt/levanter
 
 ###############################################################################
@@ -10,9 +11,9 @@ ARG SRC_PATH_LEVANTER=/opt/levanter
 FROM ${BASE_IMAGE} as mealkit
 ARG SRC_PATH_LEVANTER
 
-RUN <<"EOF" bash -ex
-get-source.sh -l levanter -m ${MANIFEST_FILE} 
-echo "-e file://${SRC_PATH_LEVANTER}" >> /opt/pip-tools.d/requirements-levanter.in
+RUN <<"EOF" bash -exu -o pipefail
+DEFAULT_GIT_URLREF_LEVANTER=$(yq '.levanter | [(.url, .latest_verified_commit)] | join("#")' ${MANIFEST_FILE})
+get-source.sh -c ${SRC_PATH_LEVANTER} -r ${GIT_URLREF_LEVANTER:-$DEFAULT_GIT_URLREF_LEVANTER} -p /opt/pip-tools.d/requirements-levanter.in
 EOF
 
 ###############################################################################

--- a/.github/container/Dockerfile.levanter
+++ b/.github/container/Dockerfile.levanter
@@ -13,7 +13,7 @@ ARG SRC_PATH_LEVANTER
 
 RUN <<"EOF" bash -exu -o pipefail
 DEFAULT_GIT_URLREF_LEVANTER=$(yq '.levanter | [(.url, .latest_verified_commit)] | join("#")' ${MANIFEST_FILE})
-get-source.sh -c ${SRC_PATH_LEVANTER} -r ${GIT_URLREF_LEVANTER:-$DEFAULT_GIT_URLREF_LEVANTER} -p /opt/pip-tools.d/requirements-levanter.in
+get-source.sh -c ${SRC_PATH_LEVANTER} -u ${GIT_URLREF_LEVANTER:-$DEFAULT_GIT_URLREF_LEVANTER} -p /opt/pip-tools.d/requirements-levanter.in
 EOF
 
 ###############################################################################

--- a/.github/container/Dockerfile.maxtext.amd64
+++ b/.github/container/Dockerfile.maxtext.amd64
@@ -14,7 +14,8 @@ ARG SRC_PATH_MAXTEXT
 
 RUN <<"EOF" bash -exu -o pipefail
 DEFAULT_GIT_URLREF_MAXTEXT=$(yq '.maxtext | [(.url, .latest_verified_commit)] | join("#")' ${MANIFEST_FILE})
-get-source.sh -c ${SRC_PATH_MAXTEXT} -u ${GIT_URLREF_MAXTEXT:-$DEFAULT_GIT_URLREF_MAXTEXT} -p /opt/pip-tools.d/requirements-maxtext.in
+get-source.sh -c ${SRC_PATH_MAXTEXT} -u ${GIT_URLREF_MAXTEXT:-$DEFAULT_GIT_URLREF_MAXTEXT}
+cat "${SRC_PATH_MAXTEXT}/requirements.txt" >> /opt/pip-tools.d/requirements-maxtext.in
 EOF
 
 ###############################################################################
@@ -37,3 +38,5 @@ ADD test-maxtext.sh /usr/local/bin
 FROM mealkit as final
 
 RUN pip-finalize.sh
+
+WORKDIR ${SRC_PATH_MAXTEXT}

--- a/.github/container/Dockerfile.maxtext.amd64
+++ b/.github/container/Dockerfile.maxtext.amd64
@@ -14,7 +14,7 @@ ARG SRC_PATH_MAXTEXT
 
 RUN <<"EOF" bash -exu -o pipefail
 DEFAULT_GIT_URLREF_MAXTEXT=$(yq '.maxtext | [(.url, .latest_verified_commit)] | join("#")' ${MANIFEST_FILE})
-get-source.sh -c ${SRC_PATH_MAXTEXT} -r ${GIT_URLREF_MAXTEXT:-$DEFAULT_GIT_URLREF_MAXTEXT} -p /opt/pip-tools.d/requirements-maxtext.in
+get-source.sh -c ${SRC_PATH_MAXTEXT} -u ${GIT_URLREF_MAXTEXT:-$DEFAULT_GIT_URLREF_MAXTEXT} -p /opt/pip-tools.d/requirements-maxtext.in
 EOF
 
 ###############################################################################

--- a/.github/container/Dockerfile.maxtext.amd64
+++ b/.github/container/Dockerfile.maxtext.amd64
@@ -1,6 +1,7 @@
 # syntax=docker/dockerfile:1-labs
 
 ARG BASE_IMAGE=ghcr.io/nvidia/jax:mealkit
+ARG GIT_URLREF_MAXTEXT  # if not set, will use defaults from the manifest file
 ARG SRC_PATH_MAXTEXT=/opt/maxtext
 
 ###############################################################################
@@ -8,13 +9,12 @@ ARG SRC_PATH_MAXTEXT=/opt/maxtext
 ###############################################################################
 
 FROM ${BASE_IMAGE} as mealkit
-
+ARG GIT_URLREF_MAXTEXT
 ARG SRC_PATH_MAXTEXT
 
-RUN <<"EOF" bash -ex
-cat ${MANIFEST_FILE}
-get-source.sh -l maxtext -m ${MANIFEST_FILE} 
-cat "${SRC_PATH_MAXTEXT}/requirements.txt" >> /opt/pip-tools.d/requirements-maxtext.in
+RUN <<"EOF" bash -exu -o pipefail
+DEFAULT_GIT_URLREF_MAXTEXT=$(yq '.maxtext | [(.url, .latest_verified_commit)] | join("#")' ${MANIFEST_FILE})
+get-source.sh -c ${SRC_PATH_MAXTEXT} -r ${GIT_URLREF_MAXTEXT:-$DEFAULT_GIT_URLREF_MAXTEXT} -p /opt/pip-tools.d/requirements-maxtext.in
 EOF
 
 ###############################################################################
@@ -25,7 +25,7 @@ ADD maxtext-mha.patch /opt
 RUN cd "${SRC_PATH_MAXTEXT}" && patch -p1 < /opt/maxtext-mha.patch && git diff
 
 ###############################################################################
-## Apply patch
+## Add test script
 ###############################################################################
 
 ADD test-maxtext.sh /usr/local/bin
@@ -37,5 +37,3 @@ ADD test-maxtext.sh /usr/local/bin
 FROM mealkit as final
 
 RUN pip-finalize.sh
-
-WORKDIR ${SRC_PATH_MAXTEXT}

--- a/.github/container/Dockerfile.mjx
+++ b/.github/container/Dockerfile.mjx
@@ -1,22 +1,27 @@
 # syntax=docker/dockerfile:1-labs
 
 ARG BASE_IMAGE=ghcr.io/nvidia/jax:mealkit
+ARG GIT_URLREF_MUJOCO  # if not set, will use defaults from the manifest file
+ARG GIT_URLREF_MUJOCO_MPC
+ARG GIT_URLREF_L2R
 ARG SRC_PATH_MUJOCO=/opt/mujoco
 ARG SRC_PATH_MUJOCO_MPC=/opt/mujoco-mpc
 ARG SRC_PATH_L2R=/opt/language-to-reward-2023
-
 
 ###############################################################################
 ## Download source and add auxiliary scripts
 ###############################################################################
 
 FROM ${BASE_IMAGE} as mealkit
+ARG GIT_URLREF_MUJOCO
+ARG GIT_URLREF_MUJOCO_MPC
+ARG GIT_URLREF_L2R
 ARG SRC_PATH_MUJOCO
 ARG SRC_PATH_MUJOCO_MPC
 ARG SRC_PATH_L2R
 
 # Install system dependencies for Mujuco/MPC
-RUN <<"EOF" bash -ex
+RUN <<"EOF" bash -exu -o pipefail
 apt-get update
 apt-get install -y \
     libgl1-mesa-dev \
@@ -30,16 +35,18 @@ rm -rf /var/lib/apt/lists/*
 EOF
 
 # Specify installation targets
-RUN <<"EOF" bash -ex
-get-source.sh -l mujoco -m ${MANIFEST_FILE} -b $(dirname ${SRC_PATH_MUJOCO})
-get-source.sh -l mujoco-mpc -m ${MANIFEST_FILE}
-get-source.sh -l language-to-reward-2023 -m ${MANIFEST_FILE}
+RUN <<"EOF" bash -exu -o pipefail
+DEFAULT_GIT_URLREF_MUJOCO=$(yq '.mujoco | [(.url, .latest_verified_commit)] | join("#")' ${MANIFEST_FILE})
+DEFAULT_GIT_URLREF_MUJOCO_MPC=$(yq '.mujoco-mpc | [(.url, .latest_verified_commit)] | join("#")' ${MANIFEST_FILE})
+get-source.sh -c ${SRC_PATH_MUJOCO} -r ${GIT_URLREF_MUJOCO:-$DEFAULT_GIT_URLREF_MUJOCO}
+get-source.sh -c ${SRC_PATH_MUJOCO_MPC} -r ${GIT_URLREF_MUJOCO_MPC:-$DEFAULT_GIT_URLREF_MUJOCO_MPC}
 echo "-f https://py.mujoco.org/" >> /opt/pip-tools.d/requirements-mjx.in
 echo "-e file://${SRC_PATH_MUJOCO}/mjx" >> /opt/pip-tools.d/requirements-mjx.in
 echo "-e file://${SRC_PATH_MUJOCO_MPC}/python" >> /opt/pip-tools.d/requirements-l2r.in
-echo "-e file://${SRC_PATH_L2R}" >> /opt/pip-tools.d/requirements-l2r.in
-EOF
 
+DEFAULT_GIT_URLREF_L2R=$(yq '.language-to-reward-2023 | [(.url, .latest_verified_commit)] | join("#")' ${MANIFEST_FILE})
+get-source.sh -c ${SRC_PATH_L2R} -r ${GIT_URLREF_L2R:-$DEFAULT_GIT_URLREF_L2R} -p /opt/pip-tools.d/requirements-l2r.in
+EOF
 
 ###############################################################################
 ## Install accumulated packages from the base image and the previous stage

--- a/.github/container/Dockerfile.mjx
+++ b/.github/container/Dockerfile.mjx
@@ -38,14 +38,14 @@ EOF
 RUN <<"EOF" bash -exu -o pipefail
 DEFAULT_GIT_URLREF_MUJOCO=$(yq '.mujoco | [(.url, .latest_verified_commit)] | join("#")' ${MANIFEST_FILE})
 DEFAULT_GIT_URLREF_MUJOCO_MPC=$(yq '.mujoco-mpc | [(.url, .latest_verified_commit)] | join("#")' ${MANIFEST_FILE})
-get-source.sh -c ${SRC_PATH_MUJOCO} -r ${GIT_URLREF_MUJOCO:-$DEFAULT_GIT_URLREF_MUJOCO}
-get-source.sh -c ${SRC_PATH_MUJOCO_MPC} -r ${GIT_URLREF_MUJOCO_MPC:-$DEFAULT_GIT_URLREF_MUJOCO_MPC}
+get-source.sh -c ${SRC_PATH_MUJOCO} -u ${GIT_URLREF_MUJOCO:-$DEFAULT_GIT_URLREF_MUJOCO}
+get-source.sh -c ${SRC_PATH_MUJOCO_MPC} -u ${GIT_URLREF_MUJOCO_MPC:-$DEFAULT_GIT_URLREF_MUJOCO_MPC}
 echo "-f https://py.mujoco.org/" >> /opt/pip-tools.d/requirements-mjx.in
 echo "-e file://${SRC_PATH_MUJOCO}/mjx" >> /opt/pip-tools.d/requirements-mjx.in
 echo "-e file://${SRC_PATH_MUJOCO_MPC}/python" >> /opt/pip-tools.d/requirements-l2r.in
 
 DEFAULT_GIT_URLREF_L2R=$(yq '.language-to-reward-2023 | [(.url, .latest_verified_commit)] | join("#")' ${MANIFEST_FILE})
-get-source.sh -c ${SRC_PATH_L2R} -r ${GIT_URLREF_L2R:-$DEFAULT_GIT_URLREF_L2R} -p /opt/pip-tools.d/requirements-l2r.in
+get-source.sh -c ${SRC_PATH_L2R} -u ${GIT_URLREF_L2R:-$DEFAULT_GIT_URLREF_L2R} -p /opt/pip-tools.d/requirements-l2r.in
 EOF
 
 ###############################################################################

--- a/.github/container/Dockerfile.pallas
+++ b/.github/container/Dockerfile.pallas
@@ -14,7 +14,7 @@ ARG SRC_PATH_OPENXLA_TRITON
 
 RUN <<"EOF" bash -exu -o pipefail
 DEFAULT_GIT_URLREF_OPENXLA_TRITON=$(yq '.openxla-triton | [(.url, .latest_verified_commit)] | join("#")' ${MANIFEST_FILE})
-get-source.sh -c ${SRC_PATH_OPENXLA_TRITON} -r ${GIT_URLREF_OPENXLA_TRITON:-$DEFAULT_GIT_URLREF_OPENXLA_TRITON}
+get-source.sh -c ${SRC_PATH_OPENXLA_TRITON} -u ${GIT_URLREF_OPENXLA_TRITON:-$DEFAULT_GIT_URLREF_OPENXLA_TRITON}
 EOF
 
 RUN <<"EOF" bash -exu -o pipefail
@@ -41,7 +41,7 @@ RUN echo "triton @ file://$(ls ${SRC_PATH_OPENXLA_TRITON}/dist/triton-*.whl)" >>
 # Check out jax-triton
 RUN <<"EOF" bash -exu -o pipefail
 DEFAULT_GIT_URLREF_JAX_TRITON=$(yq '.jax-triton | [(.url, .latest_verified_commit)] | join("#")' ${MANIFEST_FILE})
-get-source.sh -c ${SRC_PATH_JAX_TRITON} -r ${GIT_URLREF_JAX_TRITON:-$DEFAULT_GIT_URLREF_JAX_TRITON} -p /opt/pip-tools.d/requirements-pallas.in
+get-source.sh -c ${SRC_PATH_JAX_TRITON} -u ${GIT_URLREF_JAX_TRITON:-$DEFAULT_GIT_URLREF_JAX_TRITON} -p /opt/pip-tools.d/requirements-pallas.in
 sed -i 's|"jax @ [^"]\+"|"jax"|g;s|"triton-nightly @ [^"]\+"|"triton"|g' /opt/jax-triton/pyproject.toml
 EOF
 

--- a/.github/container/Dockerfile.pallas
+++ b/.github/container/Dockerfile.pallas
@@ -1,42 +1,47 @@
 # syntax=docker/dockerfile:1-labs
 ARG BASE_IMAGE=ghcr.io/nvidia/jax:mealkit
-ARG SRC_PATH_TRITON=/opt/openxla-triton
+ARG GIT_URLREF_OPENXLA_TRITON  # if not set, will use defaults from the manifest file
+ARG GIT_URLREF_JAX_TRITON
+ARG SRC_PATH_OPENXLA_TRITON=/opt/openxla-triton
+ARG SRC_PATH_JAX_TRITON=/opt/jax-triton
 
 ###############################################################################
 ## Check out Triton source and build a wheel
 ###############################################################################
 FROM ${BASE_IMAGE} as builder
+ARG GIT_URLREF_OPENXLA_TRITON
+ARG SRC_PATH_OPENXLA_TRITON
 
-ARG SRC_PATH_TRITON
+RUN <<"EOF" bash -exu -o pipefail
+DEFAULT_GIT_URLREF_OPENXLA_TRITON=$(yq '.openxla-triton | [(.url, .latest_verified_commit)] | join("#")' ${MANIFEST_FILE})
+get-source.sh -c ${SRC_PATH_OPENXLA_TRITON} -r ${GIT_URLREF_OPENXLA_TRITON:-$DEFAULT_GIT_URLREF_OPENXLA_TRITON}
+EOF
 
-# bump-openxla-triton.sh ensures that the commit of openxla-triton referenced
-# in the manifest file is consistent with the commit of xla
-RUN get-source.sh -l openxla-triton -m ${MANIFEST_FILE}
-
-RUN <<"EOF" bash -ex
-mkdir -p "${SRC_PATH_TRITON}/dist"
-sed -i 's|backends = _copy_backends(\["nvidia", "amd"\])|backends = _copy_backends(["nvidia"])|g' "${SRC_PATH_TRITON}/python/setup.py"
-sed -i '1s|^|include_directories(${CMAKE_SOURCE_DIR}/third_party/nvidia/backend/include)\n|' "${SRC_PATH_TRITON}/lib/Conversion/TritonGPUToLLVM/CMakeLists.txt"
-pip wheel --wheel-dir="${SRC_PATH_TRITON}/dist" "${SRC_PATH_TRITON}/python"
+RUN <<"EOF" bash -exu -o pipefail
+mkdir -p "${SRC_PATH_OPENXLA_TRITON}/dist"
+sed -i 's|backends = _copy_backends(\["nvidia", "amd"\])|backends = _copy_backends(["nvidia"])|g' "${SRC_PATH_OPENXLA_TRITON}/python/setup.py"
+sed -i '1s|^|include_directories(${CMAKE_SOURCE_DIR}/third_party/nvidia/backend/include)\n|' "${SRC_PATH_OPENXLA_TRITON}/lib/Conversion/TritonGPUToLLVM/CMakeLists.txt"
+pip wheel --wheel-dir="${SRC_PATH_OPENXLA_TRITON}/dist" "${SRC_PATH_OPENXLA_TRITON}/python"
 EOF
 
 # clean up the wheel build directory so it doesn't end up bloating the container
-RUN rm -rf "${SRC_PATH_TRITON}/python/build"
+RUN rm -rf "${SRC_PATH_OPENXLA_TRITON}/python/build"
 
 ###############################################################################
 ## Download source and add auxiliary scripts
 ###############################################################################
 FROM ${BASE_IMAGE} as mealkit
-
-ARG SRC_PATH_TRITON
+ARG GIT_URLREF_JAX_TRITON
+ARG SRC_PATH_OPENXLA_TRITON
 
 # Get the triton source + wheel from the build step
-COPY --from=builder ${SRC_PATH_TRITON} ${SRC_PATH_TRITON}
-RUN echo "triton @ file://$(ls ${SRC_PATH_TRITON}/dist/triton-*.whl)" >> /opt/pip-tools.d/requirements-pallas.in
+COPY --from=builder ${SRC_PATH_OPENXLA_TRITON} ${SRC_PATH_OPENXLA_TRITON}
+RUN echo "triton @ file://$(ls ${SRC_PATH_OPENXLA_TRITON}/dist/triton-*.whl)" >> /opt/pip-tools.d/requirements-pallas.in
 
 # Check out jax-triton
-RUN <<"EOF" bash -ex
-get-source.sh -l jax-triton -m ${MANIFEST_FILE} -o /opt/pip-tools.d/requirements-pallas.in
+RUN <<"EOF" bash -exu -o pipefail
+DEFAULT_GIT_URLREF_JAX_TRITON=$(yq '.jax-triton | [(.url, .latest_verified_commit)] | join("#")' ${MANIFEST_FILE})
+get-source.sh -c ${SRC_PATH_JAX_TRITON} -r ${GIT_URLREF_JAX_TRITON:-$DEFAULT_GIT_URLREF_JAX_TRITON} -p /opt/pip-tools.d/requirements-pallas.in
 sed -i 's|"jax @ [^"]\+"|"jax"|g;s|"triton-nightly @ [^"]\+"|"triton"|g' /opt/jax-triton/pyproject.toml
 EOF
 

--- a/.github/container/Dockerfile.pallas
+++ b/.github/container/Dockerfile.pallas
@@ -33,6 +33,7 @@ RUN rm -rf "${SRC_PATH_OPENXLA_TRITON}/python/build"
 FROM ${BASE_IMAGE} as mealkit
 ARG GIT_URLREF_JAX_TRITON
 ARG SRC_PATH_OPENXLA_TRITON
+ARG SRC_PATH_JAX_TRITON
 
 # Get the triton source + wheel from the build step
 COPY --from=builder ${SRC_PATH_OPENXLA_TRITON} ${SRC_PATH_OPENXLA_TRITON}

--- a/.github/container/Dockerfile.pax.amd64
+++ b/.github/container/Dockerfile.pax.amd64
@@ -1,6 +1,8 @@
 # syntax=docker/dockerfile:1-labs
 
 ARG BASE_IMAGE=ghcr.io/nvidia/jax:mealkit
+ARG GIT_URLREF_PAXML  # if not set, will use defaults from the manifest file
+ARG GIT_URLREF_PRAXIS
 ARG SRC_PATH_PAXML=/opt/paxml
 ARG SRC_PATH_PRAXIS=/opt/praxis
 
@@ -9,18 +11,25 @@ ARG SRC_PATH_PRAXIS=/opt/praxis
 ###############################################################################
 
 FROM ${BASE_IMAGE} as mealkit
+ARG GIT_URLREF_PAXML
+ARG GIT_URLREF_PRAXIS
 ARG SRC_PATH_PAXML
 ARG SRC_PATH_PRAXIS
 
 # update TE manifest file to install the [test] extras
 RUN sed -i "s/transformer-engine @/transformer-engine[test] @/g" /opt/pip-tools.d/requirements-te.in
 
-RUN <<"EOF" bash -ex
-get-source.sh -l paxml -m ${MANIFEST_FILE}
-get-source.sh -l praxis -m ${MANIFEST_FILE}
-echo "-e file://${SRC_PATH_PAXML}[gpu]" >> /opt/pip-tools.d/requirements-paxml.in
-echo "-e file://${SRC_PATH_PRAXIS}"     >> /opt/pip-tools.d/requirements-paxml.in
+# obtain paxml and praxis source
+RUN <<"EOF" bash -exu -o pipefail
+DEFAULT_GIT_URLREF_PAXML=$(yq '.paxml | [(.url, .latest_verified_commit)] | join("#")' ${MANIFEST_FILE})
+DEFAULT_GIT_URLREF_PRAXIS=$(yq '.praxis | [(.url, .latest_verified_commit)] | join("#")' ${MANIFEST_FILE})
+get-source.sh -c ${SRC_PATH_PAXML} -r ${GIT_URLREF_PAXML:-$DEFAULT_GIT_URLREF_PAXML} -p /opt/pip-tools.d/requirements-paxml.in
+get-source.sh -c ${SRC_PATH_PRAXIS} -r ${GIT_URLREF_PRAXIS:-$DEFAULT_GIT_URLREF_PRAXIS} -p /opt/pip-tools.d/requirements-paxml.in
+sed -i "s|${SRC_PATH_PAXML}|${SRC_PATH_PAXML}[gpu]|g" /opt/pip-tools.d/requirements-paxml.in
+EOF
 
+# remove head-of-tree references to packages already shipped in the container
+RUN <<"EOF" bash -exu -o pipefail
 for src in ${SRC_PATH_PAXML} ${SRC_PATH_PRAXIS}; do
   pushd ${src}
   sed -i "s| @ git+https://github.com/google/flax||g" requirements.in

--- a/.github/container/Dockerfile.pax.amd64
+++ b/.github/container/Dockerfile.pax.amd64
@@ -23,8 +23,8 @@ RUN sed -i "s/transformer-engine @/transformer-engine[test] @/g" /opt/pip-tools.
 RUN <<"EOF" bash -exu -o pipefail
 DEFAULT_GIT_URLREF_PAXML=$(yq '.paxml | [(.url, .latest_verified_commit)] | join("#")' ${MANIFEST_FILE})
 DEFAULT_GIT_URLREF_PRAXIS=$(yq '.praxis | [(.url, .latest_verified_commit)] | join("#")' ${MANIFEST_FILE})
-get-source.sh -c ${SRC_PATH_PAXML} -r ${GIT_URLREF_PAXML:-$DEFAULT_GIT_URLREF_PAXML} -p /opt/pip-tools.d/requirements-paxml.in
-get-source.sh -c ${SRC_PATH_PRAXIS} -r ${GIT_URLREF_PRAXIS:-$DEFAULT_GIT_URLREF_PRAXIS} -p /opt/pip-tools.d/requirements-paxml.in
+get-source.sh -c ${SRC_PATH_PAXML} -u ${GIT_URLREF_PAXML:-$DEFAULT_GIT_URLREF_PAXML} -p /opt/pip-tools.d/requirements-paxml.in
+get-source.sh -c ${SRC_PATH_PRAXIS} -u ${GIT_URLREF_PRAXIS:-$DEFAULT_GIT_URLREF_PRAXIS} -p /opt/pip-tools.d/requirements-paxml.in
 sed -i "s|${SRC_PATH_PAXML}|${SRC_PATH_PAXML}[gpu]|g" /opt/pip-tools.d/requirements-paxml.in
 EOF
 

--- a/.github/container/Dockerfile.pax.amd64
+++ b/.github/container/Dockerfile.pax.amd64
@@ -38,7 +38,10 @@ for src in ${SRC_PATH_PAXML} ${SRC_PATH_PRAXIS}; do
       echo "URL specs no longer present in select dependencies for ${src}"
       exit 1
   else
+      git config --global user.name "JAX Toolbox"
+      git config --global user.email "jax@nvidia.com"
       git commit -a -m "remove URL specs from select dependencies for ${src}"
+      rm ~/.gitconfig
   fi
   popd
 done

--- a/.github/container/Dockerfile.pax.arm64
+++ b/.github/container/Dockerfile.pax.arm64
@@ -142,7 +142,10 @@ for src in ${SRC_PATH_PAXML} ${SRC_PATH_PRAXIS}; do
       echo "broken dependencies no longer present in ${src}"
       exit 1
   else
+      git config --global user.name "JAX Toolbox"
+      git config --global user.email "jax@nvidia.com"
       git commit -a -m "remove broken dependencies from ${src}"
+      rm ~/.gitconfig
   fi
   popd
 done

--- a/.github/container/Dockerfile.pax.arm64
+++ b/.github/container/Dockerfile.pax.arm64
@@ -31,7 +31,7 @@ ARG SRC_PATH_TFTEXT
 RUN <<"EOF" bash -exu -o pipefail
 pip install tensorflow_datasets==4.9.2 auditwheel tensorflow==2.13.0
 DEFAULT_GIT_URLREF_TFTEXT=$(yq '.tensorflow-text | [(.url, .latest_verified_commit)] | join("#")' ${MANIFEST_FILE})
-get-source.sh -c ${SRC_PATH_TFTEXT} -r ${GIT_URLREF_TFTEXT:-$DEFAULT_GIT_URLREF_TFTEXT}
+get-source.sh -c ${SRC_PATH_TFTEXT} -u ${GIT_URLREF_TFTEXT:-$DEFAULT_GIT_URLREF_TFTEXT}
 cd ${SRC_PATH_TFTEXT}
 ./oss_scripts/run_build.sh
 EOF
@@ -50,7 +50,7 @@ COPY --from=tftext-builder ${SRC_PATH_TFTEXT}/tensorflow_text*.whl /opt/
 # get lingvo source
 RUN <<"EOF" bash -exu -o pipefail
 DEFAULT_GIT_URLREF_LINGVO=$(yq '.lingvo | [(.url, .latest_verified_commit)] | join("#")' ${MANIFEST_FILE})
-get-source.sh -c ${SRC_PATH_LINGVO} -r ${GIT_URLREF_LINGVO:-$DEFAULT_GIT_URLREF_LINGVO}
+get-source.sh -c ${SRC_PATH_LINGVO} -u ${GIT_URLREF_LINGVO:-$DEFAULT_GIT_URLREF_LINGVO}
 EOF
 
 # build lingvo
@@ -109,8 +109,8 @@ RUN echo "tensorflow-text @ file://$(ls /opt/tensorflow_text*.whl)" >> /opt/pip-
 RUN <<"EOF" bash -exu -o pipefail
 DEFAULT_GIT_URLREF_PAXML=$(yq '.paxml | [(.url, .latest_verified_commit)] | join("#")' ${MANIFEST_FILE})
 DEFAULT_GIT_URLREF_PRAXIS=$(yq '.praxis | [(.url, .latest_verified_commit)] | join("#")' ${MANIFEST_FILE})
-get-source.sh -c ${SRC_PATH_PAXML} -r ${GIT_URLREF_PAXML:-$DEFAULT_GIT_URLREF_PAXML} -p /opt/pip-tools.d/requirements-paxml.in
-get-source.sh -c ${SRC_PATH_PRAXIS} -r ${GIT_URLREF_PRAXIS:-$DEFAULT_GIT_URLREF_PRAXIS} -p /opt/pip-tools.d/requirements-paxml.in
+get-source.sh -c ${SRC_PATH_PAXML} -u ${GIT_URLREF_PAXML:-$DEFAULT_GIT_URLREF_PAXML} -p /opt/pip-tools.d/requirements-paxml.in
+get-source.sh -c ${SRC_PATH_PRAXIS} -u ${GIT_URLREF_PRAXIS:-$DEFAULT_GIT_URLREF_PRAXIS} -p /opt/pip-tools.d/requirements-paxml.in
 sed -i "s|${SRC_PATH_PAXML}|${SRC_PATH_PAXML}[gpu]|g" /opt/pip-tools.d/requirements-paxml.in
 EOF
 

--- a/.github/container/Dockerfile.pax.arm64
+++ b/.github/container/Dockerfile.pax.arm64
@@ -1,6 +1,10 @@
 # syntax=docker/dockerfile:1-labs
 
 ARG BASE_IMAGE=ghcr.io/nvidia/jax:mealkit
+ARG GIT_URLREF_PAXML  # if not set, will use defaults from the manifest file
+ARG GIT_URLREF_PRAXIS
+ARG GIT_URLREF_TFTEXT
+ARG GIT_URLREF_LINGVO
 ARG SRC_PATH_PAXML=/opt/paxml
 ARG SRC_PATH_PRAXIS=/opt/praxis
 ARG SRC_PATH_TFTEXT=/opt/tensorflow-text
@@ -22,10 +26,12 @@ RUN wget https://github.com/bazelbuild/bazelisk/releases/download/v1.17.0/bazeli
 #------------------------------------------------------------------------------
 
 FROM wheel-builder as tftext-builder
+ARG GIT_URLREF_TFTEXT
 ARG SRC_PATH_TFTEXT
 RUN <<"EOF" bash -exu -o pipefail
 pip install tensorflow_datasets==4.9.2 auditwheel tensorflow==2.13.0
-get-source.sh -l tensorflow-text -m ${MANIFEST_FILE}
+DEFAULT_GIT_URLREF_TFTEXT=$(yq '.tensorflow-text | [(.url, .latest_verified_commit)] | join("#")' ${MANIFEST_FILE})
+get-source.sh -c ${SRC_PATH_TFTEXT} -r ${GIT_URLREF_TFTEXT:-$DEFAULT_GIT_URLREF_TFTEXT}
 cd ${SRC_PATH_TFTEXT}
 ./oss_scripts/run_build.sh
 EOF
@@ -35,16 +41,20 @@ EOF
 #------------------------------------------------------------------------------
 
 FROM wheel-builder as lingvo-builder
+ARG GIT_URLREF_LINGVO
 ARG SRC_PATH_TFTEXT
 ARG SRC_PATH_LINGVO
 
 COPY --from=tftext-builder ${SRC_PATH_TFTEXT}/tensorflow_text*.whl /opt/
 
-RUN get-source.sh -l lingvo -m ${MANIFEST_FILE}
+# get lingvo source
+RUN <<"EOF" bash -exu -o pipefail
+DEFAULT_GIT_URLREF_LINGVO=$(yq '.lingvo | [(.url, .latest_verified_commit)] | join("#")' ${MANIFEST_FILE})
+get-source.sh -c ${SRC_PATH_LINGVO} -r ${GIT_URLREF_LINGVO:-$DEFAULT_GIT_URLREF_LINGVO}
+EOF
 
 # build lingvo
 RUN <<"EOF" bash -exu -o pipefail
-
 pushd ${SRC_PATH_LINGVO}
 
 # Use aarch distribution of protobufs
@@ -83,6 +93,8 @@ EOF
 
 ARG BASE_IMAGE
 FROM ${BASE_IMAGE} as mealkit
+ARG GIT_URLREF_PAXML
+ARG GIT_URLREF_PRAXIS
 ARG SRC_PATH_PAXML
 ARG SRC_PATH_PRAXIS
 ARG SRC_PATH_TFTEXT
@@ -93,17 +105,22 @@ RUN echo "lingvo @ file://$(ls /opt/lingvo*.whl)" >> /opt/pip-tools.d/requiremen
 COPY --from=tftext-builder ${SRC_PATH_TFTEXT}/tensorflow_text*.whl /opt/
 RUN echo "tensorflow-text @ file://$(ls /opt/tensorflow_text*.whl)" >> /opt/pip-tools.d/requirements-paxml.in
 
-# paxml + praxis
+# obtain paxml and praxis source
+RUN <<"EOF" bash -exu -o pipefail
+DEFAULT_GIT_URLREF_PAXML=$(yq '.paxml | [(.url, .latest_verified_commit)] | join("#")' ${MANIFEST_FILE})
+DEFAULT_GIT_URLREF_PRAXIS=$(yq '.praxis | [(.url, .latest_verified_commit)] | join("#")' ${MANIFEST_FILE})
+get-source.sh -c ${SRC_PATH_PAXML} -r ${GIT_URLREF_PAXML:-$DEFAULT_GIT_URLREF_PAXML} -p /opt/pip-tools.d/requirements-paxml.in
+get-source.sh -c ${SRC_PATH_PRAXIS} -r ${GIT_URLREF_PRAXIS:-$DEFAULT_GIT_URLREF_PRAXIS} -p /opt/pip-tools.d/requirements-paxml.in
+sed -i "s|${SRC_PATH_PAXML}|${SRC_PATH_PAXML}[gpu]|g" /opt/pip-tools.d/requirements-paxml.in
+EOF
+
+# remove dep references to packages already shipped in the container
+# modify dependencies due to arm64 wheel availability
 RUN <<"EOF" bash -ex
 echo "tensorflow==2.13.0" >> /opt/pip-tools.d/requirements-paxml.in
 echo "tensorflow_datasets==4.9.2" >> /opt/pip-tools.d/requirements-paxml.in
 echo "chex==0.1.7" >> /opt/pip-tools.d/requirements-paxml.in
 echo "auditwheel" >> /opt/pip-tools.d/requirements-paxml.in
-
-get-source.sh -l paxml  -m ${MANIFEST_FILE}
-get-source.sh -l praxis -m ${MANIFEST_FILE}
-echo "-e file://${SRC_PATH_PAXML}[gpu]" >> /opt/pip-tools.d/requirements-paxml.in
-echo "-e file://${SRC_PATH_PRAXIS}"     >> /opt/pip-tools.d/requirements-paxml.in
 
 for src in ${SRC_PATH_PAXML} ${SRC_PATH_PRAXIS}; do
   pushd ${src}

--- a/.github/container/Dockerfile.t5x.amd64
+++ b/.github/container/Dockerfile.t5x.amd64
@@ -27,7 +27,10 @@ if git diff --quiet; then
     echo "URL specs no longer present in select dependencies of t5x"
     exit 1
 else
+    git config --global user.name "JAX Toolbox"
+    git config --global user.email "jax@nvidia.com"
     git commit -a -m "remove URL specs from select dependencies of t5x"
+    rm ~/.gitconfig
 fi
 popd
 EOF

--- a/.github/container/Dockerfile.t5x.amd64
+++ b/.github/container/Dockerfile.t5x.amd64
@@ -1,6 +1,7 @@
 # syntax=docker/dockerfile:1-labs
 
 ARG BASE_IMAGE=ghcr.io/nvidia/jax:mealkit
+ARG GIT_URLREF_T5X  # if not set, will use defaults from the manifest file
 ARG SRC_PATH_T5X=/opt/t5x
 
 ###############################################################################
@@ -8,14 +9,18 @@ ARG SRC_PATH_T5X=/opt/t5x
 ###############################################################################
 
 FROM ${BASE_IMAGE} as mealkit
-
+ARG GIT_URLREF_T5X
 ARG SRC_PATH_T5X
 
-RUN <<"EOF" bash -ex
-get-source.sh -l t5x -m ${MANIFEST_FILE}
-echo "-e file://${SRC_PATH_T5X}[gpu]" >> /opt/pip-tools.d/requirements-t5x.in
+# obtain t5x source
+RUN <<"EOF" bash -exu -o pipefail
+DEFAULT_GIT_URLREF_T5X=$(yq '.t5x | [(.url, .latest_verified_commit)] | join("#")' ${MANIFEST_FILE})
+get-source.sh -c ${SRC_PATH_T5X} -r ${GIT_URLREF_T5X:-$DEFAULT_GIT_URLREF_T5X} -p /opt/pip-tools.d/requirements-t5x.in
+sed -i "s|${SRC_PATH_T5X}|${SRC_PATH_T5X}[gpu]|g" /opt/pip-tools.d/requirements-t5x.in
+EOF
 
 # remove head-of-tree specs from select dependencies
+RUN <<"EOF" bash -exu -o pipefail
 pushd ${SRC_PATH_T5X}
 sed -i "s| @ git+https://github.com/google/flax#egg=flax||g" setup.py
 if git diff --quiet; then

--- a/.github/container/Dockerfile.t5x.amd64
+++ b/.github/container/Dockerfile.t5x.amd64
@@ -15,7 +15,7 @@ ARG SRC_PATH_T5X
 # obtain t5x source
 RUN <<"EOF" bash -exu -o pipefail
 DEFAULT_GIT_URLREF_T5X=$(yq '.t5x | [(.url, .latest_verified_commit)] | join("#")' ${MANIFEST_FILE})
-get-source.sh -c ${SRC_PATH_T5X} -r ${GIT_URLREF_T5X:-$DEFAULT_GIT_URLREF_T5X} -p /opt/pip-tools.d/requirements-t5x.in
+get-source.sh -c ${SRC_PATH_T5X} -u ${GIT_URLREF_T5X:-$DEFAULT_GIT_URLREF_T5X} -p /opt/pip-tools.d/requirements-t5x.in
 sed -i "s|${SRC_PATH_T5X}|${SRC_PATH_T5X}[gpu]|g" /opt/pip-tools.d/requirements-t5x.in
 EOF
 

--- a/.github/container/Dockerfile.t5x.arm64
+++ b/.github/container/Dockerfile.t5x.arm64
@@ -3,6 +3,8 @@
 #   docker buildx build -f Dockerfile.t5x.arm64 --tag t5x --build-arg BASE_IMAGE=ghcr.io/nvidia/jax:mealkit-2024-01-22 .
 
 ARG BASE_IMAGE=ghcr.io/nvidia/jax:mealkit
+ARG GIT_URLREF_T5X  # if not set, will use defaults from the manifest file
+ARG GIT_URLREF_TFTEXT
 ARG SRC_PATH_GRAIN=/opt/grain
 ARG SRC_PATH_TFTEXT=/opt/tensorflow-text
 ARG SRC_PATH_T5X=/opt/t5x
@@ -64,9 +66,7 @@ COPY --from=wheel-builder /mealkit-python-version /mealkit-python-version
             wheel
 # END
 
-RUN <<"EOT" bash -exu
-set -o pipefail
-
+RUN <<"EOT" bash -exu -o pipefail
 git clone https://github.com/google/array_record.git /tmp/array_record
 cd /tmp/array_record
 git checkout v0.5.0
@@ -120,8 +120,7 @@ COPY --from=array_record-builder /tmp/array_record/all_dist/array_record*linux_a
             tensorflow-datasets
 # END
 
-RUN <<"EOT" bash -exu
-set -o pipefail
+RUN <<"EOT" bash -exu -o pipefail
 
 # Check out source of grain-nightly 0.0.4
 git clone https://github.com/google/grain ${SRC_PATH_GRAIN}
@@ -140,20 +139,20 @@ chmod a+x ./grain/oss/build_whl.sh
 ls /tmp/grain/all_dist/*.whl
 EOT
 
-
 #------------------------------------------------------------------------------
 # build tensorflow-text 2.13.0 from source
 #------------------------------------------------------------------------------
 
 FROM wheel-builder as tftext-builder
+ARG GIT_URLREF_TFTEXT
 ARG SRC_PATH_TFTEXT
 RUN <<"EOF" bash -exu -o pipefail
 pip install tensorflow_datasets==4.9.2 auditwheel tensorflow==2.13.0
-get-source.sh -l tensorflow-text -m ${MANIFEST_FILE}
+DEFAULT_GIT_URLREF_TFTEXT=$(yq '.tensorflow-text | [(.url, .latest_verified_commit)] | join("#")' ${MANIFEST_FILE})
+get-source.sh -c ${SRC_PATH_TFTEXT} -r ${GIT_URLREF_TFTEXT:-$DEFAULT_GIT_URLREF_TFTEXT}
 cd ${SRC_PATH_TFTEXT}
 ./oss_scripts/run_build.sh
 EOF
-
 
 ###############################################################################
 ## T5X for AArch64
@@ -172,16 +171,21 @@ RUN echo "grain @ file://$(ls /opt/grain*.whl)" >> /opt/pip-tools.d/requirements
 COPY --from=tftext-builder ${SRC_PATH_TFTEXT}/tensorflow_text*.whl /opt/
 RUN echo "tensorflow-text @ file://$(ls /opt/tensorflow_text*.whl)" >> /opt/pip-tools.d/requirements-t5x.in
 
-RUN <<"EOF" bash -ex
-# 1. Fetch T5X
-get-source.sh -l t5x -m ${MANIFEST_FILE}
-echo "-e file://${SRC_PATH_T5X}[gpu]" >> /opt/pip-tools.d/requirements-t5x.in
+# obtain t5x source
+RUN <<"EOF" bash -exu -o pipefail
+DEFAULT_GIT_URLREF_T5X=$(yq '.t5x | [(.url, .latest_verified_commit)] | join("#")' ${MANIFEST_FILE})
+get-source.sh -c ${SRC_PATH_T5X} -r ${GIT_URLREF_T5X:-$DEFAULT_GIT_URLREF_T5X} -p /opt/pip-tools.d/requirements-t5x.in
+sed -i "s|${SRC_PATH_T5X}|${SRC_PATH_T5X}[gpu]|g" /opt/pip-tools.d/requirements-t5x.in
+EOF
 
-# 2. Remove head-of-tree specs from select dependencies
+# Remove head-of-tree specs from packages already shipped in the container
+RUN <<"EOF" bash -exu -o pipefail
 pushd ${SRC_PATH_T5X}
 sed -i "s| @ git+https://github.com/google/flax#egg=flax||g" setup.py
+EOF
 
-# for ARM64 build
+# Fix ARM64 deps
+RUN <<"EOF" bash -exu -o pipefail
 sed -i "s/'tensorflow/#'tensorflow/" setup.py
 
 sed -i "s/f'jax/#f'jax/" setup.py

--- a/.github/container/Dockerfile.t5x.arm64
+++ b/.github/container/Dockerfile.t5x.arm64
@@ -198,7 +198,10 @@ if git diff --quiet; then
     echo "URL specs no longer present in select dependencies of t5x"
     exit 1
 else
+    git config --global user.name "JAX Toolbox"
+    git config --global user.email "jax@nvidia.com"
     git commit -a -m "remove URL specs from select dependencies of t5x"
+    rm ~/.gitconfig
 fi
 popd
 EOF

--- a/.github/container/Dockerfile.t5x.arm64
+++ b/.github/container/Dockerfile.t5x.arm64
@@ -149,7 +149,7 @@ ARG SRC_PATH_TFTEXT
 RUN <<"EOF" bash -exu -o pipefail
 pip install tensorflow_datasets==4.9.2 auditwheel tensorflow==2.13.0
 DEFAULT_GIT_URLREF_TFTEXT=$(yq '.tensorflow-text | [(.url, .latest_verified_commit)] | join("#")' ${MANIFEST_FILE})
-get-source.sh -c ${SRC_PATH_TFTEXT} -r ${GIT_URLREF_TFTEXT:-$DEFAULT_GIT_URLREF_TFTEXT}
+get-source.sh -c ${SRC_PATH_TFTEXT} -u ${GIT_URLREF_TFTEXT:-$DEFAULT_GIT_URLREF_TFTEXT}
 cd ${SRC_PATH_TFTEXT}
 ./oss_scripts/run_build.sh
 EOF
@@ -174,7 +174,7 @@ RUN echo "tensorflow-text @ file://$(ls /opt/tensorflow_text*.whl)" >> /opt/pip-
 # obtain t5x source
 RUN <<"EOF" bash -exu -o pipefail
 DEFAULT_GIT_URLREF_T5X=$(yq '.t5x | [(.url, .latest_verified_commit)] | join("#")' ${MANIFEST_FILE})
-get-source.sh -c ${SRC_PATH_T5X} -r ${GIT_URLREF_T5X:-$DEFAULT_GIT_URLREF_T5X} -p /opt/pip-tools.d/requirements-t5x.in
+get-source.sh -c ${SRC_PATH_T5X} -u ${GIT_URLREF_T5X:-$DEFAULT_GIT_URLREF_T5X} -p /opt/pip-tools.d/requirements-t5x.in
 sed -i "s|${SRC_PATH_T5X}|${SRC_PATH_T5X}[gpu]|g" /opt/pip-tools.d/requirements-t5x.in
 EOF
 

--- a/.github/container/get-source.sh
+++ b/.github/container/get-source.sh
@@ -16,7 +16,7 @@ usage() {
     get-source.sh -b /opt -r https://github.com/google/jax.git
   Output:
     -e /opt/jax
-  EOF
+EOF
 
   exit $1
 }

--- a/.github/container/get-source.sh
+++ b/.github/container/get-source.sh
@@ -85,5 +85,7 @@ git checkout ${GIT_REF}
 git submodule update --init --recursive
 popd
 
-echo "Appending to ${PIP_DIRECTIVE_FILE}:"
-echo "-e file://${CHECKOUT_DIR}" | tee -a ${PIP_DIRECTIVE_FILE}
+if [[ -n "${PIP_DIRECTIVE_FILE}" ]]; then
+  echo "Appending to ${PIP_DIRECTIVE_FILE}:"
+  echo "-e file://${CHECKOUT_DIR}" | tee -a ${PIP_DIRECTIVE_FILE}
+fi

--- a/.github/container/get-source.sh
+++ b/.github/container/get-source.sh
@@ -7,13 +7,13 @@ usage() {
   Clones a git repo and write the pip-compile directive to stdout
 
   Usage: $0 [OPTION]...
-    -d, --dir CHECKOUT_DIR              Directory to check out the package.
-    -p, --pip-directive-file   Write the pip directive for installing the source package to file
-    -r, --urlref               URL and ref to clone, in the form "URL#REF"
-    -h, --help                 Print usage.
+    -c, --checkout-dir            Directory to check out the package.
+    -p, --pip-directive-file      Write the pip directive for installing the source package to file
+    -u, --urlref                  URL and ref to clone, in the form "URL#REF"
+    -h, --help                    Print usage.
 
   Example:
-    get-source.sh -b /opt -r https://github.com/google/jax.git
+    get-source.sh -b /opt -r https://github.com/google/jax.git#v0.4.24
   Output:
     -e /opt/jax
 EOF

--- a/.github/container/get-source.sh
+++ b/.github/container/get-source.sh
@@ -44,7 +44,7 @@ while [ : ]; do
         shift 2
         ;;
     -u | --urlref)
-        UELREF="$2"
+        URLREF="$2"
         shift 2
         ;;
     -h | --help)

--- a/.github/workflows/_build_base.yaml
+++ b/.github/workflows/_build_base.yaml
@@ -27,16 +27,6 @@ on:
         description: 'Name of the endpoint JSON file for shields.io badge'
         required: false
         default: 'badge-base-build'
-      GIT_USER_NAME:
-        type: string
-        description: 'Username in GIT to perform git pull/push'
-        required: false
-        default: 'JAX Toolbox'
-      GIT_USER_EMAIL:
-        type: string
-        description: 'User email in GIT to perform git pull/push'
-        required: false
-        default: 'jax@nvidia.com'
       BUMP_MANIFEST:
         type: boolean
         description: "Flag to bump manifest file or not"
@@ -163,8 +153,6 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |
-            GIT_USER_NAME=${{ inputs.GIT_USER_NAME }}
-            GIT_USER_EMAIL=${{ inputs.GIT_USER_EMAIL }}
             BUILD_DATE=${{ inputs.BUILD_DATE }}
             ${{ inputs.BASE_IMAGE != 'latest' && format('BASE_IMAGE={0}', inputs.BASE_IMAGE) }}
         

--- a/.github/workflows/_build_jax.yaml
+++ b/.github/workflows/_build_jax.yaml
@@ -17,6 +17,11 @@ on:
         description: "Build date in YYYY-MM-DD format"
         required: false
         default: 'NOT SPECIFIED'
+      GIT_URLREF_XLA:
+        type: string
+        description: Git URL and ref for XLA in URL#REF format
+        default: ''
+        required: false
       ARTIFACT_NAME:
         type: string
         description: 'Name of the artifact zip file'
@@ -27,16 +32,6 @@ on:
         description: 'Name of the endpoint JSON file for shields.io badge'
         required: false
         default: 'badge-jax-build'
-      GIT_USER_NAME:
-        type: string
-        description: 'Username in GIT to perform git pull/push'
-        required: false
-        default: 'JAX Toolbox'
-      GIT_USER_EMAIL:
-        type: string
-        description: 'User email in GIT to perform git pull/push'
-        required: false
-        default: 'jax@nvidia.com'
     outputs:
       DOCKER_TAG_MEALKIT:
         description: "Tags of the 'mealkit' image built"
@@ -128,8 +123,7 @@ jobs:
             BASE_IMAGE=${{ inputs.BASE_IMAGE }}
             BAZEL_CACHE=${{ vars.BAZEL_REMOTE_CACHE_URL }}
             BUILD_DATE=${{ inputs.BUILD_DATE }}
-            GIT_USER_NAME=${{ inputs.GIT_USER_NAME }}
-            GIT_USER_EMAIL=${{ inputs.GIT_USER_EMAIL }}
+            GIT_URLREF_XLA=${{ inputs.GIT_URLREF_XLA }}
 
       - name: Set docker metadata - final
         id: final-metadata
@@ -161,6 +155,7 @@ jobs:
             BASE_IMAGE=${{ inputs.BASE_IMAGE }}
             BAZEL_CACHE=${{ vars.BAZEL_REMOTE_CACHE_URL }}
             BUILD_DATE=${{ inputs.BUILD_DATE }}
+            GIT_URLREF_XLA=${{ inputs.GIT_URLREF_XLA }}
 
       - name: Generate sitrep
         if: success() || failure()

--- a/.github/workflows/_ci.yaml
+++ b/.github/workflows/_ci.yaml
@@ -16,6 +16,11 @@ on:
         description: Flag to bump manifest file or not
         default: false
         required: false
+      GIT_URLREF_XLA:
+        type: string
+        description: Git URL and ref for XLA in URL#REF format
+        default: ''
+        required: false
     outputs:
       DOCKER_TAGS:
         description: JSON object containing tags of all docker images built
@@ -43,6 +48,7 @@ jobs:
       ARCHITECTURE: ${{ inputs.ARCHITECTURE }}
       BUILD_DATE: ${{ inputs.BUILD_DATE }}
       BASE_IMAGE: ${{ needs.build-base.outputs.DOCKER_TAG }}
+      GIT_URLREF_XLA: ${{ inputs.GIT_URLREF_XLA }}
     secrets: inherit
 
   build-pallas:

--- a/.github/workflows/_sandbox.yaml
+++ b/.github/workflows/_sandbox.yaml
@@ -1,7 +1,7 @@
 name: "~Sandbox"
 
 on:
-  push:
+  workflow_dispatch:
 
 permissions:
   contents: read  # to fetch code

--- a/.github/workflows/_sandbox.yaml
+++ b/.github/workflows/_sandbox.yaml
@@ -1,41 +1,158 @@
 name: "~Sandbox"
 
 on:
-  workflow_dispatch:
+  push:
+
+permissions:
+  contents: read  # to fetch code
+  actions:  write # to cancel previous workflows
+  packages: write # to upload container
 
 jobs:
-  sandbox:
+
+  build-base:
+    uses: ./.github/workflows/_build_base.yaml
+    with:
+      ARCHITECTURE: amd64
+      BUILD_DATE: 2024-02-12
+      BUMP_MANIFEST: false
+    secrets: inherit
+
+  build-jax:
+    needs: build-base
+    uses: ./.github/workflows/_build_jax.yaml
+    with:
+      ARCHITECTURE: amd64
+      BUILD_DATE: 2024-02-12
+      BASE_IMAGE: ${{ needs.build-base.outputs.DOCKER_TAG }}
+    secrets: inherit
+
+  build-pallas:
+    needs: build-jax
+    uses: ./.github/workflows/_build.yaml
+    with:
+      ARCHITECTURE: amd64
+      ARTIFACT_NAME: artifact-pallas-build
+      BADGE_FILENAME: badge-pallas-build
+      BUILD_DATE: 2024-02-12
+      BASE_IMAGE: ${{ needs.build-jax.outputs.DOCKER_TAG_MEALKIT }}
+      CONTAINER_NAME: pallas
+      DOCKERFILE: .github/container/Dockerfile.pallas
+    secrets: inherit
+
+  build-maxtext:
+    needs: build-jax
+    uses: ./.github/workflows/_build.yaml
+    with:
+      ARCHITECTURE: amd64
+      ARTIFACT_NAME: artifact-maxtext-build
+      BADGE_FILENAME: badge-maxtext-build
+      BUILD_DATE: 2024-02-12
+      BASE_IMAGE: ${{ needs.build-jax.outputs.DOCKER_TAG_MEALKIT }}
+      CONTAINER_NAME: maxtext
+      DOCKERFILE: .github/container/Dockerfile.maxtext.amd64
+    secrets: inherit
+
+  build-levanter:
+    needs: [build-jax]
+    uses: ./.github/workflows/_build.yaml
+    with:
+      ARCHITECTURE: amd64
+      ARTIFACT_NAME: "artifact-levanter-build"
+      BADGE_FILENAME: "badge-levanter-build"
+      BUILD_DATE: 2024-02-12
+      BASE_IMAGE: ${{ needs.build-jax.outputs.DOCKER_TAG_MEALKIT }}
+      CONTAINER_NAME: levanter
+      DOCKERFILE: .github/container/Dockerfile.levanter
+    secrets: inherit
+
+  build-t5x:
+    needs: build-jax
+    uses: ./.github/workflows/_build.yaml
+    with:
+      ARCHITECTURE: amd64
+      ARTIFACT_NAME: "artifact-t5x-build"
+      BADGE_FILENAME: "badge-t5x-build"
+      BUILD_DATE: ${{ needs.metadata.outputs.BUILD_DATE }}
+      BASE_IMAGE: ${{ needs.build-jax.outputs.DOCKER_TAG_MEALKIT }}
+      CONTAINER_NAME: upstream-t5x
+      DOCKERFILE: .github/container/Dockerfile.t5x.amd64
+    secrets: inherit
+
+  build-pax:
+    needs: build-jax
+    uses: ./.github/workflows/_build.yaml
+    with:
+      ARCHITECTURE: amd64
+      ARTIFACT_NAME: artifact-pax-build
+      BADGE_FILENAME: badge-pax-build
+      BUILD_DATE: 2024-02-12
+      BASE_IMAGE: ${{ needs.build-jax.outputs.DOCKER_TAG_MEALKIT }}
+      CONTAINER_NAME: upstream-pax
+      DOCKERFILE: .github/container/Dockerfile.pax.amd64
+    secrets: inherit
+
+  build-rosetta-t5x:
+    needs: build-t5x
+    uses: ./.github/workflows/_build_rosetta.yaml
+    with:
+      ARCHITECTURE: amd64
+      BUILD_DATE: 2024-02-12
+      BASE_IMAGE: ${{ needs.build-t5x.outputs.DOCKER_TAG_MEALKIT }}
+      BASE_LIBRARY: t5x
+    secrets: inherit
+
+  build-rosetta-pax:
+    needs: build-pax
+    uses: ./.github/workflows/_build_rosetta.yaml
+    with:
+      ARCHITECTURE: amd64
+      BUILD_DATE: 2024-02-12
+      BASE_IMAGE: ${{ needs.build-pax.outputs.DOCKER_TAG_MEALKIT }}
+      BASE_LIBRARY: pax
+    secrets: inherit
+
+  collect-docker-tags:
     runs-on: ubuntu-22.04
+    if: "!cancelled()"
+    needs:
+      - build-base
+      - build-jax
+      - build-pallas
+      - build-maxtext
+      - build-levanter
+      - build-t5x
+      - build-pax
+      - build-rosetta-t5x
+      - build-rosetta-pax
+    outputs:
+      TAGS: ${{ steps.collect-tags.outputs.TAGS }}
     steps:
-      - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3
-        with:
-          registry: ghcr.io
-          username: ${{ github.repository_owner }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Print usage
+      - name: Save docker tags as a JSON object
+        id: collect-tags
         run: |
-          cat << EOF
-          This is an empty workflow file located in the main branch of your
-          repository. It serves as a testing ground for new GitHub Actions on
-          development branches before merging them to the main branch. By
-          defining and overloading this workflow on your development branch,
-          you can test new actions without affecting your main branch, ensuring
-          a smooth integration process once the changes are ready to be merged.
-
-          Usage:
-          
-          1. In your development branch, modify the sandbox.yml workflow file
-             to include the new actions you want to test. Make sure to commit
-             the changes to the development branch.
-          2. Navigate to the 'Actions' tab in your repository, select the
-             '~Sandbox' workflow, and choose your development branch from the
-             branch dropdown menu. Click on 'Run workflow' to trigger the
-             workflow on your development branch.
-          3. Once you have tested and verified the new actions in the Sandbox
-             workflow, you can incorporate them into your main workflow(s) and
-             merge the development branch into the main branch. Remember to
-             revert the changes to the sandbox.yml file in the main branch to
-             keep it empty for future testing.
+          TAGS=$(cat <<EOF | jq -c
+          [\
+            {"flavor": "base",        "stage": "final",   "priority": 800,  "tag": "${{ needs.build-base.outputs.DOCKER_TAG }}"},\
+            {"flavor": "jax",         "stage": "final",   "priority": 1000, "tag": "${{ needs.build-jax.outputs.DOCKER_TAG_FINAL }}"},\
+            {"flavor": "pallas",      "stage": "final",   "priority": 900,  "tag": "${{ needs.build-pallas.outputs.DOCKER_TAG_FINAL }}"},\
+            {"flavor": "maxtext",     "stage": "final",   "priority": 900,  "tag": "${{ needs.build-maxtext.outputs.DOCKER_TAG_FINAL }}"},\
+            {"flavor": "levanter",    "stage": "final",   "priority": 900,  "tag": "${{ needs.build-levanter.outputs.DOCKER_TAG_FINAL }}"},\
+            {"flavor": "t5x",         "stage": "final",   "priority": 900,  "tag": "${{ needs.build-t5x.outputs.DOCKER_TAG_FINAL }}"},\
+            {"flavor": "pax",         "stage": "final",   "priority": 900,  "tag": "${{ needs.build-pax.outputs.DOCKER_TAG_FINAL }}"},\
+            {"flavor": "rosetta-t5x", "stage": "final",   "priority": 900,  "tag": "${{ needs.build-rosetta-t5x.outputs.DOCKER_TAG_FINAL }}"},\
+            {"flavor": "rosetta-pax", "stage": "final",   "priority": 900,  "tag": "${{ needs.build-rosetta-pax.outputs.DOCKER_TAG_FINAL }}"},\
+            {"flavor": "jax",         "stage": "mealkit", "priority": 500,  "tag": "${{ needs.build-jax.outputs.DOCKER_TAG_MEALKIT }}"},\
+            {"flavor": "pallas",      "stage": "mealkit", "priority": 500,  "tag": "${{ needs.build-pallas.outputs.DOCKER_TAG_MEALKIT }}"},\
+            {"flavor": "maxtext",     "stage": "mealkit", "priority": 500,  "tag": "${{ needs.build-maxtext.outputs.DOCKER_TAG_MEALKIT }}"},\
+            {"flavor": "levanter",    "stage": "mealkit", "priority": 500,  "tag": "${{ needs.build-levanter.outputs.DOCKER_TAG_MEALKIT }}"},\
+            {"flavor": "t5x",         "stage": "mealkit", "priority": 500,  "tag": "${{ needs.build-t5x.outputs.DOCKER_TAG_MEALKIT }}"},\
+            {"flavor": "pax",         "stage": "mealkit", "priority": 500,  "tag": "${{ needs.build-pax.outputs.DOCKER_TAG_MEALKIT }}"},\
+            {"flavor": "rosetta-t5x", "stage": "mealkit", "priority": 500,  "tag": "${{ needs.build-rosetta-t5x.outputs.DOCKER_TAG_MEALKIT }}"},\
+            {"flavor": "rosetta-pax", "stage": "mealkit", "priority": 500,  "tag": "${{ needs.build-rosetta-pax.outputs.DOCKER_TAG_MEALKIT }}"},\
+            {}\
+          ]
           EOF
+          )
+
+          echo "TAGS=${TAGS}" >> $GITHUB_OUTPUT

--- a/.github/workflows/_sandbox.yaml
+++ b/.github/workflows/_sandbox.yaml
@@ -3,156 +3,39 @@ name: "~Sandbox"
 on:
   workflow_dispatch:
 
-permissions:
-  contents: read  # to fetch code
-  actions:  write # to cancel previous workflows
-  packages: write # to upload container
-
 jobs:
-
-  build-base:
-    uses: ./.github/workflows/_build_base.yaml
-    with:
-      ARCHITECTURE: amd64
-      BUILD_DATE: 2024-02-12
-      BUMP_MANIFEST: false
-    secrets: inherit
-
-  build-jax:
-    needs: build-base
-    uses: ./.github/workflows/_build_jax.yaml
-    with:
-      ARCHITECTURE: amd64
-      BUILD_DATE: 2024-02-12
-      BASE_IMAGE: ${{ needs.build-base.outputs.DOCKER_TAG }}
-    secrets: inherit
-
-  build-pallas:
-    needs: build-jax
-    uses: ./.github/workflows/_build.yaml
-    with:
-      ARCHITECTURE: amd64
-      ARTIFACT_NAME: artifact-pallas-build
-      BADGE_FILENAME: badge-pallas-build
-      BUILD_DATE: 2024-02-12
-      BASE_IMAGE: ${{ needs.build-jax.outputs.DOCKER_TAG_MEALKIT }}
-      CONTAINER_NAME: pallas
-      DOCKERFILE: .github/container/Dockerfile.pallas
-    secrets: inherit
-
-  build-maxtext:
-    needs: build-jax
-    uses: ./.github/workflows/_build.yaml
-    with:
-      ARCHITECTURE: amd64
-      ARTIFACT_NAME: artifact-maxtext-build
-      BADGE_FILENAME: badge-maxtext-build
-      BUILD_DATE: 2024-02-12
-      BASE_IMAGE: ${{ needs.build-jax.outputs.DOCKER_TAG_MEALKIT }}
-      CONTAINER_NAME: maxtext
-      DOCKERFILE: .github/container/Dockerfile.maxtext.amd64
-    secrets: inherit
-
-  build-levanter:
-    needs: [build-jax]
-    uses: ./.github/workflows/_build.yaml
-    with:
-      ARCHITECTURE: amd64
-      ARTIFACT_NAME: "artifact-levanter-build"
-      BADGE_FILENAME: "badge-levanter-build"
-      BUILD_DATE: 2024-02-12
-      BASE_IMAGE: ${{ needs.build-jax.outputs.DOCKER_TAG_MEALKIT }}
-      CONTAINER_NAME: levanter
-      DOCKERFILE: .github/container/Dockerfile.levanter
-    secrets: inherit
-
-  build-t5x:
-    needs: build-jax
-    uses: ./.github/workflows/_build.yaml
-    with:
-      ARCHITECTURE: amd64
-      ARTIFACT_NAME: "artifact-t5x-build"
-      BADGE_FILENAME: "badge-t5x-build"
-      BUILD_DATE: ${{ needs.metadata.outputs.BUILD_DATE }}
-      BASE_IMAGE: ${{ needs.build-jax.outputs.DOCKER_TAG_MEALKIT }}
-      CONTAINER_NAME: upstream-t5x
-      DOCKERFILE: .github/container/Dockerfile.t5x.amd64
-    secrets: inherit
-
-  build-pax:
-    needs: build-jax
-    uses: ./.github/workflows/_build.yaml
-    with:
-      ARCHITECTURE: amd64
-      ARTIFACT_NAME: artifact-pax-build
-      BADGE_FILENAME: badge-pax-build
-      BUILD_DATE: 2024-02-12
-      BASE_IMAGE: ${{ needs.build-jax.outputs.DOCKER_TAG_MEALKIT }}
-      CONTAINER_NAME: upstream-pax
-      DOCKERFILE: .github/container/Dockerfile.pax.amd64
-    secrets: inherit
-
-  build-rosetta-t5x:
-    needs: build-t5x
-    uses: ./.github/workflows/_build_rosetta.yaml
-    with:
-      ARCHITECTURE: amd64
-      BUILD_DATE: 2024-02-12
-      BASE_IMAGE: ${{ needs.build-t5x.outputs.DOCKER_TAG_MEALKIT }}
-      BASE_LIBRARY: t5x
-    secrets: inherit
-
-  build-rosetta-pax:
-    needs: build-pax
-    uses: ./.github/workflows/_build_rosetta.yaml
-    with:
-      ARCHITECTURE: amd64
-      BUILD_DATE: 2024-02-12
-      BASE_IMAGE: ${{ needs.build-pax.outputs.DOCKER_TAG_MEALKIT }}
-      BASE_LIBRARY: pax
-    secrets: inherit
-
-  collect-docker-tags:
+  sandbox:
     runs-on: ubuntu-22.04
-    if: "!cancelled()"
-    needs:
-      - build-base
-      - build-jax
-      - build-pallas
-      - build-maxtext
-      - build-levanter
-      - build-t5x
-      - build-pax
-      - build-rosetta-t5x
-      - build-rosetta-pax
-    outputs:
-      TAGS: ${{ steps.collect-tags.outputs.TAGS }}
     steps:
-      - name: Save docker tags as a JSON object
-        id: collect-tags
-        run: |
-          TAGS=$(cat <<EOF | jq -c
-          [\
-            {"flavor": "base",        "stage": "final",   "priority": 800,  "tag": "${{ needs.build-base.outputs.DOCKER_TAG }}"},\
-            {"flavor": "jax",         "stage": "final",   "priority": 1000, "tag": "${{ needs.build-jax.outputs.DOCKER_TAG_FINAL }}"},\
-            {"flavor": "pallas",      "stage": "final",   "priority": 900,  "tag": "${{ needs.build-pallas.outputs.DOCKER_TAG_FINAL }}"},\
-            {"flavor": "maxtext",     "stage": "final",   "priority": 900,  "tag": "${{ needs.build-maxtext.outputs.DOCKER_TAG_FINAL }}"},\
-            {"flavor": "levanter",    "stage": "final",   "priority": 900,  "tag": "${{ needs.build-levanter.outputs.DOCKER_TAG_FINAL }}"},\
-            {"flavor": "t5x",         "stage": "final",   "priority": 900,  "tag": "${{ needs.build-t5x.outputs.DOCKER_TAG_FINAL }}"},\
-            {"flavor": "pax",         "stage": "final",   "priority": 900,  "tag": "${{ needs.build-pax.outputs.DOCKER_TAG_FINAL }}"},\
-            {"flavor": "rosetta-t5x", "stage": "final",   "priority": 900,  "tag": "${{ needs.build-rosetta-t5x.outputs.DOCKER_TAG_FINAL }}"},\
-            {"flavor": "rosetta-pax", "stage": "final",   "priority": 900,  "tag": "${{ needs.build-rosetta-pax.outputs.DOCKER_TAG_FINAL }}"},\
-            {"flavor": "jax",         "stage": "mealkit", "priority": 500,  "tag": "${{ needs.build-jax.outputs.DOCKER_TAG_MEALKIT }}"},\
-            {"flavor": "pallas",      "stage": "mealkit", "priority": 500,  "tag": "${{ needs.build-pallas.outputs.DOCKER_TAG_MEALKIT }}"},\
-            {"flavor": "maxtext",     "stage": "mealkit", "priority": 500,  "tag": "${{ needs.build-maxtext.outputs.DOCKER_TAG_MEALKIT }}"},\
-            {"flavor": "levanter",    "stage": "mealkit", "priority": 500,  "tag": "${{ needs.build-levanter.outputs.DOCKER_TAG_MEALKIT }}"},\
-            {"flavor": "t5x",         "stage": "mealkit", "priority": 500,  "tag": "${{ needs.build-t5x.outputs.DOCKER_TAG_MEALKIT }}"},\
-            {"flavor": "pax",         "stage": "mealkit", "priority": 500,  "tag": "${{ needs.build-pax.outputs.DOCKER_TAG_MEALKIT }}"},\
-            {"flavor": "rosetta-t5x", "stage": "mealkit", "priority": 500,  "tag": "${{ needs.build-rosetta-t5x.outputs.DOCKER_TAG_MEALKIT }}"},\
-            {"flavor": "rosetta-pax", "stage": "mealkit", "priority": 500,  "tag": "${{ needs.build-rosetta-pax.outputs.DOCKER_TAG_MEALKIT }}"},\
-            {}\
-          ]
-          EOF
-          )
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
-          echo "TAGS=${TAGS}" >> $GITHUB_OUTPUT
+      - name: Print usage
+        run: |
+          cat << EOF
+          This is an empty workflow file located in the main branch of your
+          repository. It serves as a testing ground for new GitHub Actions on
+          development branches before merging them to the main branch. By
+          defining and overloading this workflow on your development branch,
+          you can test new actions without affecting your main branch, ensuring
+          a smooth integration process once the changes are ready to be merged.
+
+          Usage:
+          
+          1. In your development branch, modify the sandbox.yml workflow file
+             to include the new actions you want to test. Make sure to commit
+             the changes to the development branch.
+          2. Navigate to the 'Actions' tab in your repository, select the
+             '~Sandbox' workflow, and choose your development branch from the
+             branch dropdown menu. Click on 'Run workflow' to trigger the
+             workflow on your development branch.
+          3. Once you have tested and verified the new actions in the Sandbox
+             workflow, you can incorporate them into your main workflow(s) and
+             merge the development branch into the main branch. Remember to
+             revert the changes to the sandbox.yml file in the main branch to
+             keep it empty for future testing.
+          EOF

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -23,6 +23,11 @@ on:
         description: Bump git repos in manifest.yaml to head of tree?
         default: false
         required: false
+      GIT_URLREF_XLA:
+        type: string
+        description: Git URL and ref for XLA in URL#REF format
+        default: ''
+        required: false
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}

--- a/rosetta/tests/mirror-only-distribution.sh
+++ b/rosetta/tests/mirror-only-distribution.sh
@@ -26,7 +26,9 @@ t5x:
     mirror/pull/4/head: null
 EOF
 
-bash ../../.github/container/get-source.sh --base-dir $tmp_base --manifest $manifest_tmp --library $LIBRARY
+bash ../../.github/container/get-source.sh \
+  --checkout-dir $tmp_base/t5x
+  --urlref $(yq '.t5x | [(.url, .latest_verified_commit)] | join("#")' $manifest_tmp)
 
 cp ../../.github/container/create-distribution.sh $workspace_tmp/
 base_cmd() {

--- a/rosetta/tests/mirror-only-distribution.sh
+++ b/rosetta/tests/mirror-only-distribution.sh
@@ -27,7 +27,7 @@ t5x:
 EOF
 
 bash ../../.github/container/get-source.sh \
-  --checkout-dir $tmp_base/t5x
+  --checkout-dir $tmp_base/t5x \
   --urlref $(yq '.t5x | [(.url, .latest_verified_commit)] | join("#")' $manifest_tmp)
 
 cp ../../.github/container/create-distribution.sh $workspace_tmp/

--- a/rosetta/tests/upstream-only-distribution.sh
+++ b/rosetta/tests/upstream-only-distribution.sh
@@ -25,7 +25,10 @@ t5x:
   patches:
     pull/1372/head: null
 EOF
-bash ../../.github/container/get-source.sh --base-dir $tmp_base --manifest $manifest_tmp --library $LIBRARY
+
+bash ../../.github/container/get-source.sh \
+  --checkout-dir $tmp_base/t5x
+  --urlref $(yq '.t5x | [(.url, .latest_verified_commit)] | join("#")' $manifest_tmp)
 
 cp ../../.github/container/create-distribution.sh $workspace_tmp/
 base_cmd() {

--- a/rosetta/tests/upstream-only-distribution.sh
+++ b/rosetta/tests/upstream-only-distribution.sh
@@ -27,7 +27,7 @@ t5x:
 EOF
 
 bash ../../.github/container/get-source.sh \
-  --checkout-dir $tmp_base/t5x
+  --checkout-dir $tmp_base/t5x \
   --urlref $(yq '.t5x | [(.url, .latest_verified_commit)] | join("#")' $manifest_tmp)
 
 cp ../../.github/container/create-distribution.sh $workspace_tmp/


### PR DESCRIPTION
This is to address NVBug 4490803, where the recently introduced manifest file mechanism made it inconvenient for external repos to trigger JAX-Toolbox as an API.

Taking JAX as an example, here is an explanation of the new behavior:
- `Dockerfile.jax` will accept a build arg `GIT_URLREF_JAX` that takes in arguments in forms such as `https://github.com/google/jax.git#v0.4.24`.
- If such a build arg is not provided at build time, we will use the corresponding information from `manifest.yaml` as the fallback.
- The url-ref spec from either the build arg or manifest.yaml is then passed into `get-source.sh` to checkout the source code.

`get-source.sh` is refactored so that its dependency on `manifest.yaml` is removed. This reduces the coupling between the two components.