### PR TITLE
update manifest to support mlperf-logging for maxtext

### DIFF
--- a/.github/container/Dockerfile.maxtext.amd64
+++ b/.github/container/Dockerfile.maxtext.amd64
@@ -11,8 +11,6 @@ FROM ${BASE_IMAGE} as mealkit
 
 ARG SRC_PATH_MAXTEXT
 
-COPY manifest.yaml ${MANIFEST_FILE}
-
 RUN <<"EOF" bash -ex
 cat ${MANIFEST_FILE}
 get-source.sh -l maxtext -m ${MANIFEST_FILE} 

--- a/.github/container/Dockerfile.maxtext.amd64
+++ b/.github/container/Dockerfile.maxtext.amd64
@@ -18,7 +18,7 @@ echo "logging:
   latest_verified_commit: 38709131757a786d7f66150243b49eb0365324d7
   mode: git-clone" >> ${MANIFEST_FILE}
 cat ${MANIFEST_FILE}
-bump.sh --input-manifest -m ${MANIFEST_FILE}
+bump.sh --input-manifest ${MANIFEST_FILE}
 cat ${MANIFEST_FILE}
 get-source.sh -l maxtext -m ${MANIFEST_FILE} 
 cat "${SRC_PATH_MAXTEXT}/requirements.txt" >> /opt/pip-tools.d/requirements-maxtext.in

--- a/.github/container/Dockerfile.maxtext.amd64
+++ b/.github/container/Dockerfile.maxtext.amd64
@@ -12,6 +12,11 @@ FROM ${BASE_IMAGE} as mealkit
 ARG SRC_PATH_MAXTEXT
 
 RUN <<"EOF" bash -ex
+echo "logging:
+  url: https://github.com/mlcommons/logging.git
+  tracking_ref: main 
+  latest_verified_commit: 38709131757a786d7f66150243b49eb0365324d7
+  mode: git-clone" >> ${MANIFEST_FILE}
 cat ${MANIFEST_FILE}
 get-source.sh -l maxtext -m ${MANIFEST_FILE} 
 cat "${SRC_PATH_MAXTEXT}/requirements.txt" >> /opt/pip-tools.d/requirements-maxtext.in

--- a/.github/container/Dockerfile.maxtext.amd64
+++ b/.github/container/Dockerfile.maxtext.amd64
@@ -18,6 +18,8 @@ echo "logging:
   latest_verified_commit: 38709131757a786d7f66150243b49eb0365324d7
   mode: git-clone" >> ${MANIFEST_FILE}
 cat ${MANIFEST_FILE}
+bash bump.sh --input-manifest manifest.yaml
+cat ${MANIFEST_FILE}
 get-source.sh -l maxtext -m ${MANIFEST_FILE} 
 cat "${SRC_PATH_MAXTEXT}/requirements.txt" >> /opt/pip-tools.d/requirements-maxtext.in
 EOF

--- a/.github/container/Dockerfile.maxtext.amd64
+++ b/.github/container/Dockerfile.maxtext.amd64
@@ -11,8 +11,9 @@ FROM ${BASE_IMAGE} as mealkit
 
 ARG SRC_PATH_MAXTEXT
 
+COPY manifest.yaml ${MANIFEST_FILE}
+
 RUN <<"EOF" bash -ex
-COPY manifest.yaml ${MANIFEST_FILE} 
 cat ${MANIFEST_FILE}
 get-source.sh -l maxtext -m ${MANIFEST_FILE} 
 cat "${SRC_PATH_MAXTEXT}/requirements.txt" >> /opt/pip-tools.d/requirements-maxtext.in

--- a/.github/container/Dockerfile.maxtext.amd64
+++ b/.github/container/Dockerfile.maxtext.amd64
@@ -12,13 +12,7 @@ FROM ${BASE_IMAGE} as mealkit
 ARG SRC_PATH_MAXTEXT
 
 RUN <<"EOF" bash -ex
