### PR TITLE
Pax2TEConverter support for LLaMa2 checkpoints

### DIFF
--- a/rosetta/utils/te_pax_t5x_ckpt_converter/README.md
+++ b/rosetta/utils/te_pax_t5x_ckpt_converter/README.md
@@ -112,6 +112,7 @@ python  converter/main.py \
     --head-dim=128 \
     --mlp-intermediate-dim=28672 \
     --kernel-chunk-size=512 \
+    --skip-bias \
     --weight-only \
     --use-gated-activations \
     --pax-split-qkv \

--- a/rosetta/utils/te_pax_t5x_ckpt_converter/README.md
+++ b/rosetta/utils/te_pax_t5x_ckpt_converter/README.md
@@ -2,29 +2,42 @@
 
 ### Arguments
 ```bash
--h, --help            show this help message and exit
+-h, --help
+                    show this help message and exit
 --input-path INPUT_PATH
-                        the path to load a source checkponint for this conversion. (Required)
+                    the path to load a source checkponint for this conversion. (Required)
 --output-path OUTPUT_PATH
                     the path to store the converted checkponint. (Required)
---fw {pax,t5x}        the framework that stored the given source checkpoint. (Required)
+--fw {pax,t5x}
+                    the framework that stored the given source checkpoint. (Required)
 --direction {fw2te,te2fw}
                     the direction of this conversion. (Required)
 --num-of-layer NUM_OF_LAYER
                     the number of Transformer layer of the given source checkpoint. (Required)
 --num-of-head NUM_OF_HEAD
                     the number of head of multi-head attention of the given source checkpoint. (Required)
---head-dim HEAD_DIM   the head dimension of multi-head attention of the given source checkpoint. (Required)
+--head-dim HEAD_DIM
+                    the head dimension of multi-head attention of the given source checkpoint. (Required)
 --mlp-intermediate-dim MLP_INTERMEDIATE_DIM
                     the intermediate dimension of MLP block (FFN) of the given source checkpoint. (Required)
 --embed-dim EMBED_DIM
                     the embeded dimension of the given source checkpoint, must give if --fw=t5x. (default: None)
 --kernel-chunk-size KERNEL_CHUNK_SIZE
                     the size to chucnk kernel (weighs) then store, only support with --fw=pax. Setting None means no chunking. (default: None)
---weight-only         indicate if the source checkpoint only includes weights. (default: False)
---skip-ln             indicate if skip the conversion for LayerNorm. (default: False)
---pax-repeat          indicate if the source Pax checkpoint enables Repeat. (default: False)
---t5x-fuse-qkv        indicate if the source T5X checkpoint enables fused_qkv_params of TE. (default: False)
+--weight-only
+                    indicate if the source checkpoint only includes weights. (default: False)
+--skip-ln
+                    indicate if skip the conversion for LayerNorm. (default: False)
+--use-gated-activations
+                    indicate if the checkpointed model uses a gated activation function. (default: False)
+--pax-repeat
+                    indicate if the source Pax checkpoint enables Repeat. (default: False)
+--pax-split-qkv
+                    indicate if the source Pax checkpoint has split QKV parameters. Only supported with --fw=pax and --direction=fw2te. (default: False)
+--t5x-fuse-qkv
+                    indicate if the source T5X checkpoint enables fused_qkv_params of TE. (default: False)
+--te-qkv-layout {qkv_packed,kv_packed}
+                    indicate the QKV layout of the converted TE checkpoint. Only supported with --fw=pax and --direction=fw2te. (default: 'qkv_packed')
 ```
 
 ### Usage Examples
@@ -154,7 +167,7 @@ restoring it to keep training.
 
 #### The folder structure of CKPT by Pax and T5X
 If you would like to run the converted CKPTs with frameworks, you may expect the converted CKPTs have the same folder
