### PR TITLE
Always bump manifest and save as a new file in CI

### DIFF
--- a/.github/workflows/_build_base.yaml
+++ b/.github/workflows/_build_base.yaml
@@ -63,12 +63,18 @@ jobs:
       - name: Check out the repository under ${GITHUB_WORKSPACE}
         uses: actions/checkout@v4
 
-      - name: Update manifest and patches in-place - show diff
+      - name: Test if manifest bump is functional, and save result to a new file
+        working-directory: .github/container
+        shell: bash -x -e {0}
+        run: |
+          bash bump.sh --input-manifest manifest.yaml --output-manifest manifest.yaml.new
+
+      - name: Replace current manifest with the new one and show diff
         if: inputs.BUMP_MANIFEST
         working-directory: .github/container
         shell: bash -x -e {0}
         run: |
-          bash bump.sh --input-manifest manifest.yaml
+          mv manifest.yaml.new manifest.yaml
           git diff
 
       - name: Upload bumped manifest to be used in build-base


### PR DESCRIPTION
This is to avoid future incidents like https://github.com/NVIDIA/JAX-Toolbox/actions/runs/7913764480, where an error introduced via [an earlier PR](https://github.com/NVIDIA/JAX-Toolbox/pull/542/files#diff-fe97711a3e6691d7687dcb162852ad8d926930e75cb7bcba71b5eaa3112056efR153) was not catched by presubmit CI because the job that uses it only runs during the nightlies.