### PR TITLE
Apply XLA's patches to XLA's tag of Triton

### DIFF
--- a/.github/container/Dockerfile.pallas
+++ b/.github/container/Dockerfile.pallas
@@ -13,8 +13,7 @@ ARG SRC_PATH_TRITON
 # in the manifest file is consistent with the commit of xla, and that any extra
 # patches are available under patches/openxla-triton
 RUN get-source.sh -l openxla-triton -m ${MANIFEST_FILE}
-ADD patches/openxla-triton/*.patch /opt/openxla-triton/xla-patches/
-RUN cd /opt/openxla-triton && for patch in xla-patches/*.patch; do patch -p1 < "${patch}"; done && git diff
+RUN cd /opt/openxla-triton && for patch in /opt/manifest.d/patches/openxla-triton/*.patch; do patch -p1 < "${patch}"; done && git diff
 
 RUN <<"EOF" bash -ex
 mkdir -p "${SRC_PATH_TRITON}/dist"

--- a/.github/container/Dockerfile.pallas
+++ b/.github/container/Dockerfile.pallas
@@ -10,8 +10,11 @@ FROM ${BASE_IMAGE} as builder
 ARG SRC_PATH_TRITON
 
 # bump-openxla-triton.sh ensures that the commit of openxla-triton referenced
-# in the manifest file is consistent with the commit of xla
+# in the manifest file is consistent with the commit of xla, and that any extra
+# patches are available under patches/openxla-triton
 RUN get-source.sh -l openxla-triton -m ${MANIFEST_FILE}
+ADD patches/openxla-triton/*.patch /opt/openxla-triton/xla-patches/
+RUN cd /opt/openxla-triton && for patch in xla-patches/*.patch; do patch -p1 < "${patch}"; done && git diff
 
 RUN <<"EOF" bash -ex
 mkdir -p "${SRC_PATH_TRITON}/dist"

--- a/.github/container/bump-openxla-triton.sh
+++ b/.github/container/bump-openxla-triton.sh
@@ -6,7 +6,7 @@ usage() {
 cat <<EOF
 This script is a utility for updating the commit reference for openxla-triton
 in a manifest YAML file used to build JAX-Toolbox images. The commit is derived
-from the commit for xla contained in the manifest.
+from the commit for xla contained in the manifest, along with the patches.
 
 Usage: $0 [OPTION]...
   -h, --help      Print usage.
@@ -50,6 +50,7 @@ if [[ -z "${MANIFEST:-}" ]]; then
 fi
 
 set -eou pipefail
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 
 xla_url=$(yq e ".xla.url" $MANIFEST)
 xla_tracking_ref=$(yq e ".xla.tracking_ref" $MANIFEST)
@@ -58,8 +59,18 @@ xla_commit=$(yq e ".xla.latest_verified_commit" $MANIFEST)
 git clone --branch "${xla_tracking_ref}" --single-branch "${xla_url}" "${xla_repo}"
 (cd "${xla_repo}" && git checkout "${xla_commit}")
 # Extract the openxla/triton tag used by XLA. Even though it is called
-# TRITON_COMMIT it is a tag. In principle we should also account for the
-# patches in this .bzl file, but skip that for now.
-openxla_triton_tag=$(sed -n -e 's#\s\+TRITON_COMMIT = "\(cl[0-9]\+\)"#\1#p' "${xla_repo}/third_party/triton/workspace.bzl")
+# TRITON_COMMIT it is a tag.
+workspace_file="${xla_repo}/third_party/triton/workspace.bzl"
+openxla_triton_tag=$(sed -n -e 's#\s\+TRITON_COMMIT = "\(cl[0-9]\+\)"#\1#p' "${workspace_file}")
+# Extract Triton patch files applied by XLA
+patch_files=$(python3 -c 'import ast, sys; tree = ast.parse(sys.stdin.read()); print(" ".join(elem.value.removeprefix("//third_party/triton:").removesuffix(".patch") for node in ast.walk(tree) if isinstance(node, ast.keyword) and node.arg == "patch_file" for elem in node.value.elts))' < "${workspace_file}")
+# Clear old patches from the manifest file
+yq e 'del(.openxla-triton.patches)' -i "${MANIFEST}"
+i=0
+for patch_file in ${patch_files}; do
+  cp -v "${xla_repo}/third_party/triton/${patch_file}.patch" "${SCRIPT_DIR}/patches/openxla-triton/${i}_${patch_file}.patch"
+  yq e ".openxla-triton.patches.${patch_file} = \"file://patches/openxla-triton/${i}_${patch_file}.patch\"" -i "${MANIFEST}"
+  i=$((i+1))
+done
 rm -rf "${xla_repo}"
 yq e ".openxla-triton.latest_verified_commit = \"${openxla_triton_tag}\"" -i $MANIFEST

--- a/.github/container/bump-openxla-triton.sh
+++ b/.github/container/bump-openxla-triton.sh
@@ -65,6 +65,8 @@ openxla_triton_tag=$(sed -n -e 's#\s\+TRITON_COMMIT = "\(cl[0-9]\+\)"#\1#p' "${w
 # Extract Triton patch files applied by XLA
 patch_files=$(python3 -c 'import ast, sys; tree = ast.parse(sys.stdin.read()); print(" ".join(elem.value.removeprefix("//third_party/triton:").removesuffix(".patch") for node in ast.walk(tree) if isinstance(node, ast.keyword) and node.arg == "patch_file" for elem in node.value.elts))' < "${workspace_file}")
 i=0
+# Remove old patch files
+rm -vf ${SCRIPT_DIR}/patches/openxla-triton/*.patch
 for patch_file in ${patch_files}; do
   cp -v "${xla_repo}/third_party/triton/${patch_file}.patch" "${SCRIPT_DIR}/patches/openxla-triton/${i}_${patch_file}.patch"
   i=$((i+1))

--- a/.github/container/bump-openxla-triton.sh
+++ b/.github/container/bump-openxla-triton.sh
@@ -64,12 +64,9 @@ workspace_file="${xla_repo}/third_party/triton/workspace.bzl"
 openxla_triton_tag=$(sed -n -e 's#\s\+TRITON_COMMIT = "\(cl[0-9]\+\)"#\1#p' "${workspace_file}")
 # Extract Triton patch files applied by XLA
 patch_files=$(python3 -c 'import ast, sys; tree = ast.parse(sys.stdin.read()); print(" ".join(elem.value.removeprefix("//third_party/triton:").removesuffix(".patch") for node in ast.walk(tree) if isinstance(node, ast.keyword) and node.arg == "patch_file" for elem in node.value.elts))' < "${workspace_file}")
-# Clear old patches from the manifest file
-yq e 'del(.openxla-triton.patches)' -i "${MANIFEST}"
 i=0
 for patch_file in ${patch_files}; do
   cp -v "${xla_repo}/third_party/triton/${patch_file}.patch" "${SCRIPT_DIR}/patches/openxla-triton/${i}_${patch_file}.patch"
-  yq e ".openxla-triton.patches.${patch_file} = \"file://patches/openxla-triton/${i}_${patch_file}.patch\"" -i "${MANIFEST}"
   i=$((i+1))
 done
 rm -rf "${xla_repo}"

--- a/.github/container/patches/openxla-triton/0_cl602723852.patch
+++ b/.github/container/patches/openxla-triton/0_cl602723852.patch
@@ -1,0 +1,15 @@
+Remove once b/322980485 is fixed.
+diff --git a/python/triton/backends/__init__.py b/python/triton/backends/__init__.py
+--- a/python/triton/backends/__init__.py
++++ b/python/triton/backends/__init__.py
+@@ -46,5 +46,8 @@ def _discover_backends():
+                                  _find_concrete_subclasses(driver, DriverBase))
+     return backends
+ 
+-
+-backends = _discover_backends()
++from triton.backends.nvidia.driver import CudaDriver
++from triton.backends.nvidia.compiler import CUDABackend
++backends = {
++        "nvidia": Backend(CUDABackend, CudaDriver)
++}

--- a/.github/container/patches/openxla-triton/1_cl602997103.patch
+++ b/.github/container/patches/openxla-triton/1_cl602997103.patch
@@ -1,0 +1,14 @@
+==== triton/python/src/ir.cc#3 - /google/src/cloud/joelwee/mlir_da784a25557e29996bd33638d51d569ddf989faf_1706700588/triton/python/src/ir.cc ====
+# action=edit type=text
+--- triton/python/src/ir.cc	2024-01-30 04:43:56.000000000 -0800
++++ triton/python/src/ir.cc	2024-01-31 04:40:21.000000000 -0800
+@@ -271,7 +271,8 @@
+            })
+       .def("get_num_arguments", &mlir::Block::getNumArguments)
+       .def("dump", &mlir::Block::dump)
+-      .def("move_before", &mlir::Block::moveBefore)
++      .def("move_before",
++           [](mlir::Block &self, mlir::Block *tgt) { self.moveBefore(tgt); })
+       .def("insert_before", &mlir::Block::insertBefore)
+       .def("get_parent", &mlir::Block::getParent, ret::reference)
+       .def("merge_block_before",


### PR DESCRIPTION
XLA maintains a list of patches: https://github.com/openxla/xla/blob/e83773328ac3b327e4925b877f2988bb45aa7bf1/third_party/triton/workspace.bzl#L16-L18 that should be applied on top of its specific tag of Triton.

Previously we did not apply these when building the Pallas containers. This PR applies them.

I did initially try to use more of the Rosetta machinery for applying patches, but this was a bit painful. Note that Google's patches do not contain headers like the commit author/date/message, and that confuses the `git am` command that Rosetta uses.

https://github.com/NVIDIA/JAX-Toolbox/actions/runs/7972292328 was launched with the manifest bump enabled, to test that side of the changeset.