### PR TITLE
Save package URLs to Gist

### DIFF
--- a/.github/workflows/_finalize.yaml
+++ b/.github/workflows/_finalize.yaml
@@ -62,6 +62,7 @@ jobs:
     env:
       # Name/bash regex for shields.io endpoint JSON files
       BADGE_FILES: '*badge*.json'
+      MARKDOWN_FILES: '*.md'
     outputs:
       GIST_ID: ${{ steps.extract-id.outputs.GIST_ID }}
     steps:
@@ -73,7 +74,7 @@ jobs:
         shell: bash -x -e {0}
         run: |
           workdir=$(mktemp -d)
-          find -name "${BADGE_FILES}" | while read -s f; do
+          find -name "${BADGE_FILES}" -or -name "${MARKDOWN_FILES}" | while read -s f; do
             cp "$f" $workdir
           done
           echo "WORKDIR=$workdir" >> $GITHUB_OUTPUT
@@ -179,7 +180,7 @@ jobs:
     runs-on: ubuntu-22.04
     env:
       # Name/bash regex for shields.io endpoint JSON files
-      PUBLISH_BADGE_FILES: '.*badge.*.json'
+      PUBLISH_BADGE_FILES: '(.*badge.*\.json|.*\.md)'
     steps:
       - name: copy badge to primary Gist
         uses: actions/github-script@v7

--- a/.github/workflows/_publish_container.yaml
+++ b/.github/workflows/_publish_container.yaml
@@ -3,6 +3,14 @@ name: ~publish images from internal to public repo
 on:
   workflow_call:
     inputs:
+      ARTIFACT_NAME:
+        type: string
+        description: 'Artifact name; the markdown filename is derived from this'
+        required: true
+      ARTIFACT_TAG:
+        type: string
+        description: 'Container tag used to find the GitHub package ID and embedded in links'
+        required: true
       SOURCE_IMAGE:
         type: string
         description: 'Source docker image:'
@@ -19,6 +27,9 @@ on:
       DOCKER_TAGS:
         description: "Tags of the image published"
         value: ${{ jobs.publish.outputs.DOCKER_TAGS }}
+      PACKAGE_URL:
+        description: "Direct link to the GitHub package page for this image"
+        value: ${{ jobs.publish.outputs.PACKAGE_URL }}
 
 env:
   DOCKER_REGISTRY: 'ghcr.io/nvidia'
@@ -28,6 +39,7 @@ jobs:
     runs-on: ubuntu-22.04
     outputs:
       DOCKER_TAGS: ${{ steps.meta.outputs.tags }}
+      PACKAGE_URL: ${{ steps.github-meta.package_url }}
     steps:
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v3
@@ -86,6 +98,32 @@ jobs:
           for tag in $(echo -e "${{ steps.meta.outputs.tags }}"); do
             docker buildx imagetools create --tag $tag ${{ steps.get-manifests.outputs.manifests }}
           done
+
+      - name: Get GitHub package URL
+        id: github-meta
+        shell: bash -x -e {0}
+        run: |
+          # Note that /users/ seems to work for both user and organization
+          # owners, while /orgs/ only works for owners that are organizations.
+          # TODO: do we need a delay or re-try loop in order for the package
+          # to be available?
+          package_url=$(curl \
+              -H "Authorization: token ${{ github.token }}" \
+              -H "Accept: application/vnd.github.v3+json" \
+              -H "X-GitHub-Api-Version: 2022-11-28" \
+              "https://api.github.com/users/${{ github.repository_owner }}/packages/container/${{ inputs.TARGET_IMAGE }}/versions" \
+            | jq -r ".[] | select(.metadata.container.tags[] == \"${{ inputs.ARTIFACT_TAG }}\").html_url")
+          # Got ~ https://github.com/NVIDIA/JAX-Toolbox/pkgs/container/jax/12
+          package_url="${package_url}?tag=${{ inputs.ARTIFACT_TAG }}"
+          echo "package_url=${package_url}" >> $GITHUB_OUTPUT
+          echo "[${{ env.DOCKER_REGISTRY }}/${{ inputs.TARGET_IMAGE }}:${{ inputs.ARTIFACT_TAG }}](${package_url})" > "${{ inputs.ARTIFACT_NAME }}.md"
+
+      - name: Upload link file
+        if: "!cancelled()"
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ inputs.ARTIFACT_NAME }}
+          path: ${{ inputs.ARTIFACT_NAME }}.md
 
       # - name: Create single-arch images
       #   if: ${{ inputs.EXPOSE_SINGLE_ARCH_IMAGES }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -292,7 +292,6 @@ jobs:
             equinox
             maxtext
             levanter
