### PR TITLE
Re-enable environment variables to guard against hangs with Triton gemms

### DIFF
--- a/.github/container/Dockerfile.jax
+++ b/.github/container/Dockerfile.jax
@@ -59,10 +59,11 @@ ENV XLA_FLAGS=""
 ENV XLA_FLAGS="${XLA_FLAGS} --xla_gpu_enable_latency_hiding_scheduler=true"
 ENV XLA_FLAGS="${XLA_FLAGS} --xla_gpu_enable_async_all_gather=true"
 ENV XLA_FLAGS="${XLA_FLAGS} --xla_gpu_enable_async_reduce_scatter=true"
-ENV XLA_FLAGS="${XLA_FLAGS} --xla_gpu_enable_triton_gemm=false"
 ENV CUDA_DEVICE_MAX_CONNECTIONS=1
 ENV NCCL_NVLS_ENABLE=0
 ENV CUDA_MODULE_LOADING=EAGER
+ENV JAX_SHARE_BINARY_BETWEEN_HOSTS=True
+ENV JAX_SHARE_AUTOTUNE_CONFIG_BETWEEN_HOSTS=True
 
 ADD --chmod=777 create-distribution.sh ${DEST_MANIFEST_DIR}/
 

--- a/.github/container/manifest.yaml
+++ b/.github/container/manifest.yaml
@@ -1,31 +1,31 @@
 jax:
   url: https://github.com/google/jax.git
   tracking_ref: main
-  latest_verified_commit: 75cdef7626b92b8b6563ea68ae4747fd6994db2e
+  latest_verified_commit: c94ec17c0d255b560e948e1b6bb98f1a1b8be45f
   mode: git-clone
 xla:
   url: https://github.com/openxla/xla.git
   tracking_ref: main
-  latest_verified_commit: 831e9cef85493ff7ee2e24fd4cc64377d682aecc
+  latest_verified_commit: e025d9f3ed4d5b7ed80b2352c613e3706d917416
   mode: git-clone
 flax:
   url: https://github.com/google/flax.git
   mirror_url: https://github.com/nvjax-svc-0/flax.git
   tracking_ref: main
-  latest_verified_commit: aaf130c90eb46160a3234c258a48bf1b932d7829
+  latest_verified_commit: e4282ee187efbefbde268c6873c592a352f56313
   mode: git-clone
   patches:
     pull/3340/head: file://patches/flax/PR-3340.patch # Add Sharding Annotations to Flax Modules
 transformer-engine:
   url: https://github.com/NVIDIA/TransformerEngine.git
   tracking_ref: main
-  latest_verified_commit: 9b2fed514ea419141146f843ab2c84b22b86bfd7
+  latest_verified_commit: b459ccc93549c13797f884271904e019ad7fa3db
   mode: git-clone
 t5x:
   url: https://github.com/google-research/t5x.git
   mirror_url: https://github.com/nvjax-svc-0/t5x.git
   tracking_ref: main
-  latest_verified_commit: ecb126e1f5c2aea648f39869d4e69fb4374a4868
+  latest_verified_commit: ecc6369c95b7b3066a46af5050c8ff9113eb219b
   mode: git-clone
   patches:
     mirror/patch/partial-checkpoint-restore: file://patches/t5x/mirror-patch-partial-checkpoint-restore.patch # pull/1392/head  # https://github.com/google-research/t5x/pull/1392: Add support for partial checkpoint restore
@@ -43,7 +43,7 @@ praxis:
   url: https://github.com/google/praxis.git
   mirror_url: https://github.com/nvjax-svc-0/praxis.git
   tracking_ref: main
-  latest_verified_commit: c4271181833d540ea22b1e3875e2bd54951763e9
+  latest_verified_commit: 833073e5f7516f487ced5b7b1dcc06b962ebd4e0
   mode: git-clone
   patches:
     pull/27/head: file://patches/praxis/PR-27.patch # This PR allows XLA:GPU to detect the MHA pattern more easily to call fused kernels from cublas.
@@ -52,7 +52,7 @@ lingvo:
   # Used only in ARM pax builds
   url: https://github.com/tensorflow/lingvo.git
   tracking_ref: master
-  latest_verified_commit: 5bbe38c046519b86fa5c0488f813ffbf8b467d7e
+  latest_verified_commit: 05a076b0783a8bbf4a770095966c472bb37bbf65
   mode: git-clone
 tensorflow-text:
   # Used only in ARM pax and t5x builds
@@ -73,12 +73,12 @@ fiddle:
 airio:
   url: https://github.com/google/airio.git
   tracking_ref: main
-  latest_verified_commit: e4c682e691354d75a6bea521cd61709b1ab81d34
+  latest_verified_commit: 9051cd3375de479df41e0385d200da5101285e55
   mode: pip-vcs
 clu:
   url: https://github.com/google/CommonLoopUtils.git
   tracking_ref: main
