### PR TITLE
Fix on-demand A100 runner name conflict

### DIFF
--- a/.github/workflows/_runner_ondemand_slurm.yaml
+++ b/.github/workflows/_runner_ondemand_slurm.yaml
@@ -44,7 +44,7 @@ jobs:
         id: meta
         shell: bash -x -e {0}
         run: |
-          JOB_NAME=${{ inputs.NAME }}-$(printf "%8x" $((RANDOM<<16+RANDOM)))
+          JOB_NAME=${{ inputs.NAME }}-$(printf "%012x" $(((RANDOM<<32)+(RANDOM<<16)+RANDOM)))
           LOG_FILE=/nfs/cluster/${JOB_NAME}.log
           for var in JOB_NAME LOG_FILE; do
             echo "$var=${!var}" >> $GITHUB_OUTPUT

--- a/.github/workflows/_runner_ondemand_slurm.yaml
+++ b/.github/workflows/_runner_ondemand_slurm.yaml
@@ -44,7 +44,7 @@ jobs:
         id: meta
         shell: bash -x -e {0}
         run: |
-          JOB_NAME=${{ inputs.NAME }}-$(printf "%04x%04x" $RANDOM $RANDOM)
+          JOB_NAME=${{ inputs.NAME }}-$(printf "%8x" $((RANDOM<<16+RANDOM)))
           LOG_FILE=/nfs/cluster/${JOB_NAME}.log
           for var in JOB_NAME LOG_FILE; do
             echo "$var=${!var}" >> $GITHUB_OUTPUT
@@ -59,7 +59,7 @@ jobs:
             sbatch --parsable \
           <<"EOF"
           #!/bin/bash
-          #SBATCH --job-name=${{steps.meta.outputs.JOB_NAME }}
+          #SBATCH --job-name=${{ steps.meta.outputs.JOB_NAME }}
           #SBATCH --exclusive
           #SBATCH --nodes=1
           #SBATCH --tasks=1
@@ -85,7 +85,7 @@ jobs:
             --gpus all \
             --privileged \
             -v /runner \
-            -e RUNNER_NAME="${{ inputs.NAME }}" \
+            -e RUNNER_NAME="${{ steps.meta.outputs.JOB_NAME }}" \
             -e RUNNER_LABELS="${{ inputs.LABELS }}" \
             -e RUNNER_REPO="${{ github.repository }}" \
             -e RUNNER_TOKEN="${RUNNER_TOKEN}" \

--- a/.github/workflows/_sandbox.yaml
+++ b/.github/workflows/_sandbox.yaml
@@ -1,32 +1,41 @@
 name: "~Sandbox"
 
 on:
-  push:
+  workflow_dispatch:
 
 jobs:
-  test-jax:
-    uses: ./.github/workflows/_test_unit.yaml
-    with:
-      IMAGE: ghcr.io/nvidia/jax:jax
-      TEST_NAME: jax
-      ARTIFACT_NAME: artifact-jax-unit-test
-      BADGE_FILENAME: badge-jax-unit-test
-    secrets: inherit
+  sandbox:
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
-  test-pallas:
-    uses: ./.github/workflows/_test_unit.yaml
-    with:
-      IMAGE: ghcr.io/nvidia/jax:pallas
-      TEST_NAME: pallas
-      ARTIFACT_NAME: artifact-pallas-unit-test
-      BADGE_FILENAME: badge-pallas-unit-test
-    secrets: inherit
+      - name: Print usage
+        run: |
+          cat << EOF
+          This is an empty workflow file located in the main branch of your
+          repository. It serves as a testing ground for new GitHub Actions on
+          development branches before merging them to the main branch. By
+          defining and overloading this workflow on your development branch,
+          you can test new actions without affecting your main branch, ensuring
+          a smooth integration process once the changes are ready to be merged.
 