-structure with CKPTs stored by frameworks. In this case, you could set `--output-path` to be the same stucture as the 
+structure with CKPTs stored by frameworks. In this case, you could set `--output-path` to be the same stucture as the
 CKPTs from frameworks, and no need to pre-generate folders, since it would be generated when needed.
 For Pax, you could set `--output-path` be like ` /${your_path_to_output}/checkpoints/checkpoint_${step}`.
 For T5X, you could set `--output-path` be like `/${your_path_to_output}/checkpoint_${step}`.

--- a/rosetta/utils/te_pax_t5x_ckpt_converter/README.md
+++ b/rosetta/utils/te_pax_t5x_ckpt_converter/README.md
@@ -16,6 +16,8 @@
                     the number of Transformer layer of the given source checkpoint. (Required)
 --num-of-head NUM_OF_HEAD
                     the number of head of multi-head attention of the given source checkpoint. (Required)
+--num-gqa-groups NUM_GQA_GROUPS
+                    the number of GQA groups (key-value heads) of the given source checkpoint. Required for --te-qkv-layout=kv_packed.
 --head-dim HEAD_DIM
                     the head dimension of multi-head attention of the given source checkpoint. (Required)
 --mlp-intermediate-dim MLP_INTERMEDIATE_DIM
@@ -33,11 +35,11 @@
 --pax-repeat
                     indicate if the source Pax checkpoint enables Repeat. (default: False)
 --pax-split-qkv
-                    indicate if the source Pax checkpoint has split QKV parameters. Only supported with --fw=pax and --direction=fw2te. (default: False)
+                    indicate if the source Pax checkpoint has split QKV parameters. Required for --te-qkv-layout=kv_packed. (default: False)
 --t5x-fuse-qkv
                     indicate if the source T5X checkpoint enables fused_qkv_params of TE. (default: False)
 --te-qkv-layout {qkv_packed,kv_packed}
-                    indicate the QKV layout of the converted TE checkpoint. Only supported with --fw=pax and --direction=fw2te. (default: 'qkv_packed')
+                    indicate the QKV layout of the converted TE checkpoint. Only supported with --pax-split-qkv and requires --num-gqa-heads <N> to be set. (default: 'qkv_packed')
 ```
 
 ### Usage Examples
@@ -84,7 +86,7 @@ python  converter/main.py \
     --mlp-intermediate-dim=1024
 ```
 
-2. Pax -> TE (Not Repeat):
+4. Pax -> TE (Not Repeat):
 ```bash
 python  converter/main.py \
     --input-path=/your_path_to_src_ckpt \
@@ -95,6 +97,25 @@ python  converter/main.py \
     --num-of-head=6 \
     --head-dim=64 \
     --mlp-intermediate-dim=1024
+```
+
+5. Pax -> TE (LLaMa2-70b):
+```bash
+python  converter/main.py \
+    --input-path=/your_path_to_src_ckpt \
+    --output-path=/your_path_to_output_ckpt \
+    --fw=pax \
+    --direction=fw2te \
+    --num-of-layer=80 \
+    --num-of-head=64 \
+    --num-gqa-groups=8 \
+    --head-dim=128 \
+    --mlp-intermediate-dim=28672 \
+    --kernel-chunk-size=512 \
+    --weight-only \
+    --use-gated-activations \
+    --pax-split-qkv \
+    --te-qkv-layout=kv_packed
 ```
 
 #### T5X

--- a/rosetta/utils/te_pax_t5x_ckpt_converter/converter/main.py
+++ b/rosetta/utils/te_pax_t5x_ckpt_converter/converter/main.py
@@ -113,6 +113,11 @@ def parse_args():
                         default=False,
                         help="indicate if the source checkpoint only includes weights.")
 