-  latest_verified_commit: eed40a1facd526df0e0faa192525f357a3321dca
+  latest_verified_commit: 0b961e5390da283448b5fc4632b61641980e0a0e
   mode: pip-vcs
 dllogger:
   url: https://github.com/NVIDIA/dllogger.git
@@ -93,54 +93,54 @@ jestimator:
 optax:
   url: https://github.com/google-deepmind/optax.git
   tracking_ref: main
-  latest_verified_commit: 623609c7a77a19d48b021cbc300262308846317e
+  latest_verified_commit: 18110a40153097d15015af2d5d2ee73a86c2a9df
   mode: pip-vcs
 seqio:
   url: https://github.com/google/seqio.git
   tracking_ref: main
-  latest_verified_commit: e31af8c1a11f749edeac512f34d148b9933f863f
+  latest_verified_commit: 11706e4a1e01a81ea6b3e02c5ad147028d5b94bb
   mode: pip-vcs
 # used by Pallas
 openxla-triton:
   url: https://github.com/openxla/triton.git
   tracking_ref: llvm-head
-  latest_verified_commit: cl608559313
+  latest_verified_commit: c33bbb01d087129e3714cfc2a0bcd53b80dd2013
   mode: git-clone
 jax-triton:
   url: https://github.com/jax-ml/jax-triton.git
   tracking_ref: main
-  latest_verified_commit: 708d3e8afe13b52e4191ad3b677c6f1238677c9e
+  latest_verified_commit: 08f10633740924de30d85a65386e226b5cbbe564
   mode: git-clone
 maxtext:
   url: https://github.com/google/maxtext.git
   tracking_ref: main
-  latest_verified_commit: 5420bc5753fec4b3a811664cdb58f3c9e98d35fb
+  latest_verified_commit: fac91938e2f23670ced1f6569557927d31185c9e
   mode: git-clone
 levanter:
   url: https://github.com/stanford-crfm/levanter.git
   tracking_ref: main
-  latest_verified_commit: 94a432e7999ae016645bc72e9dda55e724d0f834
+  latest_verified_commit: 26577417d6c48144e30d97b6aceaf5da917c4f79
   mode: git-clone
 haliax:
   url: https://github.com/stanford-crfm/haliax.git
   tracking_ref: main
-  latest_verified_commit: 690623131e107972ec2ec67d6183c77649d4b7e0
+  latest_verified_commit: b94cef72e8bafec57e170fceb9ee86bbe2b1bcfa
   mode: git-clone
 mujoco:
   url: https://github.com/google-deepmind/mujoco.git
   tracking_ref: main
-  latest_verified_commit: c6a41fbfe64ee7b2680a6bde90200ca660d08c2a
+  latest_verified_commit: ef3cb7ec2e75da93e3307b88b53923ee8f8c7f66
   mode: git-clone
 grain:
   # Used only in ARM t5x builds
   url: https://github.com/google/grain.git
   tracking_ref: main
-  latest_verified_commit: f58031724ff06bcc84943c9a8ec501c8941dd660
+  latest_verified_commit: 98531edd5332c3f212853f88513ac55f29be96b7
   mode: git-clone
 mujoco-mpc:
   url: https://github.com/google-deepmind/mujoco_mpc.git
   tracking_ref: main
-  latest_verified_commit: 50a0159cbc70b38a7fee425b8bf5edbc04a1b62e
+  latest_verified_commit: 4700f4a13be18398f5aaf6a33ed42e531967e3ae
   mode: git-clone
 language-to-reward-2023:
   url: https://github.com/google-deepmind/language_to_reward_2023.git

--- a/.github/container/patches/praxis/PR-36.patch
+++ b/.github/container/patches/praxis/PR-36.patch
@@ -1,7 +1,7 @@
 From 41488517eb6d95eb7943681e706c8804e6102c41 Mon Sep 17 00:00:00 2001
 From: Ming-Xu Huang <mingh@nvidia.com>
 Date: Wed, 15 Nov 2023 11:38:27 +0800
-Subject: [PATCH 1/3] Adding TE support
+Subject: [PATCH 01/10] Adding TE support
 
 ---
  praxis/contrib/gpu/scripts_gpu/te_helper.py | 176 ++++++++++++++++++++
@@ -253,7 +253,7 @@ index ab6cff3..c79dac9 100644
 From ff1745796009cf1ec59f463f8e776c66f1286938 Mon Sep 17 00:00:00 2001
 From: Ming-Xu Huang <mingh@nvidia.com>
 Date: Fri, 17 Nov 2023 15:21:06 +0800
