### PR TITLE
Fix bug with E2E time in metrics

### DIFF
--- a/.github/workflows/baselines/test_utils.py
+++ b/.github/workflows/baselines/test_utils.py
@@ -32,7 +32,7 @@ def read_maxtext_tb_tag(tb_file: str, summary_name: str) -> dict:
 
 def read_e2e_time(log_file: str) -> float:
     with open(log_file, "r") as log:
-        for line in log:
+        for line in reversed(list(log)):
             if line.startswith("real"):
                 minutes = line.split()[1].split('m')[0]
                 seconds = line.split('m')[1].split('s')[0]


### PR DESCRIPTION
https://github.com/NVIDIA/JAX-Toolbox/pull/619 introduced a bug in which the E2E time for nightly tests ended up recording the time to load the container rather than the time to run the experiment. This PR fixes that by finding the E2E time for the last job run, rather than the first