-  test-levanter:
-    uses: ./.github/workflows/_test_unit.yaml
-    with:
-      IMAGE: ghcr.io/nvidia/jax:levanter
-      TEST_NAME: levanter
-      ARTIFACT_NAME: artifact-levanter-unit-test
-      BADGE_FILENAME: badge-levanter-unit-test
-    secrets: inherit
+          Usage:
+          
+          1. In your development branch, modify the sandbox.yml workflow file
+             to include the new actions you want to test. Make sure to commit
+             the changes to the development branch.
+          2. Navigate to the 'Actions' tab in your repository, select the
+             '~Sandbox' workflow, and choose your development branch from the
+             branch dropdown menu. Click on 'Run workflow' to trigger the
+             workflow on your development branch.
+          3. Once you have tested and verified the new actions in the Sandbox
+             workflow, you can incorporate them into your main workflow(s) and
+             merge the development branch into the main branch. Remember to
+             revert the changes to the sandbox.yml file in the main branch to
+             keep it empty for future testing.
+          EOF

--- a/.github/workflows/_sandbox.yaml
+++ b/.github/workflows/_sandbox.yaml
@@ -13,7 +13,6 @@ jobs:
     secrets: inherit
 
   jax-unit-test:
-    needs: runner
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/_sandbox.yaml
+++ b/.github/workflows/_sandbox.yaml
@@ -18,11 +18,11 @@ jobs:
       matrix:
         GPU_ARCH: [V100, A100]
         include:
-          - EXTRA_LABEL: "self-hosted"
           - GPU_ARCH: A100
             EXTRA_LABEL: "${{ github.run_id }}"
     # ensures A100 job lands on dedicated runner for this particular job
     runs-on:
+      - self-hosted
       - "${{ matrix.GPU_ARCH }}"
       - "${{ matrix.EXTRA_LABEL }}"
     env:

--- a/.github/workflows/_sandbox.yaml
+++ b/.github/workflows/_sandbox.yaml
@@ -1,41 +1,32 @@
 name: "~Sandbox"
 
 on:
-  workflow_dispatch:
+  push:
 
 jobs:
-  sandbox:
-    runs-on: ubuntu-22.04
+  runner:
+    uses: ./.github/workflows/_runner_ondemand_slurm.yaml
+    with:
+      NAME: "TEST"
+      LABELS: "A100,${{ github.run_id }}"
+      TIME: "01:00:00"
+    secrets: inherit
+
+  jax-unit-test:
+    strategy:
+      fail-fast: false
+      matrix:
+        GPU_ARCH: [V100, A100]
+    # ensures A100 job lands on dedicated runner for this particular job
+    runs-on:
+      - self-hosted
+      - "${{ matrix.GPU_ARCH }}"
+      - "${{ matrix.GPU_ARCH == 'A100' && github.run_id || '' }}"
+    env:
+      BADGE_FILENAME_FULL: ${{ inputs.BADGE_FILENAME }}-${{ matrix.GPU_ARCH }}.json
     steps:
