### PR TITLE
README: add container URLs

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -291,6 +291,7 @@ jobs:
             triton
             maxtext
             levanter
+            equinox
             upstream-t5x
             upstream-pax
             t5x

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 <table>
   <thead>
     <tr>
-      <th colspan=5 style="text-align:center;">
+      <th colspan=4 style="text-align:center;">
         <a href="https://github.com/NVIDIA/JAX-Toolbox/actions/workflows/ci.yaml?query=event%3Aschedule+branch%3Amain">
         <img
           style="height: 1.5em;"

--- a/README.md
+++ b/README.md
@@ -180,6 +180,7 @@
       </td>
   </tbody>
 </table>
+
 In all of the above cases, `ghcr.io/nvidia/jax:XXX` points to the most recent
 nightly build of the container for `XXX`. These containers are also tagged as
 `ghcr.io/nvidia/jax:XXX-YYYY-MM-DD`, if a stable reference is required.

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
       </th>
     </tr>
     <tr>
-      <th colspan=2>Components</th>
+      <th>Components</th>
       <th>Container</th>
       <th>Build</th>
       <th>Test</th>
@@ -24,7 +24,6 @@
       <td>
         <img style="height:1em;" src="https://img.shields.io/static/v1?label=&color=gray&logo=docker&message=base%3D%7BCUDA%2CcuDNN%2CNCCL%2COFED%2CEFA%7D">
       </td>
-      <td></td>
       <td>
         <code>ghcr.io/nvidia/jax:base</code>
       </td>
@@ -38,7 +37,6 @@
       <td>
         <img style="height:1em;" src="https://img.shields.io/static/v1?label=&color=gray&logo=docker&message=core%3D%7Bbase%2CJAX%2CFlax%2CTE%7D">
       </td>
-      <td></td>
       <td>
         <code>ghcr.io/nvidia/jax:jax</code>
       </td>
@@ -62,7 +60,6 @@
       <td>
         <img style="height:1em;" src="https://img.shields.io/static/v1?label=&color=gray&logo=docker&message=Levanter%3D%7Bcore%2CLevanter%7D">
       </td>
-      <td></td>
       <td>
         <code>ghcr.io/nvidia/jax:levanter</code>
       </td>
@@ -79,7 +76,6 @@
       <td>
         <img style="height:1em;" src="https://img.shields.io/static/v1?label=&color=gray&logo=docker&message=Equinox%3D%7Bcore%2CEquinox%7D">
       </td>
-      <td></td>
       <td>
         <code>ghcr.io/nvidia/jax:equinox</code>
       </td>
@@ -96,7 +92,6 @@
       <td>
         <img style="height:1em;" src="https://img.shields.io/static/v1?label=&color=gray&logo=docker&message=Triton%3D%7Bcore%2CJAX-Triton%2CTriton%7D">
       </td>
-      <td></td>
       <td>
         <code>ghcr.io/nvidia/jax:triton</code>
       </td>
@@ -110,10 +105,9 @@
       </td>
     </tr>
     <tr>
-      <td rowspan=2>
-        <img style="height:1em;" src="https://img.shields.io/static/v1?label=&color=gray&logo=docker&message=T5X%3D%7Bcore%2CT5X%7D">
+      <td>
+        <img style="height:1em;" src="https://img.shields.io/static/v1?label=&color=gray&logo=docker&message=Upstream%20T5X%3D%7Bcore%2CT5X%7D">
       </td>
-      <td>upstream</td>
       <td>
         <code>ghcr.io/nvidia/jax:upstream-t5x</code>
       </td>
@@ -126,7 +120,9 @@
       </td>
     </tr>
     <tr>
-      <td>rosetta</td>
+      <td>
+        <img style="height:1em;" src="https://img.shields.io/static/v1?label=&color=gray&logo=docker&message=Rosetta%20T5X%3D%7Bcore%2CT5X%7D">
+      </td>
       <td>
         <code>ghcr.io/nvidia/jax:t5x</code>
       </td>
@@ -139,10 +135,9 @@
       </td>
     </tr>
     <tr>
-      <td rowspan=2>
-        <img style="height:1em;" src="https://img.shields.io/static/v1?label=&color=gray&logo=docker&message=PAX%3D%7Bcore%2Cpaxml%2Cpraxis%7D">
+      <td>
+        <img style="height:1em;" src="https://img.shields.io/static/v1?label=&color=gray&logo=docker&message=Upstream%20PAX%3D%7Bcore%2Cpaxml%2Cpraxis%7D">
       </td>
-      <td>upstream</td>
       <td>
         <code>ghcr.io/nvidia/jax:upstream-pax</code>
       </td>
@@ -155,7 +150,9 @@
       </td>
     </tr>
     <tr>
-      <td>rosetta</td>
+      <td>
+        <img style="height:1em;" src="https://img.shields.io/static/v1?label=&color=gray&logo=docker&message=Rosetta%20PAX%3D%7Bcore%2Cpaxml%2Cpraxis%7D">
+      </td>
       <td>
         <code>ghcr.io/nvidia/jax:pax</code>
       </td>