-            equinox
             upstream-t5x
             upstream-pax
             t5x
@@ -348,7 +347,8 @@ jobs:
                     \"flavor\": \"${flavor}\",
                     \"target_image\": \"${target_image}\",
                     \"priority\": \"${priority}\",
-                    \"source_image\": ${source_image}
+                    \"source_image\": ${source_image},
+                    \"stage\": \"${stage}\"
                   }]"
                 )
               else
@@ -371,6 +371,8 @@ jobs:
       matrix: ${{ fromJson(needs.make-publish-configs.outputs.PUBLISH_CONFIGS) }}
     uses: ./.github/workflows/_publish_container.yaml
     with:
+      ARTIFACT_NAME: ${{ matrix.config.stage }}-${{ matrix.config.flavor }}
+      ARTIFACT_TAG: ${{ matrix.config.flavor }}-${{ needs.metadata.outputs.BUILD_DATE }}
       SOURCE_IMAGE: ${{ join(matrix.config.source_image, ' ') }}
       TARGET_IMAGE: ${{ matrix.config.target_image }}
       TARGET_TAGS: |
@@ -378,7 +380,7 @@ jobs:
         type=raw,value=${{ matrix.config.flavor }}-${{ needs.metadata.outputs.BUILD_DATE }},priority=${{ matrix.config.priority }}
 
   finalize:
-    needs: [metadata, amd64, arm64]
+    needs: [metadata, amd64, arm64, publish-containers]
     if: "!cancelled()"
     uses: ./.github/workflows/_finalize.yaml
     with:

--- a/.github/workflows/mjx-build-test.yaml
+++ b/.github/workflows/mjx-build-test.yaml
@@ -116,6 +116,8 @@ jobs:
     #if: needs.metadata.outputs.PUBLISH == 'true'
     uses: ./.github/workflows/_publish_container.yaml
     with:
+      ARTIFACT_NAME: mealkit-mjx
+      ARTIFACT_TAG: mjx-mealkit-${{ needs.metadata.outputs.BUILD_DATE }}
       SOURCE_IMAGE: |
         ${{ needs.amd64.outputs.DOCKER_TAG_MEALKIT }}
         ${{ needs.arm64.outputs.DOCKER_TAG_MEALKIT }}
@@ -130,6 +132,8 @@ jobs:
     #if: needs.metadata.outputs.PUBLISH == 'true'
     uses: ./.github/workflows/_publish_container.yaml
     with:
+      ARTIFACT_NAME: final-mjx
+      ARTIFACT_TAG: mjx-nightly-${{ needs.metadata.outputs.BUILD_DATE }}
       SOURCE_IMAGE: |
         ${{ needs.amd64.outputs.DOCKER_TAG_FINAL }}
         ${{ needs.arm64.outputs.DOCKER_TAG_FINAL }}

--- a/README.md
+++ b/README.md
@@ -28,8 +28,8 @@
         <code>ghcr.io/nvidia/jax:base</code>
       </td>
       <td>
