### PR TITLE
Prefer libcupti.so.12.3 to libcupti.so.12.4

### DIFF
--- a/.github/container/install-nsight.sh
+++ b/.github/container/install-nsight.sh
@@ -20,10 +20,10 @@ rm -rf /var/lib/apt/lists/*
 # "Wrong event order has been detected when adding events to the collection"
 # workaround during nsys report post-processing with 2024.1.1 and CUDA 12.3
 NSYS202411=/opt/nvidia/nsight-systems-cli/2024.1.1
-if [[ -d "${NSYS202411}" ]]; then
+if [[ "${UBUNTU_ARCH}" == "amd64" && -d "${NSYS202411}" ]]; then
   LIBCUPTI123=/opt/nvidia/nsight-compute/2023.3.0/host/target-linux-x64/libcupti.so.12.3
   if [[ ! -f "${LIBCUPTI123}" ]]; then
-    echo "2024.1.1 workaround expects to be running inside 12.3.0 container"
+    echo "2024.1.1 workaround expects to be running inside CUDA 12.3 container"
     exit 1
   fi
   # Use libcupti.so.12.3 because this is a CUDA 12.3 container

--- a/.github/container/install-nsight.sh
+++ b/.github/container/install-nsight.sh
@@ -16,3 +16,17 @@ apt-get install -y nsight-compute nsight-systems-cli
 apt-get clean
 
 rm -rf /var/lib/apt/lists/*
+
+# "Wrong event order has been detected when adding events to the collection"
+# workaround during nsys report post-processing with 2024.1.1 and CUDA 12.3
+NSYS202411=/opt/nvidia/nsight-systems-cli/2024.1.1
+if [[ -d "${NSYS202411}" ]]; then
+  LIBCUPTI123=/opt/nvidia/nsight-compute/2023.3.0/host/target-linux-x64/libcupti.so.12.3
+  if [[ ! -f "${LIBCUPTI123}" ]]; then
+    echo "2024.1.1 workaround expects to be running inside 12.3.0 container"
+    exit 1
+  fi
+  # Use libcupti.so.12.3 because this is a CUDA 12.3 container
+  ln -s "${LIBCUPTI123}" "${NSYS202411}/target-linux-x64/libcupti.so.12.3"
+  mv "${NSYS202411}/target-linux-x64/libcupti.so.12.4" "${NSYS202411}/target-linux-x64/_libcupti.so.12.4"
+fi


### PR DESCRIPTION
Works around an error during `nsys profile` post-processing with `nsys` 2024.1.1 and CUDA 12.3.

After `nsys profile` collection has completed, the `.nsys-rep` file generation can throw an error, for example:
```
Generating '/tmp/nsys-report-a844.qdstrm'
[1/1] [====28%                     ] report7.nsys-rep
Importer error status: Importation failed.
Import Failed with unexpected exception: /dvs/p4/build/sw/devtools/Agora/Rel/QuadD_Main/QuadD/Host/QdstrmImporter/main.cpp(34): Throw in function {anonymous}::Importer::Importer(const boost::filesystem::path&, const boost::filesystem::path&)
Dynamic exception type: boost::wrapexcept<QuadDCommon::RuntimeException>
std::exception::what: RuntimeException
[QuadDCommon::tag_message*] = Status: AnalysisFailed
Error {
  Type: RuntimeError
  SubError {
    Type: InvalidArgument
    Props {
      Items {
        Type: OriginalExceptionClass
        Value: "N5boost10wrapexceptIN11QuadDCommon24InvalidArgumentExceptionEEE"
      }
      Items {
        Type: OriginalFile
        Value: "/dvs/p4/build/sw/devtools/Agora/Rel/QuadD_Main/QuadD/Host/Analysis/Modules/EventCollection.cpp"
      }
      Items {
        Type: OriginalLine
        Value: "1055"
      }
      Items {
        Type: OriginalFunction
        Value: "void QuadDAnalysis::EventCollection::CheckOrder(QuadDAnalysis::EventCollectionHelper::EventContainer&, const QuadDAnalysis::ConstEvent&) const"
      }
      Items {
        Type: ErrorText
        Value: "Wrong event order has been detected when adding events to the collection:\nnew event ={ StartNs=7700709 StopNs=7703724 GlobalId=282099626054000 Event={ TraceProcessEvent=[{ Correlation=61037 EventClass=1 TextId=7104 ReturnValue=0
 },] } Type=48 }\nlast event ={ StartNs=544475002 StopNs=544478549 GlobalId=282099626054000 Event={ TraceProcessEvent=[{ Correlation=112698 EventClass=1 TextId=7086 ReturnValue=0 },] } Type=48 }"
      }
    }
  }
}
Generated:
    /root/report7.qdstrm
```

This works around this error by using a `libcupti.so` version that matches the CUDA version in the container.