### PR TITLE
Fixes issue of bumped manifest patches residing in old ephemeral dir

### DIFF
--- a/.github/container/manifest.yaml
+++ b/.github/container/manifest.yaml
@@ -1,4 +1,3 @@
-# Updated in: 2023-12-01
 jax:
   url: https://github.com/google/jax.git
   tracking_ref: main

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -127,6 +127,7 @@ jobs:
           else
             rm -rf patches-new manifest.yaml.new
           fi
+          sed -i 's|file://patches-new/|file://patches/|g' manifest.yaml
           git diff
 
       - name: Upload bumped manifest/patches to be used in build-base


### PR DESCRIPTION
A bug was introduced after #566 was merged where patches in the manifest now had their relative path updated to `patches-new` even after replacing the patches directory. See this automatic bump PR: https://github.com/NVIDIA/JAX-Toolbox/pull/591/files#diff-fe97711a3e6691d7687dcb162852ad8d926930e75cb7bcba71b5eaa3112056efR32