### PR TITLE
Remove chex pin from pax build causing failure due to pax using later than 0.1.7 now

### DIFF
--- a/.github/container/Dockerfile.pax.arm64
+++ b/.github/container/Dockerfile.pax.arm64
@@ -97,7 +97,6 @@ RUN echo "tensorflow-text @ file://$(ls /opt/tensorflow_text*.whl)" >> /opt/pip-
 RUN <<"EOF" bash -ex
 echo "tensorflow==2.13.0" >> /opt/pip-tools.d/requirements-paxml.in
 echo "tensorflow_datasets==4.9.2" >> /opt/pip-tools.d/requirements-paxml.in
-echo "chex==0.1.7" >> /opt/pip-tools.d/requirements-paxml.in
 echo "auditwheel" >> /opt/pip-tools.d/requirements-paxml.in
 
 get-source.sh -l paxml  -m ${MANIFEST_FILE}


### PR DESCRIPTION
Failing build: https://github.com/NVIDIA/JAX-Toolbox/actions/runs/7971250761/job/21763211927#step:10:240