-        <img style="height:1em;" src="https://img.shields.io/endpoint?url=https%3A%2F%2Fgist.githubusercontent.com%2Fnvjax%2F913c2af68649fe568e9711c2dabb23ae%2Fraw%2Fbadge-base-build-amd64.json&logo=docker&label=amd64">
-        <img style="height:1em;" src="https://img.shields.io/endpoint?url=https%3A%2F%2Fgist.githubusercontent.com%2Fnvjax%2F913c2af68649fe568e9711c2dabb23ae%2Fraw%2Fbadge-base-build-arm64.json&logo=docker&label=arm64">
+        [<img style="height:1em;" src="https://img.shields.io/endpoint?url=https%3A%2F%2Fgist.githubusercontent.com%2Fnvjax%2F913c2af68649fe568e9711c2dabb23ae%2Fraw%2Fbadge-base-build-amd64.json&logo=docker&label=amd64">](https://gist.github.com/nvjax/913c2af68649fe568e9711c2dabb23ae/#file-final-base-md)
+        [<img style="height:1em;" src="https://img.shields.io/endpoint?url=https%3A%2F%2Fgist.githubusercontent.com%2Fnvjax%2F913c2af68649fe568e9711c2dabb23ae%2Fraw%2Fbadge-base-build-arm64.json&logo=docker&label=arm64">](https://gist.github.com/nvjax/913c2af68649fe568e9711c2dabb23ae/#file-final-base-md)
       </td>
       <td></td>
     </tr>
@@ -41,8 +41,8 @@
         <code>ghcr.io/nvidia/jax:jax</code>
       </td>
       <td>
-        <img style="height:1em;" src="https://img.shields.io/endpoint?url=https%3A%2F%2Fgist.githubusercontent.com%2Fnvjax%2F913c2af68649fe568e9711c2dabb23ae%2Fraw%2Fbadge-jax-build-amd64.json&logo=docker&label=amd64">
-        <img style="height:1em;" src="https://img.shields.io/endpoint?url=https%3A%2F%2Fgist.githubusercontent.com%2Fnvjax%2F913c2af68649fe568e9711c2dabb23ae%2Fraw%2Fbadge-jax-build-arm64.json&logo=docker&label=arm64">
+        [<img style="height:1em;" src="https://img.shields.io/endpoint?url=https%3A%2F%2Fgist.githubusercontent.com%2Fnvjax%2F913c2af68649fe568e9711c2dabb23ae%2Fraw%2Fbadge-jax-build-amd64.json&logo=docker&label=amd64">](https://gist.github.com/nvjax/913c2af68649fe568e9711c2dabb23ae/#file-final-jax-md)
+        [<img style="height:1em;" src="https://img.shields.io/endpoint?url=https%3A%2F%2Fgist.githubusercontent.com%2Fnvjax%2F913c2af68649fe568e9711c2dabb23ae%2Fraw%2Fbadge-jax-build-arm64.json&logo=docker&label=arm64">](https://gist.github.com/nvjax/913c2af68649fe568e9711c2dabb23ae/#file-final-jax-md)
       </td>
       <td>
         <img style="height:1em;" src="https://img.shields.io/endpoint?url=https%3A%2F%2Fgist.githubusercontent.com%2Fnvjax%2F913c2af68649fe568e9711c2dabb23ae%2Fraw%2Fbadge-jax-unit-test-V100.json&logo=nvidia&label=V100">
@@ -64,8 +64,8 @@
         <code>ghcr.io/nvidia/jax:levanter</code>
       </td>
       <td>
-        <img style="height:1em;" src="https://img.shields.io/endpoint?url=https%3A%2F%2Fgist.githubusercontent.com%2Fnvjax%2F913c2af68649fe568e9711c2dabb23ae%2Fraw%2Fbadge-levanter-build-amd64.json&logo=docker&label=amd64">
-        <img style="height:1em;" src="https://img.shields.io/endpoint?url=https%3A%2F%2Fgist.githubusercontent.com%2Fnvjax%2F913c2af68649fe568e9711c2dabb23ae%2Fraw%2Fbadge-levanter-build-arm64.json&logo=docker&label=arm64">
+        [<img style="height:1em;" src="https://img.shields.io/endpoint?url=https%3A%2F%2Fgist.githubusercontent.com%2Fnvjax%2F913c2af68649fe568e9711c2dabb23ae%2Fraw%2Fbadge-levanter-build-amd64.json&logo=docker&label=amd64">](https://gist.github.com/nvjax/913c2af68649fe568e9711c2dabb23ae/#file-final-levanter-md)
+        [<img style="height:1em;" src="https://img.shields.io/endpoint?url=https%3A%2F%2Fgist.githubusercontent.com%2Fnvjax%2F913c2af68649fe568e9711c2dabb23ae%2Fraw%2Fbadge-levanter-build-arm64.json&logo=docker&label=arm64">](https://gist.github.com/nvjax/913c2af68649fe568e9711c2dabb23ae/#file-final-levanter-md)
       </td>
       <td>
         <img style="height:1em;" src="https://img.shields.io/endpoint?url=https%3A%2F%2Fgist.githubusercontent.com%2Fnvjax%2F913c2af68649fe568e9711c2dabb23ae%2Fraw%2Fbadge-levanter-unit-test-V100.json&logo=nvidia&label=V100">
@@ -80,8 +80,8 @@
         <code>ghcr.io/nvidia/jax:equinox</code>
       </td>
       <td>
-        <img style="height:1em;" src="https://img.shields.io/endpoint?url=https%3A%2F%2Fgist.githubusercontent.com%2Fnvjax%2F913c2af68649fe568e9711c2dabb23ae%2Fraw%2Fbadge-equinox-build-amd64.json&logo=docker&label=amd64">
-        <img style="height:1em;" src="https://img.shields.io/endpoint?url=https%3A%2F%2Fgist.githubusercontent.com%2Fnvjax%2F913c2af68649fe568e9711c2dabb23ae%2Fraw%2Fbadge-equinox-build-arm64.json&logo=docker&label=arm64">
+        [<img style="height:1em;" src="https://img.shields.io/endpoint?url=https%3A%2F%2Fgist.githubusercontent.com%2Fnvjax%2F913c2af68649fe568e9711c2dabb23ae%2Fraw%2Fbadge-equinox-build-amd64.json&logo=docker&label=amd64">](https://gist.github.com/nvjax/913c2af68649fe568e9711c2dabb23ae/#file-final-equinox-md)
+        [<img style="height:1em;" src="https://img.shields.io/endpoint?url=https%3A%2F%2Fgist.githubusercontent.com%2Fnvjax%2F913c2af68649fe568e9711c2dabb23ae%2Fraw%2Fbadge-equinox-build-arm64.json&logo=docker&label=arm64">](https://gist.github.com/nvjax/913c2af68649fe568e9711c2dabb23ae/#file-final-equinox-md)
       </td>
       <!-- <td>
         <img style="height:1em;" src="https://img.shields.io/endpoint?url=https%3A%2F%2Fgist.githubusercontent.com%2Fnvjax%2F913c2af68649fe568e9711c2dabb23ae%2Fraw%2Fbadge-equinox-unit-test-V100.json&logo=nvidia&label=V100">
@@ -96,7 +96,7 @@
         <code>ghcr.io/nvidia/jax:triton</code>
       </td>
       <td>
-        <img style="height:1em;" src="https://img.shields.io/endpoint?url=https%3A%2F%2Fgist.githubusercontent.com%2Fnvjax%2F913c2af68649fe568e9711c2dabb23ae%2Fraw%2Fbadge-triton-build-amd64.json&logo=docker&label=amd64">
+        [<img style="height:1em;" src="https://img.shields.io/endpoint?url=https%3A%2F%2Fgist.githubusercontent.com%2Fnvjax%2F913c2af68649fe568e9711c2dabb23ae%2Fraw%2Fbadge-triton-build-amd64.json&logo=docker&label=amd64">](https://gist.github.com/nvjax/913c2af68649fe568e9711c2dabb23ae/#file-final-triton-md)
         <!-- <img style="height:1em;" src="https://img.shields.io/endpoint?url=https%3A%2F%2Fgist.githubusercontent.com%2Fnvjax%2F913c2af68649fe568e9711c2dabb23ae%2Fraw%2Fbadge-triton-build-arm64.json&logo=docker&label=arm64"> -->
       </td>
       <td>
@@ -112,8 +112,8 @@
         <code>ghcr.io/nvidia/jax:upstream-t5x</code>
       </td>
       <td>
-        <img style="height:1em;" src="https://img.shields.io/endpoint?url=https%3A%2F%2Fgist.githubusercontent.com%2Fnvjax%2F913c2af68649fe568e9711c2dabb23ae%2Fraw%2Fbadge-t5x-build-amd64.json&logo=docker&label=amd64">
-        <img style="height:1em;" src="https://img.shields.io/endpoint?url=https%3A%2F%2Fgist.githubusercontent.com%2Fnvjax%2F913c2af68649fe568e9711c2dabb23ae%2Fraw%2Fbadge-t5x-build-arm64.json&logo=docker&label=arm64">
+        [<img style="height:1em;" src="https://img.shields.io/endpoint?url=https%3A%2F%2Fgist.githubusercontent.com%2Fnvjax%2F913c2af68649fe568e9711c2dabb23ae%2Fraw%2Fbadge-t5x-build-amd64.json&logo=docker&label=amd64">](https://gist.github.com/nvjax/913c2af68649fe568e9711c2dabb23ae/#file-final-upstream-t5x-md)
+        [<img style="height:1em;" src="https://img.shields.io/endpoint?url=https%3A%2F%2Fgist.githubusercontent.com%2Fnvjax%2F913c2af68649fe568e9711c2dabb23ae%2Fraw%2Fbadge-t5x-build-arm64.json&logo=docker&label=arm64">](https://gist.github.com/nvjax/913c2af68649fe568e9711c2dabb23ae/#file-final-upstream-t5x-md)
       </td>
       <td>
         <img style="height:1em;" src="https://img.shields.io/endpoint?url=https%3A%2F%2Fgist.githubusercontent.com%2Fnvjax%2F913c2af68649fe568e9711c2dabb23ae%2Fraw%2Fbadge-upstream-t5x-mgmn-test.json&logo=nvidia&label=A100%20distributed">
@@ -127,8 +127,8 @@
         <code>ghcr.io/nvidia/jax:t5x</code>
       </td>
       <td>
-        <img style="height:1em;" src="https://img.shields.io/endpoint?url=https%3A%2F%2Fgist.githubusercontent.com%2Fnvjax%2F913c2af68649fe568e9711c2dabb23ae%2Fraw%2Fbadge-rosetta-build-t5x-amd64.json&logo=docker&label=amd64">
-        <img style="height:1em;" src="https://img.shields.io/endpoint?url=https%3A%2F%2Fgist.githubusercontent.com%2Fnvjax%2F913c2af68649fe568e9711c2dabb23ae%2Fraw%2Fbadge-rosetta-build-t5x-arm64.json&logo=docker&label=arm64">
+        [<img style="height:1em;" src="https://img.shields.io/endpoint?url=https%3A%2F%2Fgist.githubusercontent.com%2Fnvjax%2F913c2af68649fe568e9711c2dabb23ae%2Fraw%2Fbadge-rosetta-build-t5x-amd64.json&logo=docker&label=amd64">](https://gist.github.com/nvjax/913c2af68649fe568e9711c2dabb23ae/#file-final-t5x-md)
+        [<img style="height:1em;" src="https://img.shields.io/endpoint?url=https%3A%2F%2Fgist.githubusercontent.com%2Fnvjax%2F913c2af68649fe568e9711c2dabb23ae%2Fraw%2Fbadge-rosetta-build-t5x-arm64.json&logo=docker&label=arm64">](https://gist.github.com/nvjax/913c2af68649fe568e9711c2dabb23ae/#file-final-t5x-md)
       </td>
       <td>
         <img style="height:1em;" src="https://img.shields.io/endpoint?url=https%3A%2F%2Fgist.githubusercontent.com%2Fnvjax%2F913c2af68649fe568e9711c2dabb23ae%2Fraw%2Fbadge-rosetta-t5x-mgmn-test.json&logo=nvidia&label=A100%20distributed">
@@ -142,8 +142,8 @@
         <code>ghcr.io/nvidia/jax:upstream-pax</code>
       </td>
       <td>
-        <img style="height:1em;" src="https://img.shields.io/endpoint?url=https%3A%2F%2Fgist.githubusercontent.com%2Fnvjax%2F913c2af68649fe568e9711c2dabb23ae%2Fraw%2Fbadge-pax-build-amd64.json&logo=docker&label=amd64">
-        <img style="height:1em;" src="https://img.shields.io/endpoint?url=https%3A%2F%2Fgist.githubusercontent.com%2Fnvjax%2F913c2af68649fe568e9711c2dabb23ae%2Fraw%2Fbadge-pax-build-arm64.json&logo=docker&label=arm64">
+        [<img style="height:1em;" src="https://img.shields.io/endpoint?url=https%3A%2F%2Fgist.githubusercontent.com%2Fnvjax%2F913c2af68649fe568e9711c2dabb23ae%2Fraw%2Fbadge-pax-build-amd64.json&logo=docker&label=amd64">](https://gist.github.com/nvjax/913c2af68649fe568e9711c2dabb23ae/#file-final-upstream-pax-md)
+        [<img style="height:1em;" src="https://img.shields.io/endpoint?url=https%3A%2F%2Fgist.githubusercontent.com%2Fnvjax%2F913c2af68649fe568e9711c2dabb23ae%2Fraw%2Fbadge-pax-build-arm64.json&logo=docker&label=arm64">](https://gist.github.com/nvjax/913c2af68649fe568e9711c2dabb23ae/#file-final-upstream-pax-md)
       </td>
       <td>
         <img style="height:1em;" src="https://img.shields.io/endpoint?url=https%3A%2F%2Fgist.githubusercontent.com%2Fnvjax%2F913c2af68649fe568e9711c2dabb23ae%2Fraw%2Fbadge-upstream-pax-mgmn-test.json&logo=nvidia&label=A100%20distributed">
@@ -157,8 +157,8 @@
         <code>ghcr.io/nvidia/jax:pax</code>
       </td>
       <td>
-        <img style="height:1em;" src="https://img.shields.io/endpoint?url=https%3A%2F%2Fgist.githubusercontent.com%2Fnvjax%2F913c2af68649fe568e9711c2dabb23ae%2Fraw%2Fbadge-rosetta-build-pax-amd64.json&logo=docker&label=amd64">
-        <img style="height:1em;" src="https://img.shields.io/endpoint?url=https%3A%2F%2Fgist.githubusercontent.com%2Fnvjax%2F913c2af68649fe568e9711c2dabb23ae%2Fraw%2Fbadge-rosetta-build-pax-arm64.json&logo=docker&label=arm64">
+        [<img style="height:1em;" src="https://img.shields.io/endpoint?url=https%3A%2F%2Fgist.githubusercontent.com%2Fnvjax%2F913c2af68649fe568e9711c2dabb23ae%2Fraw%2Fbadge-rosetta-build-pax-amd64.json&logo=docker&label=amd64">](https://gist.github.com/nvjax/913c2af68649fe568e9711c2dabb23ae/#file-final-pax-md)
+        [<img style="height:1em;" src="https://img.shields.io/endpoint?url=https%3A%2F%2Fgist.githubusercontent.com%2Fnvjax%2F913c2af68649fe568e9711c2dabb23ae%2Fraw%2Fbadge-rosetta-build-pax-arm64.json&logo=docker&label=arm64">](https://gist.github.com/nvjax/913c2af68649fe568e9711c2dabb23ae/#file-final-pax-md)
       </td>
       <td>
         <img style="height:1em;" src="https://img.shields.io/endpoint?url=https%3A%2F%2Fgist.githubusercontent.com%2Fnvjax%2F913c2af68649fe568e9711c2dabb23ae%2Fraw%2Fbadge-rosetta-pax-mgmn-test.json&logo=nvidia&label=A100%20distributed">
@@ -172,7 +172,7 @@
         <code>ghcr.io/nvidia/jax:maxtext</code>
       </td>
       <td>
-        <img style="height:1em;" src="https://img.shields.io/endpoint?url=https%3A%2F%2Fgist.githubusercontent.com%2Fnvjax%2F913c2af68649fe568e9711c2dabb23ae%2Fraw%2Fbadge-maxtext-build-amd64.json&logo=docker&label=amd64">
+        [<img style="height:1em;" src="https://img.shields.io/endpoint?url=https%3A%2F%2Fgist.githubusercontent.com%2Fnvjax%2F913c2af68649fe568e9711c2dabb23ae%2Fraw%2Fbadge-maxtext-build-amd64.json&logo=docker&label=amd64">](https://gist.github.com/nvjax/913c2af68649fe568e9711c2dabb23ae/#file-final-maxtext-md)
         <!-- <img style="height:1em;" src="https://img.shields.io/endpoint?url=https%3A%2F%2Fgist.githubusercontent.com%2Fnvjax%2F913c2af68649fe568e9711c2dabb23ae%2Fraw%2Fbadge-maxtext-build-arm64.json&logo=docker&label=arm64"> -->
       </td>
       <td>
@@ -183,10 +183,12 @@
       <td>
         <img style="height:1em;" src="https://img.shields.io/static/v1?label=&color=gray&logo=docker&message=Grok%3D%7Bcore%2CGrok-1%7D">
       </td>
-      <td></td>
       <td>
-        <img style="height:1em;" src="https://img.shields.io/endpoint?url=https%3A%2F%2Fgist.githubusercontent.com%2Fnvjax%2F913c2af68649fe568e9711c2dabb23ae%2Fraw%2Fbadge-grok-build-amd64.json&logo=docker&label=amd64">
-        <img style="height:1em;" src="https://img.shields.io/endpoint?url=https%3A%2F%2Fgist.githubusercontent.com%2Fnvjax%2F913c2af68649fe568e9711c2dabb23ae%2Fraw%2Fbadge-grok-build-arm64.json&logo=docker&label=arm64">
+        <code>ghcr.io/nvidia/jax:grok</code>
+      </td>
+      <td>
+        [<img style="height:1em;" src="https://img.shields.io/endpoint?url=https%3A%2F%2Fgist.githubusercontent.com%2Fnvjax%2F913c2af68649fe568e9711c2dabb23ae%2Fraw%2Fbadge-grok-build-amd64.json&logo=docker&label=amd64">](https://gist.github.com/nvjax/913c2af68649fe568e9711c2dabb23ae/#file-final-grok-md)
+        [<img style="height:1em;" src="https://img.shields.io/endpoint?url=https%3A%2F%2Fgist.githubusercontent.com%2Fnvjax%2F913c2af68649fe568e9711c2dabb23ae%2Fraw%2Fbadge-grok-build-arm64.json&logo=docker&label=arm64">](https://gist.github.com/nvjax/913c2af68649fe568e9711c2dabb23ae/#file-final-grok-md)
       </td>
       <td>
       </td>


### PR DESCRIPTION
This uploads a tiny markdown file with the latest package link, like this: https://gist.github.com/olupton/7921cf0da6a420f8091b8fabc91fd095#file-final-base-md, and links to it from the README.