+    parser.add_argument('--skip-bias',
+                        action="store_true",
+                        default=False,
+                        help="indicate whether the source checkpoint has biases.")
+
     parser.add_argument('--skip-ln',
                         action="store_true",
                         default=False,
@@ -177,8 +182,9 @@ def get_convert_helper(args):
 
     assert convert_helper_cls is not None, "Not Supported."
     return convert_helper_cls(args.input_path, args.output_path, model_config,
-                              args.weight_only, args.skip_ln, args.use_gated_activations,
-                              args.pax_split_qkv, args.te_qkv_layout)
+                              args.weight_only, args.skip_bias, args.skip_ln,
+                              args.use_gated_activations, args.pax_split_qkv,
+                              args.te_qkv_layout)
 
 
 if __name__ == "__main__":

--- a/rosetta/utils/te_pax_t5x_ckpt_converter/converter/main.py
+++ b/rosetta/utils/te_pax_t5x_ckpt_converter/converter/main.py
@@ -27,6 +27,9 @@ T5X = 't5x'
 FW2TE = 'fw2te'
 TE2FW = 'te2fw'
 
+QKV_PACKED='qkv_packed'
+KV_PACKED='kv_packed'
+
 # Key = (Direction, isRepeat)
 PAX_CONVERT_HELPER_DICT = {
     (FW2TE, False): Pax2TEConvertHelper,
@@ -109,15 +112,35 @@ def parse_args():
                         default=False,
                         help="indicate if skip the conversion for LayerNorm.")
 
+    parser.add_argument(
+        '--use-gated-activations',
+        action="store_true",
+        default=False,
+        help="indicate if the model uses a gated activation function.")
+
     parser.add_argument('--pax-repeat',
                         action="store_true",
                         default=False,
                         help="indicate if the source Pax checkpoint enables Repeat.")
+
+    parser.add_argument(
+        '--pax-split-qkv',
+        action="store_true",
+        default=False,
+        help="indicate if the source Pax checkpoint has split QKV parameters.")
+
     parser.add_argument(
         '--t5x-fuse-qkv',
         action="store_true",
         default=False,
         help="indicate if the source T5X checkpoint enables fused_qkv_params of TE.")
+
+    parser.add_argument(
+        '--te-qkv-layout',
+        type=str,
+        choices=(QKV_PACKED, KV_PACKED),
+        default=QKV_PACKED,
+        help="indicate the QKV layout of the target TE checkpoint.")
 
     args = parser.parse_args()
 
@@ -141,7 +164,8 @@ def get_convert_helper(args):
 
     assert convert_helper_cls is not None, "Not Supported."
     return convert_helper_cls(args.input_path, args.output_path, model_config,
-                              args.weight_only, args.skip_ln)
+                              args.weight_only, args.skip_ln, args.use_gated_activations,
+                              args.pax_split_qkv, args.te_qkv_layout)
 
 
 if __name__ == "__main__":

--- a/rosetta/utils/te_pax_t5x_ckpt_converter/converter/paxml_converters.py
+++ b/rosetta/utils/te_pax_t5x_ckpt_converter/converter/paxml_converters.py
@@ -129,7 +129,7 @@ class Pax2TEConvertHelper(PaxConvertHelperBase):
             else:
                 raise RuntimeError("Unrecognized TE QKV layout in --te-qkv-layout.")
 