-      - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3
-        with:
-          registry: ghcr.io
-          username: ${{ github.repository_owner }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Print environment variables
+        run: env
 
-      - name: Print usage
-        run: |
-          cat << EOF
-          This is an empty workflow file located in the main branch of your
-          repository. It serves as a testing ground for new GitHub Actions on
-          development branches before merging them to the main branch. By
-          defining and overloading this workflow on your development branch,
-          you can test new actions without affecting your main branch, ensuring
-          a smooth integration process once the changes are ready to be merged.
-
-          Usage:
-          
-          1. In your development branch, modify the sandbox.yml workflow file
-             to include the new actions you want to test. Make sure to commit
-             the changes to the development branch.
-          2. Navigate to the 'Actions' tab in your repository, select the
-             '~Sandbox' workflow, and choose your development branch from the
-             branch dropdown menu. Click on 'Run workflow' to trigger the
-             workflow on your development branch.
-          3. Once you have tested and verified the new actions in the Sandbox
-             workflow, you can incorporate them into your main workflow(s) and
-             merge the development branch into the main branch. Remember to
-             revert the changes to the sandbox.yml file in the main branch to
-             keep it empty for future testing.
-          EOF
+      - name: Print GPU information
+        run: nvidia-smi  

--- a/.github/workflows/_sandbox.yaml
+++ b/.github/workflows/_sandbox.yaml
@@ -4,24 +4,27 @@ on:
   push:
 
 jobs:
-  runner:
-    uses: ./.github/workflows/_runner_ondemand_slurm.yaml
-    with:
-      NAME: "TEST"
-      LABELS: "A100,${{ github.run_id }}"
-      TIME: "01:00:00"
-    secrets: inherit
+  # runner:
+  #   uses: ./.github/workflows/_runner_ondemand_slurm.yaml
+  #   with:
+  #     NAME: "TEST"
+  #     LABELS: "A100,${{ github.run_id }}"
+  #     TIME: "01:00:00"
+  #   secrets: inherit
 
   jax-unit-test:
     strategy:
       fail-fast: false
       matrix:
         GPU_ARCH: [V100, A100]
+        include:
+          - EXTRA_LABEL: "self-hosted"
+          - GPU_ARCH: A100
+            EXTRA_LABEL: "${{ github.run_id }}"
     # ensures A100 job lands on dedicated runner for this particular job
     runs-on:
-      - self-hosted
       - "${{ matrix.GPU_ARCH }}"
-      - "${{ matrix.GPU_ARCH == 'A100' && github.run_id || '' }}"
+      - "${{ matrix.EXTRA_LABEL }}"
     env:
       BADGE_FILENAME_FULL: ${{ inputs.BADGE_FILENAME }}-${{ matrix.GPU_ARCH }}.json
     steps:

--- a/.github/workflows/_sandbox.yaml
+++ b/.github/workflows/_sandbox.yaml
@@ -18,6 +18,7 @@ jobs:
       matrix:
         GPU_ARCH: [V100, A100]
         include:
+          - EXTRA_LABEL: "self-hosted"
           - GPU_ARCH: A100
             EXTRA_LABEL: "${{ github.run_id }}"
     # ensures A100 job lands on dedicated runner for this particular job

--- a/.github/workflows/_sandbox.yaml
+++ b/.github/workflows/_sandbox.yaml
@@ -4,33 +4,29 @@ on:
   push:
 
 jobs:
-  # runner:
-  #   uses: ./.github/workflows/_runner_ondemand_slurm.yaml
-  #   with:
-  #     NAME: "TEST"
-  #     LABELS: "A100,${{ github.run_id }}"
-  #     TIME: "01:00:00"
-  #   secrets: inherit
+  test-jax:
+    uses: ./.github/workflows/_test_unit.yaml
+    with:
+      IMAGE: ghcr.io/nvidia/jax:jax
+      TEST_NAME: jax
+      ARTIFACT_NAME: artifact-jax-unit-test
+      BADGE_FILENAME: badge-jax-unit-test
+    secrets: inherit
 
-  jax-unit-test:
-    strategy:
-      fail-fast: false
-      matrix:
-        GPU_ARCH: [V100, A100]
-        include:
-          - EXTRA_LABEL: "self-hosted"
-          - GPU_ARCH: A100
-            EXTRA_LABEL: "${{ github.run_id }}"
-    # ensures A100 job lands on dedicated runner for this particular job
-    runs-on:
-      - self-hosted
-      - "${{ matrix.GPU_ARCH }}"
-      - "${{ matrix.EXTRA_LABEL }}"
-    env:
-      BADGE_FILENAME_FULL: ${{ inputs.BADGE_FILENAME }}-${{ matrix.GPU_ARCH }}.json
-    steps:
-      - name: Print environment variables
-        run: env
+  test-pallas:
+    uses: ./.github/workflows/_test_unit.yaml
+    with:
+      IMAGE: ghcr.io/nvidia/jax:pallas
+      TEST_NAME: pallas
+      ARTIFACT_NAME: artifact-pallas-unit-test
+      BADGE_FILENAME: badge-pallas-unit-test
+    secrets: inherit
 
-      - name: Print GPU information
-        run: nvidia-smi  
+  test-levanter:
+    uses: ./.github/workflows/_test_unit.yaml
+    with:
+      IMAGE: ghcr.io/nvidia/jax:levanter
+      TEST_NAME: levanter
+      ARTIFACT_NAME: artifact-levanter-unit-test
+      BADGE_FILENAME: badge-levanter-unit-test
+    secrets: inherit

--- a/.github/workflows/_sandbox.yaml
+++ b/.github/workflows/_sandbox.yaml
@@ -13,6 +13,7 @@ jobs:
     secrets: inherit
 
   jax-unit-test:
+    needs: runner
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/_test_unit.yaml
+++ b/.github/workflows/_test_unit.yaml
@@ -26,8 +26,8 @@ jobs:
   runner:
     uses: ./.github/workflows/_runner_ondemand_slurm.yaml
     with:
-      NAME: "A100-${{ github.run_id }}"
-      LABELS: "A100:${{ github.run_id }}"
+      NAME: "A100"
+      LABELS: "A100,${{ github.run_id }}"
       TIME: "01:00:00"
     secrets: inherit
 
@@ -37,8 +37,15 @@ jobs:
       fail-fast: false
       matrix:
         GPU_ARCH: [V100, A100]
-    # ensures A100 job lands on dedicated runner for this particular job
-    runs-on: [self-hosted, "${{ matrix.GPU_ARCH == 'A100' && format('{0}:{1}', matrix.GPU_ARCH, github.run_id) || matrix.GPU_ARCH }}"]
+        include:
+          - EXTRA_LABEL: "self-hosted"
+          # ensures A100 job lands on dedicated runner for this particular job
+          - GPU_ARCH: A100
+            EXTRA_LABEL: "${{ github.run_id }}"
+    runs-on:
+      - self-hosted
+      - "${{ matrix.GPU_ARCH }}"
+      - "${{ matrix.EXTRA_LABEL }}"
     env:
       BADGE_FILENAME_FULL: ${{ inputs.BADGE_FILENAME }}-${{ matrix.GPU_ARCH }}.json
     steps:
@@ -132,8 +139,15 @@ jobs:
       fail-fast: false
       matrix:
         GPU_ARCH: [V100, A100]
-    # ensures A100 job lands on dedicated runner for this particular job
-    runs-on: [self-hosted, "${{ matrix.GPU_ARCH == 'A100' && format('{0}:{1}', matrix.GPU_ARCH, github.run_id) || matrix.GPU_ARCH }}"]
+        include:
+          - EXTRA_LABEL: "self-hosted"
+          # ensures A100 job lands on dedicated runner for this particular job
+          - GPU_ARCH: A100
+            EXTRA_LABEL: "${{ github.run_id }}"
+    runs-on:
+      - self-hosted
+      - "${{ matrix.GPU_ARCH }}"
+      - "${{ matrix.EXTRA_LABEL }}"
     env:
       BADGE_FILENAME_FULL: ${{ inputs.BADGE_FILENAME }}-${{ matrix.GPU_ARCH }}.json
     steps:
@@ -221,8 +235,15 @@ jobs:
       fail-fast: false
       matrix:
         GPU_ARCH: [V100, A100]
-    # ensures A100 job lands on dedicated runner for this particular job
-    runs-on: [self-hosted, "${{ matrix.GPU_ARCH == 'A100' && format('{0}:{1}', matrix.GPU_ARCH, github.run_id) || matrix.GPU_ARCH }}"]
+        include:
+          - EXTRA_LABEL: "self-hosted"
+          # ensures A100 job lands on dedicated runner for this particular job
+          - GPU_ARCH: A100
+            EXTRA_LABEL: "${{ github.run_id }}"
+    runs-on:
+      - self-hosted
+      - "${{ matrix.GPU_ARCH }}"
+      - "${{ matrix.EXTRA_LABEL }}"
     env:
       BADGE_FILENAME_FULL: ${{ inputs.BADGE_FILENAME }}-${{ matrix.GPU_ARCH }}.json
     steps:


### PR DESCRIPTION
Append random 12-digit hex number to runner names, and use the `matrix.include` strategy to ensure placement of GPU jobs on the desired runner.