@@ -171,7 +168,6 @@
       <td>
         <img style="height:1em;" src="https://img.shields.io/static/v1?label=&color=gray&logo=docker&message=MaxText%3D%7Bcore%2CMaxText%7D">
       </td>
-      <td></td>
       <td>
         <code>ghcr.io/nvidia/jax:maxtext</code>
       </td>

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 <table>
   <thead>
     <tr>
-      <th colspan=4 style="text-align:center;">
+      <th colspan=5 style="text-align:center;">
         <a href="https://github.com/NVIDIA/JAX-Toolbox/actions/workflows/ci.yaml?query=event%3Aschedule+branch%3Amain">
         <img
           style="height: 1.5em;"
@@ -14,6 +14,7 @@
     </tr>
     <tr>
       <th colspan=2>Components</th>
+      <th>Container</th>
       <th>Build</th>
       <th>Test</th>
     </tr>
@@ -25,6 +26,9 @@
       </td>
       <td></td>
       <td>
+        <code>ghcr.io/nvidia/jax:base</code>
+      </td>
+      <td>
         <img style="height:1em;" src="https://img.shields.io/endpoint?url=https%3A%2F%2Fgist.githubusercontent.com%2Fnvjax%2F913c2af68649fe568e9711c2dabb23ae%2Fraw%2Fbadge-base-build-amd64.json&logo=docker&label=amd64">
         <img style="height:1em;" src="https://img.shields.io/endpoint?url=https%3A%2F%2Fgist.githubusercontent.com%2Fnvjax%2F913c2af68649fe568e9711c2dabb23ae%2Fraw%2Fbadge-base-build-arm64.json&logo=docker&label=arm64">
       </td>
@@ -35,6 +39,9 @@
         <img style="height:1em;" src="https://img.shields.io/static/v1?label=&color=gray&logo=docker&message=core%3D%7Bbase%2CJAX%2CFlax%2CTE%7D">
       </td>
       <td></td>
+      <td>
+        <code>ghcr.io/nvidia/jax:jax</code>
+      </td>
       <td>
         <img style="height:1em;" src="https://img.shields.io/endpoint?url=https%3A%2F%2Fgist.githubusercontent.com%2Fnvjax%2F913c2af68649fe568e9711c2dabb23ae%2Fraw%2Fbadge-jax-build-amd64.json&logo=docker&label=amd64">
         <img style="height:1em;" src="https://img.shields.io/endpoint?url=https%3A%2F%2Fgist.githubusercontent.com%2Fnvjax%2F913c2af68649fe568e9711c2dabb23ae%2Fraw%2Fbadge-jax-build-arm64.json&logo=docker&label=arm64">
@@ -57,6 +64,9 @@
       </td>
       <td></td>
       <td>
+        <code>ghcr.io/nvidia/jax:levanter</code>
+      </td>
+      <td>
         <img style="height:1em;" src="https://img.shields.io/endpoint?url=https%3A%2F%2Fgist.githubusercontent.com%2Fnvjax%2F913c2af68649fe568e9711c2dabb23ae%2Fraw%2Fbadge-levanter-build-amd64.json&logo=docker&label=amd64">
         <img style="height:1em;" src="https://img.shields.io/endpoint?url=https%3A%2F%2Fgist.githubusercontent.com%2Fnvjax%2F913c2af68649fe568e9711c2dabb23ae%2Fraw%2Fbadge-levanter-build-arm64.json&logo=docker&label=arm64">
       </td>
@@ -70,6 +80,9 @@
         <img style="height:1em;" src="https://img.shields.io/static/v1?label=&color=gray&logo=docker&message=Equinox%3D%7Bcore%2CEquinox%7D">
       </td>
       <td></td>
+      <td>
+        <code>ghcr.io/nvidia/jax:equinox</code>
+      </td>
       <td>
         <img style="height:1em;" src="https://img.shields.io/endpoint?url=https%3A%2F%2Fgist.githubusercontent.com%2Fnvjax%2F913c2af68649fe568e9711c2dabb23ae%2Fraw%2Fbadge-equinox-build-amd64.json&logo=docker&label=amd64">
         <img style="height:1em;" src="https://img.shields.io/endpoint?url=https%3A%2F%2Fgist.githubusercontent.com%2Fnvjax%2F913c2af68649fe568e9711c2dabb23ae%2Fraw%2Fbadge-equinox-build-arm64.json&logo=docker&label=arm64">
@@ -85,6 +98,9 @@
       </td>
       <td></td>
       <td>
+        <code>ghcr.io/nvidia/jax:triton</code>
+      </td>
+      <td>
         <img style="height:1em;" src="https://img.shields.io/endpoint?url=https%3A%2F%2Fgist.githubusercontent.com%2Fnvjax%2F913c2af68649fe568e9711c2dabb23ae%2Fraw%2Fbadge-triton-build-amd64.json&logo=docker&label=amd64">
         <!-- <img style="height:1em;" src="https://img.shields.io/endpoint?url=https%3A%2F%2Fgist.githubusercontent.com%2Fnvjax%2F913c2af68649fe568e9711c2dabb23ae%2Fraw%2Fbadge-triton-build-arm64.json&logo=docker&label=arm64"> -->
       </td>