-            if not self.weight_only:
+            if not self.skip_bias:
                 ckpt_map.update({
                     f"lm.transformer.x_layers_{i}.ff_layer.ffn_layer1.bias.b":
                         self._get_convert_pkg(

--- a/rosetta/utils/te_pax_t5x_ckpt_converter/converter/paxml_converters.py
+++ b/rosetta/utils/te_pax_t5x_ckpt_converter/converter/paxml_converters.py
@@ -85,7 +85,7 @@ class Pax2TEConvertHelper(PaxConvertHelperBase):
                                 lambda x: jnp.reshape(x, (*x.shape[:-2], x.shape[-2] * x.shape[-1])),
                                 extra_src_paths = [f"lm.transformer.x_layers_{i}.self_attention.key.w",
                                                     f"lm.transformer.x_layers_{i}.self_attention.value.w"],
-                                stack_dim = -2)
+                                stack_dim = -3)
                     })
                 else:
                     ckpt_map.update({
@@ -118,7 +118,7 @@ class Pax2TEConvertHelper(PaxConvertHelperBase):
                             (hidden_dim, num_gqa_groups, head_dim), 0,
                             lambda x: jnp.reshape(x, (*x.shape[:-2], x.shape[-2] * x.shape[-1])),
                             extra_src_paths = [f"lm.transformer.x_layers_{i}.self_attention.value.w"],
-                            stack_dim = -2),
+                            stack_dim = -3),
                     f"lm.transformer.x_layers_{i}.layer_norm.scale":
                         self._get_convert_pkg(
                             f"lm.transformer.x_layers_{i}.transformerlayer.cld.attention.query.scale",
@@ -165,7 +165,7 @@ class Pax2TEConvertHelper(PaxConvertHelperBase):
                                     lambda x: jnp.reshape(x, (*x.shape[:-2], x.shape[-2] * x.shape[-1])),
                                     extra_src_paths = [f"lm.transformer.x_layers_{i}.self_attention.key.b",
                                                        f"lm.transformer.x_layers_{i}.self_attention.value.b"],
-                                    stack_dim = -2)
+                                    stack_dim = -3)
                         })
                     else:
                         ckpt_map.update({
@@ -198,7 +198,7 @@ class Pax2TEConvertHelper(PaxConvertHelperBase):
                                     (num_gqa_groups, head_dim), None,
                                     lambda x: jnp.reshape(x, (*x.shape[:-2], x.shape[-2] * x.shape[-1])),
                                     extra_src_paths = [f"lm.transformer.x_layers_{i}.self_attention.value.b"],
-                                    stack_dim = -2),
+                                    stack_dim = -3),
                         f"lm.transformer.x_layers_{i}.layer_norm.bias":
                             self._get_convert_pkg(
                                 f"lm.transformer.x_layers_{i}.transformerlayer.cld.attention.query.ln_bias",

--- a/rosetta/utils/te_pax_t5x_ckpt_converter/converter/paxml_converters.py
+++ b/rosetta/utils/te_pax_t5x_ckpt_converter/converter/paxml_converters.py
@@ -43,7 +43,6 @@ class Pax2TEConvertHelper(PaxConvertHelperBase):
                     self._get_convert_pkg(
                         f"lm.transformer.x_layers_{i}.transformerlayer.cld.mlp.wi_kernel",
                         (hidden_dim, mlp_intermediate_dim), 0,
-                        lambda x: jnp.reshape(x, (*x.shape[:-1], 1, x.shape[-1])),
                         extra_src_paths = [f"lm.transformer.x_layers_{i}.ff_layer.ffn_layer1_gate.linear.w"],
                         stack_dim = -2) if self.use_gated_act else \
                     self._get_convert_pkg(
@@ -82,7 +81,7 @@ class Pax2TEConvertHelper(PaxConvertHelperBase):
                             self._get_convert_pkg(
                                 f"lm.transformer.x_layers_{i}.transformerlayer.cld.attention.qkv.kernel",
                                 (hidden_dim, num_of_head, head_dim), 0,
-                                lambda x: jnp.reshape(x, (*x.shape[:-2], 1, x.shape[-2] * x.shape[-1])),
+                                lambda x: jnp.reshape(x, (*x.shape[:-2], x.shape[-2] * x.shape[-1])),
                                 extra_src_paths = [f"lm.transformer.x_layers_{i}.self_attention.key.w",
                                                     f"lm.transformer.x_layers_{i}.self_attention.value.w"],
                                 stack_dim = -2)
@@ -118,7 +117,7 @@ class Pax2TEConvertHelper(PaxConvertHelperBase):
                         self._get_convert_pkg(
                             f"lm.transformer.x_layers_{i}.transformerlayer.cld.attention.kv.kernel",
                             (hidden_dim, num_of_head, head_dim), 0,
-                            lambda x: jnp.reshape(x, (*x.shape[:-2], 1, x.shape[-2] * x.shape[-1])),
+                            lambda x: jnp.reshape(x, (*x.shape[:-2], x.shape[-2] * x.shape[-1])),
                             extra_src_paths = [f"lm.transformer.x_layers_{i}.self_attention.value.w"],
                             stack_dim = -2),
                     f"lm.transformer.x_layers_{i}.layer_norm.scale":
@@ -164,7 +163,7 @@ class Pax2TEConvertHelper(PaxConvertHelperBase):
                                 self._get_convert_pkg(
                                     f"lm.transformer.x_layers_{i}.transformerlayer.cld.attention.qkv.bias",
                                     (num_of_head, head_dim), None,
-                                    lambda x: jnp.reshape(x, (1, x.shape[-2] * x.shape[-1])),
+                                    lambda x: jnp.reshape(x, (*x.shape[:-2], x.shape[-2] * x.shape[-1])),
                                     extra_src_paths = [f"lm.transformer.x_layers_{i}.self_attention.key.b",
                                                        f"lm.transformer.x_layers_{i}.self_attention.value.b"],
                                     stack_dim = -2)
@@ -175,7 +174,7 @@ class Pax2TEConvertHelper(PaxConvertHelperBase):
                                 self._get_convert_pkg(
                                     f"lm.transformer.x_layers_{i}.transformerlayer.cld.attention.qkv.bias",
                                     (3, num_of_head, head_dim), None,
-                                    lambda x: jnp.reshape(x, (3, x.shape[-2] * x.shape[-1])))
+                                    lambda x: jnp.reshape(x, (*x.shape[:-2], x.shape[-2] * x.shape[-1])))
                         })
 
                     ckpt_map.update({
@@ -200,7 +199,7 @@ class Pax2TEConvertHelper(PaxConvertHelperBase):
                                 self._get_convert_pkg(
                                     f"lm.transformer.x_layers_{i}.transformerlayer.cld.attention.kv.bias",
                                     (num_of_head, head_dim), None,
-                                    lambda x: jnp.reshape(x, (1, x.shape[-2] * x.shape[-1])),
+                                    lambda x: jnp.reshape(x, (*x.shape[:-2], x.shape[-2] * x.shape[-1])),
                                     extra_src_paths = [f"lm.transformer.x_layers_{i}.self_attention.value.b"],
                                     stack_dim = -2),
                         f"lm.transformer.x_layers_{i}.layer_norm.bias":

--- a/rosetta/utils/te_pax_t5x_ckpt_converter/converter/paxml_converters.py
+++ b/rosetta/utils/te_pax_t5x_ckpt_converter/converter/paxml_converters.py
@@ -39,63 +39,29 @@ class Pax2TEConvertHelper(PaxConvertHelperBase):
 
         for i in range(self.model_config.num_of_layer):
             ckpt_map.update({
-                f"lm.transformer.x_layers_{i}.ff_layer.ffn_layer1.bias.b":
-                    self._get_convert_pkg(
-                        f"lm.transformer.x_layers_{i}.transformerlayer.cld.mlp.wi_bias",
-                        (mlp_intermediate_dim,), None, lambda x: jnp.reshape(x, (1, *x.shape))),
                 f"lm.transformer.x_layers_{i}.ff_layer.ffn_layer1.linear.w":
                     self._get_convert_pkg(
                         f"lm.transformer.x_layers_{i}.transformerlayer.cld.mlp.wi_kernel",
                         (hidden_dim, mlp_intermediate_dim), 0,
-                        lambda x: jnp.reshape(x, (*x.shape[:-1], 1, x.shape[-1]))),
-                f"lm.transformer.x_layers_{i}.ff_layer.ffn_layer2.bias.b":
+                        extra_src_paths = [f"lm.transformer.x_layers_{i}.ff_layer.ffn_layer1_gate.linear.w"],
+                        stack_dim = -2) if self.use_gated_act else \
                     self._get_convert_pkg(
-                        f"lm.transformer.x_layers_{i}.transformerlayer.cld.mlp.wo_bias",
-                        None,
-                        None,
-                        just_copy=True),
+                        f"lm.transformer.x_layers_{i}.transformerlayer.cld.mlp.wi_kernel",
+                        (hidden_dim, mlp_intermediate_dim), 0,
+                        lambda x: jnp.reshape(x, (*x.shape[:-1], 1, x.shape[-1]))),
                 f"lm.transformer.x_layers_{i}.ff_layer.ffn_layer2.linear.w":
                     self._get_convert_pkg(
                         f"lm.transformer.x_layers_{i}.transformerlayer.cld.mlp.wo_kernel",
                         (mlp_intermediate_dim, hidden_dim), 1),
-                f"lm.transformer.x_layers_{i}.ff_layer.layer_norm.bias":
-                    self._get_convert_pkg(
-                        f"lm.transformer.x_layers_{i}.transformerlayer.cld.mlp.ln_bias",
-                        None,
-                        None,
-                        just_copy=True),
                 f"lm.transformer.x_layers_{i}.ff_layer.layer_norm.scale":
                     self._get_convert_pkg(
                         f"lm.transformer.x_layers_{i}.transformerlayer.cld.mlp.scale",
                         None,
                         None,
                         just_copy=True),
-                f"lm.transformer.x_layers_{i}.layer_norm.bias":
-                    self._get_convert_pkg(
-                        f"lm.transformer.x_layers_{i}.transformerlayer.cld.attention.qkv.ln_bias",
-                        None,
-                        None,
-                        just_copy=True),
                 f"lm.transformer.x_layers_{i}.layer_norm.scale":
                     self._get_convert_pkg(
                         f"lm.transformer.x_layers_{i}.transformerlayer.cld.attention.qkv.scale",
-                        None,
-                        None,
-                        just_copy=True),
-                f"lm.transformer.x_layers_{i}.self_attention.combined_qkv.b":
-                    self._get_convert_pkg(
-                        f"lm.transformer.x_layers_{i}.transformerlayer.cld.attention.qkv.bias",
-                        (3, num_of_head, head_dim), None,
-                        lambda x: jnp.reshape(x, (*x.shape[:-2], x.shape[-2] * x.shape[-1]))),
-                f"lm.transformer.x_layers_{i}.self_attention.combined_qkv.w":
-                    self._get_convert_pkg(
-                        f"lm.transformer.x_layers_{i}.transformerlayer.cld.attention.qkv.kernel",
-                        (3, hidden_dim, num_of_head, head_dim), 0,
-                        lambda x: jnp.reshape(x, (*x.shape[:-2], x.shape[-2] * x.shape[-1])),
-                        lambda x: jnp.transpose(x, (1, 0, 2))),
-                f"lm.transformer.x_layers_{i}.self_attention.post.b":
-                    self._get_convert_pkg(
-                        f"lm.transformer.x_layers_{i}.transformerlayer.cld.attention.out.bias",
                         None,
                         None,
                         just_copy=True),
@@ -106,6 +72,93 @@ class Pax2TEConvertHelper(PaxConvertHelperBase):
                         lambda x: jnp.reshape(x, (*x.shape[:-2], x.shape[-2] * x.shape[-1])),
                         lambda x: jnp.transpose(x, (1, 0)))
             })
