### PR TITLE
Draft: Save -status.json (recreated)

### DIFF
--- a/.github/workflows/_test_maxtext.yaml
+++ b/.github/workflows/_test_maxtext.yaml
@@ -363,6 +363,7 @@ jobs:
           path: |
             report.jsonl
             *_metrics.json
+            *-status.json
 
   sitrep:
     needs: [single-process-multi-device, maxtext-multinode, metrics]

--- a/.github/workflows/_test_maxtext.yaml
+++ b/.github/workflows/_test_maxtext.yaml
@@ -351,7 +351,7 @@ jobs:
             METRIC_PATH=${JOB_NAME}_metrics.json
             python3 .github/workflows/baselines/summarize_metrics.py $i/$JOB_NAME --loss_summary_name "learning/loss" --perf_summary_name "perf/step_time_seconds" --output_json_path $METRIC_PATH
             # Test script expects the job dir and the log to be in the CWD
-            mv $i/$JOB_NAME $i/${JOB_NAME}.log .
+            mv $i/$JOB_NAME $i/${JOB_NAME}.log $i/${JOB_NAME}/*-status.json .
           done
 
           RESULTS_DIR=$PWD BASELINES_DIR=MAXTEXT/upstream pytest --report-log=report.jsonl .github/workflows/baselines/test_maxtext_metrics.py || true

--- a/.github/workflows/_test_pax_rosetta.yaml
+++ b/.github/workflows/_test_pax_rosetta.yaml
@@ -1041,7 +1041,7 @@ jobs:
             METRIC_PATH=${JOB_NAME}_metrics.json
             python3 .github/workflows/baselines/summarize_metrics.py $i/$JOB_NAME --output_json_path $METRIC_PATH
             # Test script expects the job dir and the log to be in the CWD
-            mv $i/$JOB_NAME $i/${JOB_NAME}.log .
+            mv $i/$JOB_NAME $i/${JOB_NAME}.log $i/${JOB_NAME}/*-status.json .
           done
 
           RESULTS_DIR=$PWD BASELINES_DIR=PAX_MGMN/rosetta pytest --report-log=report.jsonl .github/workflows/baselines/test_pax_mgmn_metrics.py || true

--- a/.github/workflows/_test_pax_rosetta.yaml
+++ b/.github/workflows/_test_pax_rosetta.yaml
@@ -1053,6 +1053,7 @@ jobs:
           path: |
             report.jsonl
             *_metrics.json
+            *-status.json
 
   sitrep:
     needs: metrics

--- a/.github/workflows/_test_t5x_rosetta.yaml
+++ b/.github/workflows/_test_t5x_rosetta.yaml
@@ -810,6 +810,7 @@ jobs:
           path: |
             report.jsonl
             *_metrics.json
+            *-status.json
   
   sitrep:
     needs: metrics

--- a/.github/workflows/_test_t5x_rosetta.yaml
+++ b/.github/workflows/_test_t5x_rosetta.yaml
@@ -798,7 +798,7 @@ jobs:
             METRIC_PATH=${JOB_NAME}_metrics.json
             python3 .github/workflows/baselines/summarize_metrics.py $i/$JOB_NAME --perf_summary_name "timing/steps_per_second" --output_json_path $METRIC_PATH
             # Test script expects the job dir and the log to be in the CWD
-            mv $i/$JOB_NAME $i/${JOB_NAME}.log .
+            mv $i/$JOB_NAME $i/${JOB_NAME}.log $i/${JOB_NAME}/*-status.json .
           done
 
           RESULTS_DIR=$PWD BASELINES_DIR=T5X_MGMN/rosetta pytest --report-log=report.jsonl .github/workflows/baselines/test_t5x_mgmn_metrics.py || true

--- a/.github/workflows/_test_upstream_pax.yaml
+++ b/.github/workflows/_test_upstream_pax.yaml
@@ -506,6 +506,7 @@ jobs:
           path: |
             report.jsonl
             *_metrics.json
+            *-status.json
 
   sitrep:
     needs: metrics

--- a/.github/workflows/_test_upstream_pax.yaml
+++ b/.github/workflows/_test_upstream_pax.yaml
@@ -494,7 +494,7 @@ jobs:
             METRIC_PATH=${JOB_NAME}_metrics.json
             python3 .github/workflows/baselines/summarize_metrics.py $i/$JOB_NAME --output_json_path $METRIC_PATH
             # Test script expects the job dir and the log to be in the CWD
-            mv $i/$JOB_NAME $i/${JOB_NAME}.log .
+            mv $i/$JOB_NAME $i/${JOB_NAME}.log $i/${JOB_NAME}/*-status.json .
           done
 
           RESULTS_DIR=$PWD BASELINES_DIR=PAX_MGMN/upstream pytest --report-log=report.jsonl .github/workflows/baselines/test_pax_mgmn_metrics.py || true

--- a/.github/workflows/_test_upstream_t5x.yaml
+++ b/.github/workflows/_test_upstream_t5x.yaml
@@ -402,6 +402,7 @@ jobs:
           path: |
             report.jsonl
             *_metrics.json
+            *-status.json
 
 
   sitrep:

--- a/.github/workflows/_test_upstream_t5x.yaml
+++ b/.github/workflows/_test_upstream_t5x.yaml
@@ -390,7 +390,7 @@ jobs:
             METRIC_PATH=${JOB_NAME}_metrics.json
             python3 .github/workflows/baselines/summarize_metrics.py $i/$JOB_NAME --perf_summary_name "timing/steps_per_second" --output_json_path $METRIC_PATH
             # Test script expects the job dir and the log to be in the CWD
-            mv $i/$JOB_NAME $i/${JOB_NAME}.log .
+            mv $i/$JOB_NAME $i/${JOB_NAME}.log $i/${JOB_NAME}/*-status.json .
           done
 
           RESULTS_DIR=$PWD BASELINES_DIR=T5X_MGMN/upstream pytest --report-log=report.jsonl .github/workflows/baselines/test_t5x_mgmn_metrics.py || true


### PR DESCRIPTION
Adds the exit status json file to the metrics artifact for convenience. Helps get the full picture of a job pass/fail, then metrics all from one artifact. Downloading all artifacts is slow since they are large files.