### PR TITLE
Fix MAX_STEPS in pax eval test

### DIFF
--- a/.github/container/test-pax.sh
+++ b/.github/container/test-pax.sh
@@ -366,6 +366,7 @@ if [[ ${EVALUATE} -ne 0 ]]; then
     --fdl_config=${CONFIG} \
     --job_log_dir=${OUTPUT} \
     --mode='eval' \
+    --fdl.MAX_STEPS=0 \
     --alsologtostderr \
     --enable_checkpoint_saving=False \
     $ADDITIONAL_ARGS \


### PR DESCRIPTION
Explicitly set `MAX_STEPS` to 0 in Pax eval test to avoid sleeping indefinitely while waiting for another checkpoint to be generated