### PR TITLE
Use Clang to build MJX

### DIFF
--- a/.github/container/Dockerfile.mjx
+++ b/.github/container/Dockerfile.mjx
@@ -31,6 +31,8 @@ EOF
 
 # Specify installation targets
 RUN <<"EOF" bash -ex
+export CC=/usr/bin/clang
+export CXX=/usr/bin/clang++
 get-source.sh -l mujoco -m ${MANIFEST_FILE} -b $(dirname ${SRC_PATH_MUJOCO})
 get-source.sh -l mujoco-mpc -m ${MANIFEST_FILE}
 get-source.sh -l language-to-reward-2023 -m ${MANIFEST_FILE}

--- a/.github/container/Dockerfile.mjx
+++ b/.github/container/Dockerfile.mjx
@@ -4,7 +4,8 @@ ARG BASE_IMAGE=ghcr.io/nvidia/jax:mealkit
 ARG SRC_PATH_MUJOCO=/opt/mujoco
 ARG SRC_PATH_MUJOCO_MPC=/opt/mujoco-mpc
 ARG SRC_PATH_L2R=/opt/language-to-reward-2023
-
+ARG CC=/usr/bin/clang
+ARG CXX=/usr/bin/clang++
 
 ###############################################################################
 ## Download source and add auxiliary scripts
@@ -14,6 +15,11 @@ FROM ${BASE_IMAGE} as mealkit
 ARG SRC_PATH_MUJOCO
 ARG SRC_PATH_MUJOCO_MPC
 ARG SRC_PATH_L2R
+ARG CC
+ARG CXX
+
+ENV CC=${CC}
+ENV CXX=${CXX}
 
 # Install system dependencies for Mujuco/MPC
 RUN <<"EOF" bash -ex
@@ -31,8 +37,6 @@ EOF
 
 # Specify installation targets
 RUN <<"EOF" bash -ex
-export CC=/usr/bin/clang
-export CXX=/usr/bin/clang++
 get-source.sh -l mujoco -m ${MANIFEST_FILE} -b $(dirname ${SRC_PATH_MUJOCO})
 get-source.sh -l mujoco-mpc -m ${MANIFEST_FILE}
 get-source.sh -l language-to-reward-2023 -m ${MANIFEST_FILE}

--- a/.github/container/manifest.yaml
+++ b/.github/container/manifest.yaml
@@ -135,7 +135,7 @@ mujoco:
 mujoco-mpc:
   url: https://github.com/google-deepmind/mujoco_mpc.git
   tracking_ref: main
-  latest_verified_commit: 73633d7da1900c428a7315d2ffe1120c5393a7d8
+  latest_verified_commit: c5c7ead065b7f4034ab265a13023231900dbfaa7
   mode: git-clone
 language-to-reward-2023:
   url: https://github.com/google-deepmind/language_to_reward_2023.git


### PR DESCRIPTION
I got a compilation issue while compiling mujoco-mpc with GNU:
```
#10 912.6         /opt/mujoco-mpc/mjpc/../mjpc/spline/spline.h:106:9: error: expected unqualified-id before ‘const’
#10 912.6           106 |         const IteratorT<SplineType, NodeType>& other) = default;
#10 912.6               |         ^~~~~
#10 912.6         /opt/mujoco-mpc/mjpc/../mjpc/spline/spline.h:105:37: error: expected ‘)’ before ‘const’
#10 912.6           105 |     IteratorT<SplineType, NodeType>(
#10 912.6               |                                    ~^
#10 912.6               |                                     )
#10 912.6           106 |         const IteratorT<SplineType, NodeType>& other) = default;
#10 912.6               |         ~~~~~
#10 912.6         /opt/mujoco-mpc/mjpc/../mjpc/spline/spline.h:109:68: error: expected ‘)’ before ‘&&’ token
#10 912.6           109 |     IteratorT<SplineType, NodeType>(IteratorT<SplineType, NodeType>&& other) =
#10 912.6               |                                    ~                               ^~
#10 912.6               |                                                                    )
```

The developers of `mujoco-mpc` use Clang to compile (https://github.com/google-deepmind/mujoco_mpc/blob/main/.github/workflows/build.yml#L19).
From now on, the default compiler for MJX is Clang, but can be changed via docker arguments.