### PR TITLE
Triton: use CUDA 12.3 tools from the base image

### DIFF
--- a/.github/container/Dockerfile.triton
+++ b/.github/container/Dockerfile.triton
@@ -3,7 +3,10 @@ ARG BASE_IMAGE=ghcr.io/nvidia/jax-mealkit:jax
 ARG SRC_PATH_TRITON=/opt/openxla-triton
 
 FROM ${BASE_IMAGE} as base
-# Tell Triton to use CUDA binaries from the host container. These should be set
+# Triton setup.py downloads and installs CUDA binaries at specific versions
+# hardcoded in the script itself:
+# https://github.com/openxla/triton/blob/84f9d9de158fb866fac67970f0f5d323999d9db1/python/setup.py#L373-L393
+# Tell Triton to use CUDA binaries from the host container instead. These should be set
 # both during the build stage and in the final container.
 ENV TRITON_PTXAS_PATH=/usr/local/cuda/bin/ptxas
 ENV TRITON_CUOBJDUMP_PATH=/usr/local/cuda/bin/cuobjdump

--- a/.github/container/Dockerfile.triton
+++ b/.github/container/Dockerfile.triton
@@ -11,7 +11,7 @@ FROM ${BASE_IMAGE} as base
 ENV TRITON_PTXAS_PATH=/usr/local/cuda/bin/ptxas
 ENV TRITON_CUOBJDUMP_PATH=/usr/local/cuda/bin/cuobjdump
 ENV TRITON_NVDISASM_PATH=/usr/local/cuda/bin/nvdisasm
-RUN [ -f "${TRITON_PTXAS_PATH}" ] && [ -f "${TRITON_CUOBJDUMP_PATH}" ] && [ -f "${TRITON_NVDISASM_PATH}" ]
+RUN [ -x "${TRITON_PTXAS_PATH}" ] && [ -x "${TRITON_CUOBJDUMP_PATH}" ] && [ -x "${TRITON_NVDISASM_PATH}" ]
 
 ###############################################################################
 ## Check out Triton source and build a wheel

--- a/.github/container/Dockerfile.triton
+++ b/.github/container/Dockerfile.triton
@@ -8,6 +8,7 @@ FROM ${BASE_IMAGE} as base
 ENV TRITON_PTXAS_PATH=/usr/local/cuda/bin/ptxas
 ENV TRITON_CUOBJDUMP_PATH=/usr/local/cuda/bin/cuobjdump
 ENV TRITON_NVDISASM_PATH=/usr/local/cuda/bin/nvdisasm
+RUN [ -f "${TRITON_PTXAS_PATH}" ] && [ -f "${TRITON_CUOBJDUMP_PATH}" ] && [ -f "${TRITON_NVDISASM_PATH}" ]
 
 ###############################################################################
 ## Check out Triton source and build a wheel

--- a/.github/container/Dockerfile.triton
+++ b/.github/container/Dockerfile.triton
@@ -2,10 +2,17 @@
 ARG BASE_IMAGE=ghcr.io/nvidia/jax-mealkit:jax
 ARG SRC_PATH_TRITON=/opt/openxla-triton
 
+FROM ${BASE_IMAGE} as base
+# Tell Triton to use CUDA binaries from the host container. These should be set
+# both during the build stage and in the final container.
+ENV TRITON_PTXAS_PATH=/usr/local/cuda/bin/ptxas
+ENV TRITON_CUOBJDUMP_PATH=/usr/local/cuda/bin/cuobjdump
+ENV TRITON_NVDISASM_PATH=/usr/local/cuda/bin/nvdisasm
+
 ###############################################################################
 ## Check out Triton source and build a wheel
 ###############################################################################
-FROM ${BASE_IMAGE} as builder
+FROM base as builder
 
 ARG SRC_PATH_TRITON
 
@@ -38,7 +45,7 @@ RUN rm -rf "${SRC_PATH_TRITON}/python/build"
 ###############################################################################
 ## Download source and add auxiliary scripts
 ###############################################################################
-FROM ${BASE_IMAGE} as mealkit
+FROM base as mealkit
 
 ARG SRC_PATH_TRITON
 


### PR DESCRIPTION
Previously, Triton would download its own copies of `ptxas`, `cuobjdump` and `nvdisasm`:
https://github.com/openxla/triton/blob/cl617459344/python/setup.py#L373-L393

This began to cause problems when those versions were bumped to CUDA 12.4, meaning that Triton started to generate PTX with version number 8.3. When this was compiled, using the `ptxas` from the base container, inside XLA, then there were errors:
```
CustomCall failed: ptxas exited with non-zero error code 65280, output: ptxas /tmp/tempfile-aac66f5d464c-1e8add55-32-61414d9c202e5, line 5;
fatal   : Unsupported .version 8.4; current version is '8.3'
ptxas fatal   : Ptx assembly aborted due to errors
```
in the nightly tests, which are taken from JAX-Triton.

Setting environment variables like `TRITON_PTXAS_PATH` has two effects:
- it blocks downloading other versions during `setup.py`
- at runtime, it is the highest precedence search location

If Triton starts depending on new fixes before the base container is updated to CUDA 12.4, problems may resurface.

Thanks to @andportnoy for help debugging.