-echo "logging:
-  url: https://github.com/mlcommons/logging.git
-  tracking_ref: main 
-  latest_verified_commit: 38709131757a786d7f66150243b49eb0365324d7
-  mode: git-clone" >> ${MANIFEST_FILE}
-cat ${MANIFEST_FILE}
-bump.sh --input-manifest ${MANIFEST_FILE}
+COPY manifest.yaml ${MANIFEST_FILE} 
 cat ${MANIFEST_FILE}
 get-source.sh -l maxtext -m ${MANIFEST_FILE} 
 cat "${SRC_PATH_MAXTEXT}/requirements.txt" >> /opt/pip-tools.d/requirements-maxtext.in

--- a/.github/container/Dockerfile.maxtext.amd64
+++ b/.github/container/Dockerfile.maxtext.amd64
@@ -18,7 +18,7 @@ echo "logging:
   latest_verified_commit: 38709131757a786d7f66150243b49eb0365324d7
   mode: git-clone" >> ${MANIFEST_FILE}
 cat ${MANIFEST_FILE}
-bash bump.sh --input-manifest manifest.yaml
+bump.sh --input-manifest -m ${MANIFEST_FILE}
 cat ${MANIFEST_FILE}
 get-source.sh -l maxtext -m ${MANIFEST_FILE} 
 cat "${SRC_PATH_MAXTEXT}/requirements.txt" >> /opt/pip-tools.d/requirements-maxtext.in

--- a/.github/container/manifest.yaml
+++ b/.github/container/manifest.yaml
@@ -148,3 +148,8 @@ language-to-reward-2023:
   tracking_ref: main
   latest_verified_commit: abb8e5125e4ecd0da378490b73448c05a694def5
   mode: git-clone
+logging:
+  url: https://github.com/mlcommons/logging.git
+  tracking_ref: main 
+  latest_verified_commit: c94564a66a6b13b4da6248847f3799b463283454
+  mode: git-clone

--- a/.github/container/manifest.yaml
+++ b/.github/container/manifest.yaml
@@ -148,7 +148,7 @@ language-to-reward-2023:
   tracking_ref: main
   latest_verified_commit: abb8e5125e4ecd0da378490b73448c05a694def5
   mode: git-clone
-logging:
+mlperf-logging:
   url: https://github.com/mlcommons/logging.git
   tracking_ref: main 
   latest_verified_commit: 38709131757a786d7f66150243b49eb0365324d7

--- a/.github/container/manifest.yaml
+++ b/.github/container/manifest.yaml
@@ -152,4 +152,4 @@ mlperf-logging:
   url: https://github.com/mlcommons/logging.git
   tracking_ref: main 
   latest_verified_commit: 38709131757a786d7f66150243b49eb0365324d7
-  mode: git-clone
+  mode: pip-vcs

--- a/.github/container/manifest.yaml
+++ b/.github/container/manifest.yaml
@@ -115,7 +115,7 @@ jax-triton:
 maxtext:
   url: https://github.com/google/maxtext.git
   tracking_ref: main
-  latest_verified_commit: 1c91b3606976765d1edbf121bf54b1e0307d4013
+  latest_verified_commit: c94564a66a6b13b4da6248847f3799b463283454
   mode: git-clone
 levanter:
   url: https://github.com/stanford-crfm/levanter.git
@@ -151,5 +151,5 @@ language-to-reward-2023:
 logging:
   url: https://github.com/mlcommons/logging.git
   tracking_ref: main 
-  latest_verified_commit: c94564a66a6b13b4da6248847f3799b463283454
+  latest_verified_commit: 38709131757a786d7f66150243b49eb0365324d7
   mode: git-clone


### PR DESCRIPTION
Added the mlperf-logging to the manifest.yaml and also verified it using this [run](https://github.com/NVIDIA/JAX-Toolbox/actions/runs/7907539388)