+
+            # Conversion map for QKV
+            if self.te_qkv_layout == 'qkv_packed':
+                ckpt_map.update({
+                    f"lm.transformer.x_layers_{i}.self_attention.query.w":
+                        self._get_convert_pkg(
+                            f"lm.transformer.x_layers_{i}.transformerlayer.cld.attention.qkv.kernel",
+                            (hidden_dim, num_of_head, head_dim), 0,
+                            lambda x: jnp.reshape(x, (*x.shape[:-2], x.shape[-2] * x.shape[-1])),
+                            extra_src_paths = [f"lm.transformer.x_layers_{i}.self_attention.key.w",
+                                                f"lm.transformer.x_layers_{i}.self_attention.value.w"],
+                            stack_dim = -2) if self.pax_split_qkv else \
+                        self._get_convert_pkg(
+                            f"lm.transformer.x_layers_{i}.transformerlayer.cld.attention.qkv.kernel",
+                            (3, hidden_dim, num_of_head, head_dim), 0,
+                            lambda x: jnp.reshape(x, (*x.shape[:-2], x.shape[-2] * x.shape[-1])),
+                            lambda x: jnp.transpose(x, (1, 0, 2))),
+                    f"lm.transformer.x_layers_{i}.layer_norm.scale":
+                        self._get_convert_pkg(
+                            f"lm.transformer.x_layers_{i}.transformerlayer.cld.attention.qkv.scale",
+                            None,
+                            None,
+                            just_copy=True),
+                })
+
+            elif self.te_qkv_layout == 'kv_packed':
+                assert self.pax_split_qkv, \
+                    "Cannot convert a QKV-packed Pax checkpoint to a KV-packed TE checkpoint."
+                ckpt_map.update({
+                    f"lm.transformer.x_layers_{i}.self_attention.query.w":
+                        self._get_convert_pkg(
+                            f"lm.transformer.x_layers_{i}.transformerlayer.cld.attention.query.kernel",
+                            (hidden_dim, num_of_head, head_dim), 0,
+                            lambda x: jnp.reshape(x, (*x.shape[:-2], x.shape[-2] * x.shape[-1]))),
+                    f"lm.transformer.x_layers_{i}.self_attention.key.w":
+                        self._get_convert_pkg(
+                            f"lm.transformer.x_layers_{i}.transformerlayer.cld.attention.kv.kernel",
+                            (hidden_dim, num_of_head, head_dim), 0,
+                            lambda x: jnp.reshape(x, (*x.shape[:-2], x.shape[-2] * x.shape[-1])),
+                            extra_src_paths = [f"lm.transformer.x_layers_{i}.self_attention.value.w"],
+                            stack_dim = -2),
+                    f"lm.transformer.x_layers_{i}.layer_norm.scale":
+                        self._get_convert_pkg(
+                            f"lm.transformer.x_layers_{i}.transformerlayer.cld.attention.query.scale",
+                            None,
+                            None,
+                            just_copy=True),
+                })
+            else:
+                raise RuntimeError("Unrecognized TE QKV layout in --te-qkv-layout.")
+
+            if not self.weight_only:
+                ckpt_map.update({
+                    f"lm.transformer.x_layers_{i}.ff_layer.ffn_layer1.bias.b":
+                        self._get_convert_pkg(
+                            f"lm.transformer.x_layers_{i}.transformerlayer.cld.mlp.wi_bias",
+                            (mlp_intermediate_dim,), None, lambda x: jnp.reshape(x, (1, *x.shape))),
+                    f"lm.transformer.x_layers_{i}.ff_layer.ffn_layer2.bias.b":
+                        self._get_convert_pkg(
+                            f"lm.transformer.x_layers_{i}.transformerlayer.cld.mlp.wo_bias",
+                            None,
+                            None,
+                            just_copy=True),
+                    f"lm.transformer.x_layers_{i}.ff_layer.layer_norm.bias":
+                        self._get_convert_pkg(
+                            f"lm.transformer.x_layers_{i}.transformerlayer.cld.mlp.ln_bias",
+                            None,
+                            None,
+                            just_copy=True),
+                    f"lm.transformer.x_layers_{i}.layer_norm.bias":
+                        self._get_convert_pkg(
+                            f"lm.transformer.x_layers_{i}.transformerlayer.cld.attention.qkv.ln_bias",
+                            None,
+                            None,
+                            just_copy=True),
+                    f"lm.transformer.x_layers_{i}.self_attention.combined_qkv.b":
+                        self._get_convert_pkg(
+                            f"lm.transformer.x_layers_{i}.transformerlayer.cld.attention.qkv.bias",
+                            (3, num_of_head, head_dim), None,
+                            lambda x: jnp.reshape(x, (*x.shape[:-2], x.shape[-2] * x.shape[-1]))),
+                    f"lm.transformer.x_layers_{i}.self_attention.post.b":
+                        self._get_convert_pkg(
+                            f"lm.transformer.x_layers_{i}.transformerlayer.cld.attention.out.bias",
+                            None,
+                            None,
+                            just_copy=True),
+                })
 
         return ckpt_map
 

