### PR TITLE
Append unique number to SLURM-based runner jobs

### DIFF
--- a/.github/workflows/_runner_ondemand_slurm.yaml
+++ b/.github/workflows/_runner_ondemand_slurm.yaml
@@ -44,7 +44,7 @@ jobs:
         id: meta
         shell: bash -x -e {0}
         run: |
-          JOB_NAME=${{ inputs.NAME }}
+          JOB_NAME=${{ inputs.NAME }}-$(printf "%04x%04x" $RANDOM $RANDOM)
           LOG_FILE=/nfs/cluster/${JOB_NAME}.log
           for var in JOB_NAME LOG_FILE; do
             echo "$var=${!var}" >> $GITHUB_OUTPUT


### PR DESCRIPTION
This is to avoid multiple A100 runners within the same run to overwrite the log of each other.