-Subject: [PATCH 2/3] Fix missing vars wiht PP.
+Subject: [PATCH 02/10] Fix missing vars wiht PP.
 
 ---
  praxis/contrib/gpu/scripts_gpu/te_helper.py | 34 ++++++++++++---------
@@ -364,7 +364,7 @@ index e3b2f7c..b31526e 100644
 From 99e26aaf14131ca73501f08162be628b55c86a88 Mon Sep 17 00:00:00 2001
 From: Reese Wang <rewang@nvidia.com>
 Date: Wed, 17 Jan 2024 02:36:31 -0800
-Subject: [PATCH 3/3] Add checkpoint_policy checker for fused attn + dropout
+Subject: [PATCH 03/10] Add checkpoint_policy checker for fused attn + dropout
 
 Signed-off-by: Reese Wang <rewang@nvidia.com>
 ---
@@ -475,6 +475,437 @@ index c79dac9..e076530 100644
      repeat_l_params = pax_fiddle.Config(
          repeats.Repeat,
          sub_tpl=self.block,
+-- 
+2.25.1
+
+
+From ab12f857404d84ed423e095d59e0bd336b94f151 Mon Sep 17 00:00:00 2001
+From: Reese Wang <rewang@nvidia.com>
+Date: Mon, 15 Jan 2024 08:25:59 -0800
+Subject: [PATCH 04/10] Support more TE configurations
+
+Signed-off-by: Reese Wang <rewang@nvidia.com>
+---
+ praxis/contrib/gpu/scripts_gpu/te_helper.py | 84 +++++++++++++++++++--
+ 1 file changed, 76 insertions(+), 8 deletions(-)
+
+diff --git a/praxis/contrib/gpu/scripts_gpu/te_helper.py b/praxis/contrib/gpu/scripts_gpu/te_helper.py
+index 290b74c..9defcbd 100644
+--- a/praxis/contrib/gpu/scripts_gpu/te_helper.py
++++ b/praxis/contrib/gpu/scripts_gpu/te_helper.py
+@@ -5,6 +5,9 @@ from praxis import pax_fiddle
+ from praxis import pytypes
+ from praxis import layers
+ from praxis.layers.checkpoint_policy import AutodiffCheckpointType
++from praxis.layers import activations
++from praxis.layers import attentions, grouped_query_attention, multi_query_attention
++from praxis.layers import normalizations
+ 
+ try:
+     import transformer_engine.jax as te
+@@ -112,19 +115,85 @@ class TEInstalledHelper(TransformerEngineHelperBase):
+ 
+     @staticmethod
+     def set_layer_params_to_stack_transformer(stacked_transformer_obj, _, layer_id):
++        enable_sp = bool(int(os.environ.get('ENABLE_TE_SP', 0)))
+         te_transformer_tpl = pax_fiddle.Config(te_praxis.TransformerLayer,
+             name=f'layer_{layer_id}',
+-            layernorm_type='layernorm',
+-            zero_centered_gamma = True,
+-            mlp_activations=('gelu',),
+-            use_bias=True,
+-            self_attn_mask_type='causal',
+             enable_relative_embedding=False,
+-            scaled_query_init=False,
+-            scale_attn_logits=True,
++            enable_sequence_parallel=enable_sp,
+             transpose_batch_sequence=False
+         )
+ 
++        def update_ln_te_tpl(te_tpl, transformer_layer_tpl):
++            # TE requires all normalization are the same
++            assert transformer_layer_tpl.ln_tpl == transformer_layer_tpl.tr_fflayer_tpl.ln_tpl
++            ln_tpl = transformer_layer_tpl.ln_tpl
++            if issubclass(ln_tpl.cls, normalizations.LayerNorm):
++                te_tpl.layernorm_type = 'layernorm'
++                assert ln_tpl.use_scale
++                assert ln_tpl.use_bias
++            elif issubclass(ln_tpl.cls, normalizations.RmsNorm):
++                te_tpl.layernorm_type = 'rmsnorm'
++            else:
++                raise ValueError(f'Unsupported {ln_tpl.cls=}, LayerNorm, RmsNorm are supported.')
++            te_tpl.zero_centered_gamma = not ln_tpl.direct_scale
++            te_tpl.layernorm_epsilon = ln_tpl.epsilon
++            return te_tpl
++
++        def update_ff_te_tpl(te_tpl, ff_layer_tpl):
++            if issubclass(ff_layer_tpl.activation_tpl.cls, activations.Identity):
++                mlp_activations = ('linear',)
++            else:
++                mlp_activations = (ff_layer_tpl.activation_tpl.cls.__name__.lower(),)
++            if ff_layer_tpl.use_gated_activation:
++                mlp_activations += ('linear',)
++            te_tpl.mlp_activations = mlp_activations
++            return te_tpl
++
++        def update_attn_te_tpl(te_tpl, attn_tpl):
++            # TODO(rewang): rope
++            if issubclass(attn_tpl.cls, attentions.DotProductAttention):
++                # Check the DotProductAttention parameters are aligned to TE's attention
++                assert attn_tpl.internal_enable_query_scale or attn_tpl.scale_logits_by_head_dims
++                assert not (attn_tpl.internal_enable_query_scale and attn_tpl.scale_logits_by_head_dims)
++                assert not attn_tpl.internal_enable_per_dim_scale
++                assert not attn_tpl.scale_query_by_dim_per_head
++                assert not attn_tpl.dconv_qkv
++                assert not attn_tpl.internal_gshard_gaussian_init
++                assert not attn_tpl.use_rotary_position_emb
++                assert attn_tpl.relative_bias_tpl is None
++                assert attn_tpl.attention_extra_logit is None
++                assert attn_tpl.ngrammer_tpl is None
++                te_tpl.enable_rotary_pos_emb = attn_tpl.use_rotary_position_emb
++            elif issubclass(attn_tpl.cls, grouped_query_attention.GroupedQueryAttention):
++                te_tpl.num_gqa_groups = attn_tpl.num_kv_heads
++                if attn_tpl.rope_min_max_timescales is not None:
++                    te_tpl.enable_rotary_pos_emb = True
++                    te_tpl.rotary_pos_emb_windows = attn_tpl.rope_min_max_timescales
++                assert attn_tpl.atten_temp == 1.
++            elif issubclass(attn_tpl.cls, multi_query_attention.MultiQueryDotProductAttention):
++                te_tpl.num_gqa_groups = attn_tpl.num_kv_heads
++                te_tpl.enable_rotary_pos_emb = attn_tpl.use_rotary_position_emb
++            else:
++                raise ValueError(f'Unsupported {attn_tpl.cls=}')
++            assert attn_tpl.atten_logit_cap <= 0., 'atten_logit_cap > 0. is not supported in TE'
++            te_tpl.scaled_query_init = False
++            te_tpl.scale_attn_logits = True
++            return te_tpl
++
++        transformer_layer_tpl = stacked_transformer_obj.transformer_layer_params_tpl
++        # Update TE normalization layer configs
++        te_transformer_tpl = update_ln_te_tpl(te_transformer_tpl, transformer_layer_tpl)
++        # Update TE feed forward layer configs
++        te_transformer_tpl = update_ff_te_tpl(te_transformer_tpl, transformer_layer_tpl.tr_fflayer_tpl)
++        # Update TE attention layer configs
++        te_transformer_tpl = update_attn_te_tpl(te_transformer_tpl, transformer_layer_tpl.tr_atten_tpl)
++        # TE currently only allow the bias config to be same between feed forward, qkv proj, out proj
++        assert (transformer_layer_tpl.tr_fflayer_tpl.has_bias ==
++            transformer_layer_tpl.tr_atten_tpl.use_bias), "TE only allows same bias settings."
++        te_transformer_tpl.use_bias = transformer_layer_tpl.tr_fflayer_tpl.has_bias
++        te_transformer_tpl.self_attn_mask_type = 'causal' \
++            if stacked_transformer_obj.mask_self_attention else 'padding'
++
+         te_transformer_tpl.logical_axes_rules = te_flax.extend_logical_axis_rules(tuple())
+         te_transformer_tpl.params_init = stacked_transformer_obj.params_init
+         te_transformer_tpl.dtype = stacked_transformer_obj.fprop_dtype
+@@ -133,7 +202,6 @@ class TEInstalledHelper(TransformerEngineHelperBase):
+         te_transformer_tpl.num_attention_heads = stacked_transformer_obj.num_heads
+         te_transformer_tpl.hidden_size = stacked_transformer_obj.model_dims
+         te_transformer_tpl.mlp_hidden_size = stacked_transformer_obj.hidden_dims
+-        te_transformer_tpl.layernorm_epsilon = stacked_transformer_obj.transformer_layer_params_tpl.ln_tpl.epsilon
+         te_transformer_tpl.dropout_rng_name = base_layer.RANDOM
+         te_transformer_tpl.attention_dropout = stacked_transformer_obj.atten_dropout_prob or stacked_transformer_obj.dropout_prob
+         te_transformer_tpl.hidden_dropout = stacked_transformer_obj.residual_dropout_prob or stacked_transformer_obj.dropout_prob
+-- 
+2.25.1
+
+
+From dc632f0b2bf8da8724e4959360da034b3a7b4075 Mon Sep 17 00:00:00 2001
+From: Reese Wang <rewang@nvidia.com>
+Date: Sun, 18 Feb 2024 01:14:41 -0800
+Subject: [PATCH 05/10] Change the gated activations orders
+
+Signed-off-by: Reese Wang <rewang@nvidia.com>
+---
+ praxis/contrib/gpu/scripts_gpu/te_helper.py | 11 +++++++----
+ 1 file changed, 7 insertions(+), 4 deletions(-)
+
+diff --git a/praxis/contrib/gpu/scripts_gpu/te_helper.py b/praxis/contrib/gpu/scripts_gpu/te_helper.py
+index 9defcbd..1f8f6d6 100644
+--- a/praxis/contrib/gpu/scripts_gpu/te_helper.py
++++ b/praxis/contrib/gpu/scripts_gpu/te_helper.py
+@@ -140,12 +140,15 @@ class TEInstalledHelper(TransformerEngineHelperBase):
+             return te_tpl
+ 
+         def update_ff_te_tpl(te_tpl, ff_layer_tpl):
+-            if issubclass(ff_layer_tpl.activation_tpl.cls, activations.Identity):
+-                mlp_activations = ('linear',)
+-            else:
+-                mlp_activations = (ff_layer_tpl.activation_tpl.cls.__name__.lower(),)
++            mlp_activations = ()
+             if ff_layer_tpl.use_gated_activation:
++               mlp_activations += ('linear',)
++
++            if issubclass(ff_layer_tpl.activation_tpl.cls, activations.Identity):
+                 mlp_activations += ('linear',)
++            else:
++                mlp_activations += (ff_layer_tpl.activation_tpl.cls.__name__.lower(),)
++
+             te_tpl.mlp_activations = mlp_activations
+             return te_tpl
+ 
+-- 
+2.25.1
+
+
+From f2e8560e6861a6dea981209b402b27dc6bc92022 Mon Sep 17 00:00:00 2001
+From: Reese Wang <rewang@nvidia.com>
+Date: Wed, 28 Feb 2024 22:37:46 -0800
+Subject: [PATCH 06/10] Remove RoPE restriction from DPA module
+
+Signed-off-by: Reese Wang <rewang@nvidia.com>
+---
+ praxis/contrib/gpu/scripts_gpu/te_helper.py | 2 --
+ 1 file changed, 2 deletions(-)
+
+diff --git a/praxis/contrib/gpu/scripts_gpu/te_helper.py b/praxis/contrib/gpu/scripts_gpu/te_helper.py
+index 1f8f6d6..7d83c08 100644
+--- a/praxis/contrib/gpu/scripts_gpu/te_helper.py
++++ b/praxis/contrib/gpu/scripts_gpu/te_helper.py
+@@ -153,7 +153,6 @@ class TEInstalledHelper(TransformerEngineHelperBase):
+             return te_tpl
+ 
+         def update_attn_te_tpl(te_tpl, attn_tpl):
+-            # TODO(rewang): rope
+             if issubclass(attn_tpl.cls, attentions.DotProductAttention):
+                 # Check the DotProductAttention parameters are aligned to TE's attention
+                 assert attn_tpl.internal_enable_query_scale or attn_tpl.scale_logits_by_head_dims
+@@ -162,7 +161,6 @@ class TEInstalledHelper(TransformerEngineHelperBase):
+                 assert not attn_tpl.scale_query_by_dim_per_head
+                 assert not attn_tpl.dconv_qkv
+                 assert not attn_tpl.internal_gshard_gaussian_init
+-                assert not attn_tpl.use_rotary_position_emb
+                 assert attn_tpl.relative_bias_tpl is None
+                 assert attn_tpl.attention_extra_logit is None
+                 assert attn_tpl.ngrammer_tpl is None
+-- 
+2.25.1
+
+
+From 3d6b5c34a64939dadcc751cf2e989cec1affc648 Mon Sep 17 00:00:00 2001
+From: Reese Wang <rewang@nvidia.com>
+Date: Wed, 28 Feb 2024 22:56:44 -0800
+Subject: [PATCH 07/10] Add rotary_pos_emb_group dispatch
+
+Signed-off-by: Reese Wang <rewang@nvidia.com>
+---
+ praxis/contrib/gpu/scripts_gpu/te_helper.py | 5 +++++
+ 1 file changed, 5 insertions(+)
+
+diff --git a/praxis/contrib/gpu/scripts_gpu/te_helper.py b/praxis/contrib/gpu/scripts_gpu/te_helper.py
+index 7d83c08..d187ba1 100644
+--- a/praxis/contrib/gpu/scripts_gpu/te_helper.py
++++ b/praxis/contrib/gpu/scripts_gpu/te_helper.py
+@@ -7,6 +7,7 @@ from praxis import layers
+ from praxis.layers.checkpoint_policy import AutodiffCheckpointType
+ from praxis.layers import activations
+ from praxis.layers import attentions, grouped_query_attention, multi_query_attention
++from praxis.layers import embedding_softmax
+ from praxis.layers import normalizations
+ 
+ try:
+@@ -165,6 +166,8 @@ class TEInstalledHelper(TransformerEngineHelperBase):
+                 assert attn_tpl.attention_extra_logit is None
+                 assert attn_tpl.ngrammer_tpl is None
+                 te_tpl.enable_rotary_pos_emb = attn_tpl.use_rotary_position_emb
++                if issubclass(attn_tpl.rotary_position_emb_tpl, embedding_softmax.RotaryPositionalEmbedding):
++                    te_tpl.rotary_pos_emb_group_method = 'alternate'
+             elif issubclass(attn_tpl.cls, grouped_query_attention.GroupedQueryAttention):
+                 te_tpl.num_gqa_groups = attn_tpl.num_kv_heads
+                 if attn_tpl.rope_min_max_timescales is not None:
+@@ -174,6 +177,8 @@ class TEInstalledHelper(TransformerEngineHelperBase):
+             elif issubclass(attn_tpl.cls, multi_query_attention.MultiQueryDotProductAttention):
+                 te_tpl.num_gqa_groups = attn_tpl.num_kv_heads
+                 te_tpl.enable_rotary_pos_emb = attn_tpl.use_rotary_position_emb
++                if issubclass(attn_tpl.rotary_position_emb_tpl, embedding_softmax.RotaryPositionalEmbedding):
++                    te_tpl.rotary_pos_emb_group_method = 'alternate'
+             else:
+                 raise ValueError(f'Unsupported {attn_tpl.cls=}')
+             assert attn_tpl.atten_logit_cap <= 0., 'atten_logit_cap > 0. is not supported in TE'
+-- 
+2.25.1
+
+
+From 454f760a095562d995e7e9102f97c05158415312 Mon Sep 17 00:00:00 2001
+From: Reese Wang <rewang@nvidia.com>
+Date: Sun, 3 Mar 2024 01:16:46 -0800
+Subject: [PATCH 08/10] Fix the missing .cls
+
+Signed-off-by: Reese Wang <rewang@nvidia.com>
+---
+ praxis/contrib/gpu/scripts_gpu/te_helper.py | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/praxis/contrib/gpu/scripts_gpu/te_helper.py b/praxis/contrib/gpu/scripts_gpu/te_helper.py
+index d187ba1..733e9bf 100644
+--- a/praxis/contrib/gpu/scripts_gpu/te_helper.py
++++ b/praxis/contrib/gpu/scripts_gpu/te_helper.py
+@@ -166,7 +166,7 @@ class TEInstalledHelper(TransformerEngineHelperBase):
+                 assert attn_tpl.attention_extra_logit is None
+                 assert attn_tpl.ngrammer_tpl is None
+                 te_tpl.enable_rotary_pos_emb = attn_tpl.use_rotary_position_emb
+-                if issubclass(attn_tpl.rotary_position_emb_tpl, embedding_softmax.RotaryPositionalEmbedding):
++                if issubclass(attn_tpl.rotary_position_emb_tpl.cls, embedding_softmax.RotaryPositionalEmbedding):
+                     te_tpl.rotary_pos_emb_group_method = 'alternate'
+             elif issubclass(attn_tpl.cls, grouped_query_attention.GroupedQueryAttention):
+                 te_tpl.num_gqa_groups = attn_tpl.num_kv_heads
+@@ -177,7 +177,7 @@ class TEInstalledHelper(TransformerEngineHelperBase):
+             elif issubclass(attn_tpl.cls, multi_query_attention.MultiQueryDotProductAttention):
+                 te_tpl.num_gqa_groups = attn_tpl.num_kv_heads
+                 te_tpl.enable_rotary_pos_emb = attn_tpl.use_rotary_position_emb
+-                if issubclass(attn_tpl.rotary_position_emb_tpl, embedding_softmax.RotaryPositionalEmbedding):
++                if issubclass(attn_tpl.rotary_position_emb_tpl.cls, embedding_softmax.RotaryPositionalEmbedding):
+                     te_tpl.rotary_pos_emb_group_method = 'alternate'
+             else:
+                 raise ValueError(f'Unsupported {attn_tpl.cls=}')
+-- 
+2.25.1
+
+
+From 0bd4a531a3d8e4ddafb5ed680092fd5636aa9f8e Mon Sep 17 00:00:00 2001
+From: Ming-Xu Huang <mingh@nvidia.com>
+Date: Fri, 2 Feb 2024 10:58:40 +0800
+Subject: [PATCH 09/10] Fixed the unexpected input sharding pattern when TE
+ enabled.
+
+Signed-off-by: Ming-Xu Huang <mingh@nvidia.com>
+---
+ praxis/contrib/gpu/scripts_gpu/te_helper.py | 25 +++++++++++++++++++--
+ praxis/layers/transformer_models.py         |  3 +++
+ 2 files changed, 26 insertions(+), 2 deletions(-)
+
+diff --git a/praxis/contrib/gpu/scripts_gpu/te_helper.py b/praxis/contrib/gpu/scripts_gpu/te_helper.py
+index 733e9bf..ee0fc84 100644
+--- a/praxis/contrib/gpu/scripts_gpu/te_helper.py
++++ b/praxis/contrib/gpu/scripts_gpu/te_helper.py
+@@ -26,10 +26,13 @@ try:
+ 
+     TE_PIPELINE_EXTRA_SCAN_VAR_BROADCAST = [te.fp8.FP8Helper.FP8_COLLECTION_NAME]
+ 
++    ENABLE_TE_SP = bool(int(os.environ.get('ENABLE_TE_SP', 0)))
++
+ except ModuleNotFoundError as e:
+     _IS_TRANSFORMER_ENGINE_INSTALLED = False
+     TE_PIPELINE_EXTRA_VMAP_VAR_AXES = {}
+     TE_PIPELINE_EXTRA_SCAN_VAR_BROADCAST = []
++    ENABLE_TE_SP = False
+ 
+ LayerTpl = pax_fiddle.Config[base_layer.BaseLayer]
+ JTensor = pytypes.JTensor
+@@ -45,6 +48,10 @@ class TransformerEngineHelperBase:
+     def set_layer_params_to_stack_transformer(stacked_transformer_obj, layer_p, layer_id):
+         raise NotImplementedError
+ 
++    @staticmethod
++    def get_input_bld(original_bld, batch_axes, mdl_axis):
++        raise NotImplementedError
++
+     @staticmethod
+     def get_bld_mapping_for_pipelined_transformer(xformer_layer_p):
+         raise NotImplementedError
+@@ -81,6 +88,10 @@ class TENotInstalledHelper(TransformerEngineHelperBase):
+             )
+         return layer_p
+ 
++    @staticmethod
++    def get_input_bld(original_bld, _, _):
++        return original_bld
++
+     @staticmethod
+     def get_bld_mapping_for_pipelined_transformer(xformer_layer_p):
+         return xformer_layer_p.tr_atten_tpl.activation_split_dims_mapping.bld
+@@ -116,11 +127,10 @@ class TEInstalledHelper(TransformerEngineHelperBase):
+ 
+     @staticmethod
+     def set_layer_params_to_stack_transformer(stacked_transformer_obj, _, layer_id):
+-        enable_sp = bool(int(os.environ.get('ENABLE_TE_SP', 0)))
+         te_transformer_tpl = pax_fiddle.Config(te_praxis.TransformerLayer,
+             name=f'layer_{layer_id}',
+             enable_relative_embedding=False,
+-            enable_sequence_parallel=enable_sp,
++            enable_sequence_parallel=ENABLE_TE_SP,
+             transpose_batch_sequence=False
+         )
+ 
+@@ -224,6 +234,12 @@ class TEInstalledHelper(TransformerEngineHelperBase):
+ 
+         return te_transformer_tpl
+ 
++    @staticmethod
++    def get_input_bld(_, batch_axes, mdl_axis):
++        if ENABLE_TE_SP:
++            return [batch_axes, mdl_axis, None]
++        return [batch_axes, None, None]
++
+     @staticmethod
+     def get_bld_mapping_for_pipelined_transformer(_):
+         rules = te_flax.extend_logical_axis_rules(tuple())
+@@ -289,6 +305,11 @@ class TransformerEngineHelper(TransformerEngineHelperBase):
+         return TransformerEngineHelper.get_helper().set_layer_params_to_stack_transformer(
+                     stacked_transformer_obj, layer_p, layer_id)
+ 
++    @staticmethod
++    def get_input_bld(original_bld, batch_axes, mdl_axis):
++        return TransformerEngineHelper.get_helper().get_input_bld(
++                    original_bld, batch_axes, mdl_axis)
++
+     @staticmethod
+     def get_bld_mapping_for_pipelined_transformer(xformer_layer_p):
+         return TransformerEngineHelper.get_helper().get_bld_mapping_for_pipelined_transformer(
+diff --git a/praxis/layers/transformer_models.py b/praxis/layers/transformer_models.py
+index d8720ae..235d63e 100644
+--- a/praxis/layers/transformer_models.py
++++ b/praxis/layers/transformer_models.py
+@@ -33,6 +33,7 @@ from praxis.layers import embedding_softmax
+ from praxis.layers import multi_query_attention
+ from praxis.layers import normalizations
+ from praxis.layers import transformers
++from praxis.contrib.gpu.scripts_gpu.te_helper import TransformerEngineHelper
+ 
+ NestedMap = py_utils.NestedMap
+ JTensor = pytypes.JTensor
+@@ -323,6 +324,8 @@ class TransformerLm(base_layer.BaseLayer):
+         if training_optimized
+         else [batch_axes, None, None]
+     )
++    bld = TransformerEngineHelper.get_input_bld(bld, batch_axes, mdl_axis)
++
+     egcm = (
+         [data_axis, None, None, mdl_axis]
+         if training_optimized
+-- 
+2.25.1
+
+
+From e3e785cfedb4f350cfcb2c43b093f94288dbc846 Mon Sep 17 00:00:00 2001
+From: Ming-Xu Huang <mingh@nvidia.com>
+Date: Wed, 7 Feb 2024 12:34:01 +0800
+Subject: [PATCH 10/10] Addind a comment to get_input_bld
+
+Signed-off-by: Ming-Xu Huang <mingh@nvidia.com>
+---
+ praxis/contrib/gpu/scripts_gpu/te_helper.py | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/praxis/contrib/gpu/scripts_gpu/te_helper.py b/praxis/contrib/gpu/scripts_gpu/te_helper.py
+index ee0fc84..d0afc1a 100644
+--- a/praxis/contrib/gpu/scripts_gpu/te_helper.py
++++ b/praxis/contrib/gpu/scripts_gpu/te_helper.py
+@@ -50,6 +50,7 @@ class TransformerEngineHelperBase:
+ 
+     @staticmethod
+     def get_input_bld(original_bld, batch_axes, mdl_axis):
++        # This is used to specify the sharding pattern of inputs to TransformerLayers.
+         raise NotImplementedError
+ 
+     @staticmethod
+@@ -89,7 +90,7 @@ class TENotInstalledHelper(TransformerEngineHelperBase):
+         return layer_p
+ 
+     @staticmethod
+-    def get_input_bld(original_bld, _, _):
++    def get_input_bld(original_bld, *_):
+         return original_bld
+ 
+     @staticmethod
 -- 
 2.25.1
 

--- a/README.md
+++ b/README.md
@@ -163,13 +163,14 @@ The [JAX image](https://github.com/NVIDIA/JAX-Toolbox/pkgs/container/jax) is emb
 | `--xla_gpu_enable_latency_hiding_scheduler` | `true`  | allows XLA to move communication collectives to increase overlap with compute kernels |
 | `--xla_gpu_enable_async_all_gather` | `true` | allows XLA to run NCCL [AllGather](https://docs.nvidia.com/deeplearning/nccl/user-guide/docs/usage/operations.html#allgather) kernels on a separate CUDA stream to allow overlap with compute kernels |
 | `--xla_gpu_enable_async_reduce_scatter` | `true` | allows XLA to run NCCL [ReduceScatter](https://docs.nvidia.com/deeplearning/nccl/user-guide/docs/usage/operations.html#reducescatter) kernels on a separate CUDA stream to allow overlap with compute kernels |
-| `--xla_gpu_enable_triton_gemm` | `false` | use cuBLAS instead of Trition GeMM kernels |
 
 | Environment Variable | Value | Explanation |
 | -------------------- | ----- | ----------- |
 | `CUDA_DEVICE_MAX_CONNECTIONS` | `1` | use a single queue for GPU work to lower latency of stream operations; OK since XLA already orders launches |
 | `NCCL_NVLS_ENABLE` | `0` | Disables NVLink SHARP ([1](https://docs.nvidia.com/deeplearning/nccl/user-guide/docs/env.html#nccl-nvls-enable)). Future releases will re-enable this feature. |
 | `CUDA_MODULE_LOADING` | `EAGER` | Disables lazy-loading ([1](https://docs.nvidia.com/cuda/cuda-c-programming-guide/#cuda-environment-variables)) which uses slightly more GPU memory. |
+| `JAX_SHARE_BINARY_BETWEEN_HOSTS` | `True` | Forces the coordinator process to share the optimized XLA module with other processes. Helps prevent hangs resulting from different processes having different optimized modules. |
+| `JAX_SHARE_AUTOTUNE_CONFIG_BETWEEN_HOSTS` | `True` | Forces the coordinator process to share the autotune config with other participants. Helps prevent hangs, but can increase compilation time by ~1.5x. |
 
 ## Profiling JAX programs on GPU
 See [this page](./docs/profiling.md) for more information about how to profile JAX programs on GPU.


### PR DESCRIPTION
From some local experiments, it appears that setting `JAX_SHARE_BINARY_BETWEEN_HOSTS=True` and `JAX_SHARE_AUTOTUNE_CONFIG_BETWEEN_HOSTS=True` no longer leads to failures. Attempting to re-enable them in the JAX container. 