--- a/rosetta/utils/te_pax_t5x_ckpt_converter/converter/utils.py
+++ b/rosetta/utils/te_pax_t5x_ckpt_converter/converter/utils.py
@@ -37,6 +37,7 @@ class ModelConfig:
     num_of_layer: int
     embed_dim: int
     num_of_head: int
+    num_gqa_groups: int
     head_dim: int
     mlp_intermediate_dim: int
     kernel_chunk_size: int = None

--- a/rosetta/utils/te_pax_t5x_ckpt_converter/converter/utils.py
+++ b/rosetta/utils/te_pax_t5x_ckpt_converter/converter/utils.py
@@ -56,12 +56,16 @@ class ConvertPkg:
 class ConvertHelper:
 
     def __init__(self, input_path: str, output_path: str, model_config: ModelConfig,
-                 weight_only: bool, skip_ln: bool):
+                 weight_only: bool, skip_ln: bool, use_gated_act: bool,
+                 pax_split_qkv: bool, te_qkv_layout: str):
         self.input_path = input_path
         self.output_path = output_path
         self.model_config = model_config
         self.weight_only = weight_only
         self.skip_ln = skip_ln
+        self.use_gated_act = use_gated_act
+        self.pax_split_qkv = pax_split_qkv
+        self.te_qkv_layout = te_qkv_layout
 
     @property
     def catagories(self):