@@ -99,6 +115,9 @@
       </td>
       <td>upstream</td>
       <td>
+        <code>ghcr.io/nvidia/jax:upstream-t5x</code>
+      </td>
+      <td>
         <img style="height:1em;" src="https://img.shields.io/endpoint?url=https%3A%2F%2Fgist.githubusercontent.com%2Fnvjax%2F913c2af68649fe568e9711c2dabb23ae%2Fraw%2Fbadge-t5x-build-amd64.json&logo=docker&label=amd64">
         <img style="height:1em;" src="https://img.shields.io/endpoint?url=https%3A%2F%2Fgist.githubusercontent.com%2Fnvjax%2F913c2af68649fe568e9711c2dabb23ae%2Fraw%2Fbadge-t5x-build-arm64.json&logo=docker&label=arm64">
       </td>
@@ -108,6 +127,9 @@
     </tr>
     <tr>
       <td>rosetta</td>
+      <td>
+        <code>ghcr.io/nvidia/jax:t5x</code>
+      </td>
       <td>
         <img style="height:1em;" src="https://img.shields.io/endpoint?url=https%3A%2F%2Fgist.githubusercontent.com%2Fnvjax%2F913c2af68649fe568e9711c2dabb23ae%2Fraw%2Fbadge-rosetta-build-t5x-amd64.json&logo=docker&label=amd64">
         <img style="height:1em;" src="https://img.shields.io/endpoint?url=https%3A%2F%2Fgist.githubusercontent.com%2Fnvjax%2F913c2af68649fe568e9711c2dabb23ae%2Fraw%2Fbadge-rosetta-build-t5x-arm64.json&logo=docker&label=arm64">
@@ -122,6 +144,9 @@
       </td>
       <td>upstream</td>
       <td>
+        <code>ghcr.io/nvidia/jax:upstream-pax</code>
+      </td>
+      <td>
         <img style="height:1em;" src="https://img.shields.io/endpoint?url=https%3A%2F%2Fgist.githubusercontent.com%2Fnvjax%2F913c2af68649fe568e9711c2dabb23ae%2Fraw%2Fbadge-pax-build-amd64.json&logo=docker&label=amd64">
         <img style="height:1em;" src="https://img.shields.io/endpoint?url=https%3A%2F%2Fgist.githubusercontent.com%2Fnvjax%2F913c2af68649fe568e9711c2dabb23ae%2Fraw%2Fbadge-pax-build-arm64.json&logo=docker&label=arm64">
       </td>
@@ -131,6 +156,9 @@
     </tr>
     <tr>
       <td>rosetta</td>
+      <td>
+        <code>ghcr.io/nvidia/jax:pax</code>
+      </td>
       <td>
         <img style="height:1em;" src="https://img.shields.io/endpoint?url=https%3A%2F%2Fgist.githubusercontent.com%2Fnvjax%2F913c2af68649fe568e9711c2dabb23ae%2Fraw%2Fbadge-rosetta-build-pax-amd64.json&logo=docker&label=amd64">
         <img style="height:1em;" src="https://img.shields.io/endpoint?url=https%3A%2F%2Fgist.githubusercontent.com%2Fnvjax%2F913c2af68649fe568e9711c2dabb23ae%2Fraw%2Fbadge-rosetta-build-pax-arm64.json&logo=docker&label=arm64">
@@ -145,6 +173,9 @@
       </td>
       <td></td>
       <td>
+        <code>ghcr.io/nvidia/jax:maxtext</code>
+      </td>
+      <td>
         <img style="height:1em;" src="https://img.shields.io/endpoint?url=https%3A%2F%2Fgist.githubusercontent.com%2Fnvjax%2F913c2af68649fe568e9711c2dabb23ae%2Fraw%2Fbadge-maxtext-build-amd64.json&logo=docker&label=amd64">
         <!-- <img style="height:1em;" src="https://img.shields.io/endpoint?url=https%3A%2F%2Fgist.githubusercontent.com%2Fnvjax%2F913c2af68649fe568e9711c2dabb23ae%2Fraw%2Fbadge-maxtext-build-arm64.json&logo=docker&label=arm64"> -->
       </td>
@@ -153,6 +184,9 @@
       </td>
   </tbody>
 </table>
+In all of the above cases, `ghcr.io/nvidia/jax:XXX` points to the most recent
+nightly build of the container for `XXX`. These containers are also tagged as
+`ghcr.io/nvidia/jax:XXX-YYYY-MM-DD`, if a stable reference is required.
 
 ## Note
 This repo currently hosts a public CI for JAX on NVIDIA GPUs and covers some JAX libraries like: [T5x](https://github.com/google-research/t5x), [PAXML](https://github.com/google/paxml), [Transformer Engine](https://github.com/NVIDIA/TransformerEngine), [Pallas](https://jax.readthedocs.io/en/latest/pallas/quickstart.html) and others to come soon.


### PR DESCRIPTION
Directly linking to pages like https://github.com/NVIDIA/JAX-Toolbox/pkgs/container/jax/192375470?tag=jax-2024-03-18 is unfortunately more complicated.