--- a/rosetta/utils/te_pax_t5x_ckpt_converter/converter/utils.py
+++ b/rosetta/utils/te_pax_t5x_ckpt_converter/converter/utils.py
@@ -57,12 +57,13 @@ class ConvertPkg:
 class ConvertHelper:
 
     def __init__(self, input_path: str, output_path: str, model_config: ModelConfig,
-                 weight_only: bool, skip_ln: bool, use_gated_act: bool,
+                 weight_only: bool, skip_bias: bool, skip_ln: bool, use_gated_act: bool,
                  pax_split_qkv: bool, te_qkv_layout: str):
         self.input_path = input_path
         self.output_path = output_path
         self.model_config = model_config
         self.weight_only = weight_only
+        self.skip_bias = skip_bias
         self.skip_ln = skip_ln
         self.use_gated_act = use_gated_act
         self.pax_split_qkv = pax_split_qkv


### PR DESCRIPTION
**Changes:**
- New option flags `--pax-split-qkv` and `--te-qkv-layout={qkv_packed,kv_packed}` for identifying QKV layouts for both the Pax source and TE target. Default behavior without new flags remains unchanged.
- New option flag `--use-gated-activations` to support gated GELU in LLaMa2.
- Bias terms are omitted from the checkpoint map when `--weight-only` is used.

**Notes:**
- Changes are verified with a 70b LLaMa2 checkpoint previously converted with @mingxu1067's hard-coded LLaMa2-only converter script.
```
python converter/main.py \
    --input-path=<...> \
    --output-path=<...> \
    --fw=pax --direction=fw2te \
    --num-of-layer=80 \
    --num-of-head=64 \
    --head-dim=128  \
    --mlp-intermediate-dim=28672 \
    --kernel-chunk-size=512 \
    --weight-only \
    --use-gated-activations \
    --pax-split-qkv \
    --te-qkv-layout=kv_packed
```

@ashors1 @sharathts @nluehr @terrykong for viz.