### PR TITLE
Combine all workflow metrics into single summary

### DIFF
--- a/.github/workflows/_finalize.yaml
+++ b/.github/workflows/_finalize.yaml
@@ -145,7 +145,8 @@ jobs:
 
           # Loop over subdirectories in the current directory
           for dir in */; do
-            dirName="${dir%/}" && [ -d "$dir" ] || continue
+            echo $dir
+            dirName=$(basename $dir) && [ -d "$dir" ] || continue
 
             # Initialize default empty JSON objects
             sitrep="{}"
@@ -163,9 +164,11 @@ jobs:
             fi
 
             # Use Bash globbing to find the *-status.json file and read it, else use default
-            statusFiles=($dir*-status.json)
-            if [ -f "${statusFiles[0]}" ]; then
-                status=$(<"${statusFiles[0]}")
+            statusFiles=("$dir"/*-status.json)
+            statusFile=${statusFiles[0]}
+            if [ -f $statusFile ]; then
+                echo "Found status file: $statusFile"
+                status=$(<"${statusFile}")
             fi
 
             # Use jq to merge the JSON data

--- a/.github/workflows/_finalize.yaml
+++ b/.github/workflows/_finalize.yaml
@@ -136,39 +136,50 @@ jobs:
             cat "$f" | jq -r '.summary' | tee -a $GITHUB_STEP_SUMMARY
           done
 
-      - name: Concatenate all sitreps
+      - name: Concatenate all json data
         shell: bash -x -e {0}
         run: |
-          # combine all sitreps files into a single file, where each sitrep json sits
-          # in a field named by the folder that contained it
-          echo "[" >> fsitrep.json
-          sitrep_files=($(find . -name "sitrep.json"))
-          total_files=${#sitrep_files[@]}
+          # Combine all json files into a final summary json
+          output="combined.json"
+          combinedJson="{}"
 
-          # parse all the sitrep files and consolidate them into one
-          for ((i=0; i<total_files; i++)); do
-            FILE=${sitrep_files[$i]}
-            # Extract directory name
-            key=$(dirname "$FILE")
-            # Extract the summary field from the JSON files and append the content to the output JSON file.
-            if [[ "$key" == "./artifact-t5x-mgmn-test" || "$key" == "./artifact-pax-mgmn-test" ]]; then 
-              val_tmp=$(cat "$FILE" |  jq -r '.summary' )
-              # For t5x/pax mgmn test extract the test summary of tests and ignore extended metric info in the summary.
-              delimiter="|"
-              IFS=$delimiter read -ra parts <<< "$val_tmp" 
-              value="${parts[0]}passed"
-            else
-              value=$(cat "$FILE" |  jq -r '.summary' )
+          # Loop over subdirectories in the current directory
+          for dir in */; do
+            dirName="${dir%/}" && [ -d "$dir" ] || continue
+
+            # Initialize default empty JSON objects
+            sitrep="{}"
+            metricSummary="{}"
+            status="{}"
+
+            # Check if the sitrep.json file exists and read it, else use default
+            if [ -f "$dir/sitrep.json" ]; then
+                sitrep=$(<"$dir/sitrep.json")
             fi
 
-            jq -n --arg key "$key" --arg value "$value" '{ ($key): $value }' >> fsitrep.json
-            if [ $i != $((total_files-1)) ]; then
-              echo -n "," >> fsitrep.json
+            # Check if the metric_summary.json file exists and read it, else use default
+            if [ -f "$dir/metric_summary.json" ]; then
+                metricSummary=$(<"$dir/metric_summary.json")
             fi
+
+            # Use Bash globbing to find the *-status.json file and read it, else use default
+            statusFiles=($dir*-status.json)
+            if [ -f "${statusFiles[0]}" ]; then
+                status=$(<"${statusFiles[0]}")
+            fi
+
+            # Use jq to merge the JSON data
+            combinedJson=$(jq --arg dirName "$dirName" \
+                              --argjson sitrep "$sitrep" \
+                              --argjson status "$status" \
+                              --argjson metricSummary "$metricSummary" \
+                              '.[$dirName] = {"sitrep": $sitrep, "status": $status, "metric_summary": $metricSummary}' <<<"$combinedJson")
           done
-          echo "]" >> fsitrep.json
-          mv fsitrep.json sitrep.json
-          
+
+          # Output the combined JSON to the file, nicely formatted
+          echo "$combinedJson" | jq '.' > "$output"
+          mv combined.json sitrep.json
+
       - name: Upload training logs as artifacts
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/_finalize.yaml
+++ b/.github/workflows/_finalize.yaml
@@ -137,7 +137,7 @@ jobs:
           combinedJson="{}"
 
           # Loop over subdirectories in the current directory
-          for dir in all-artifacts/*; do
+          while IFS= read -r dir; do
             echo $dir
             dirName=$(basename $dir) && [ -d "$dir" ] || continue
 
@@ -160,7 +160,6 @@ jobs:
             statusFiles=("$dir"/*-status.json)
             statusFile=${statusFiles[0]}
             if [ -f $statusFile ]; then
-                echo "Found status file: $statusFile"
                 status=$(<"${statusFile}")
             fi
 
@@ -170,7 +169,7 @@ jobs:
                               --argjson status "$status" \
                               --argjson metricSummary "$metricSummary" \
                               '.[$dirName] = {"sitrep": $sitrep, "status": $status, "metric_summary": $metricSummary}' <<<"$combinedJson")
-          done
+          done < <(find . -maxdepth 1 -type d)
 
           # Output the combined JSON to the file, nicely formatted
           echo "$combinedJson" | jq '.' > "$output"

--- a/.github/workflows/_finalize.yaml
+++ b/.github/workflows/_finalize.yaml
@@ -144,7 +144,7 @@ jobs:
           combinedJson="{}"
 
           # Loop over subdirectories in the current directory
-          for dir in */; do
+          for dir in all-artifacts/*; do
             echo $dir
             dirName=$(basename $dir) && [ -d "$dir" ] || continue
 

--- a/.github/workflows/_finalize.yaml
+++ b/.github/workflows/_finalize.yaml
@@ -129,13 +129,6 @@ jobs:
       - name: Download artifacts
         uses: actions/download-artifact@v4
 
-      - name: Write output to step summary
-        shell: bash -x -e {0}
-        run: |
-          find -name "sitrep.json" | while read -s f; do
-            cat "$f" | jq -r '.summary' | tee -a $GITHUB_STEP_SUMMARY
-          done
-
       - name: Concatenate all json data
         shell: bash -x -e {0}
         run: |

--- a/.github/workflows/_sandbox.yaml
+++ b/.github/workflows/_sandbox.yaml
@@ -50,6 +50,8 @@ jobs:
         run: |
           pwd; ls;
           bash .github/workflows/baselines/download_artifacts.sh 8449523553
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Upload metrics test json logs
         uses: actions/upload-artifact@v4

--- a/.github/workflows/_sandbox.yaml
+++ b/.github/workflows/_sandbox.yaml
@@ -49,7 +49,8 @@ jobs:
       - name: Download
         run: |
           pwd; ls;
-          bash .github/workflows/baselines/download_artifacts.sh 8449523553
+          bash .github/workflows/baselines/download_artifacts.sh 8449523553;
+          ls -l
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -58,7 +59,7 @@ jobs:
         with:
           name: all-artifacts
           path: |
-            *
+            8449523553/*
 
   finalize:
     if: "!cancelled()"

--- a/.github/workflows/_sandbox.yaml
+++ b/.github/workflows/_sandbox.yaml
@@ -43,7 +43,10 @@ jobs:
   download-artifacts:
     runs-on: ubuntu-22.04
     steps:
-      - name: Download
+      - name: Check out the repository under ${GITHUB_WORKSPACE}
+        uses: actions/checkout@v4
+
+        - name: Download
         run: |
           pwd; ls;
           bash .github/workflows/baselines/download_artifacts.sh 8449523553

--- a/.github/workflows/_sandbox.yaml
+++ b/.github/workflows/_sandbox.yaml
@@ -62,6 +62,7 @@ jobs:
             8449523553/*
 
   finalize:
+    needs: [download-artifacts]
     if: "!cancelled()"
     uses: ./.github/workflows/_finalize.yaml
     secrets: inherit

--- a/.github/workflows/_sandbox.yaml
+++ b/.github/workflows/_sandbox.yaml
@@ -46,7 +46,7 @@ jobs:
       - name: Check out the repository under ${GITHUB_WORKSPACE}
         uses: actions/checkout@v4
 
-        - name: Download
+      - name: Download
         run: |
           pwd; ls;
           bash .github/workflows/baselines/download_artifacts.sh 8449523553

--- a/.github/workflows/_sandbox.yaml
+++ b/.github/workflows/_sandbox.yaml
@@ -45,8 +45,8 @@ jobs:
     steps:
       - name: Download
         run: |
-          UTIL_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
-          bash ${UTIL_DIR}/download_artifacts.sh 8449523553
+          pwd; ls;
+          bash workflows/scripts/download_artifacts.sh 8449523553
 
       - name: Upload metrics test json logs
         uses: actions/upload-artifact@v4

--- a/.github/workflows/_sandbox.yaml
+++ b/.github/workflows/_sandbox.yaml
@@ -46,7 +46,7 @@ jobs:
       - name: Download
         run: |
           pwd; ls;
-          bash workflows/scripts/download_artifacts.sh 8449523553
+          bash .github/workflows/baselines/download_artifacts.sh 8449523553
 
       - name: Upload metrics test json logs
         uses: actions/upload-artifact@v4

--- a/.github/workflows/_sandbox.yaml
+++ b/.github/workflows/_sandbox.yaml
@@ -39,30 +39,3 @@ jobs:
              revert the changes to the sandbox.yml file in the main branch to
              keep it empty for future testing.
           EOF
-
-  download-artifacts:
-    runs-on: ubuntu-22.04
-    steps:
-      - name: Check out the repository under ${GITHUB_WORKSPACE}
-        uses: actions/checkout@v4
-
-      - name: Download
-        run: |
-          pwd; ls;
-          bash .github/workflows/baselines/download_artifacts.sh 8449523553;
-          ls -l
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Upload metrics test json logs
-        uses: actions/upload-artifact@v4
-        with:
-          name: all-artifacts
-          path: |
-            8449523553/*
-
-  finalize:
-    needs: [download-artifacts]
-    if: "!cancelled()"
-    uses: ./.github/workflows/_finalize.yaml
-    secrets: inherit

--- a/.github/workflows/_sandbox.yaml
+++ b/.github/workflows/_sandbox.yaml
@@ -40,6 +40,20 @@ jobs:
              keep it empty for future testing.
           EOF
 
+  download-artifacts:
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Download
+        run: |
+          UTIL_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+          bash ${UTIL_DIR}/download_artifacts.sh 8449523553
+
+      - name: Upload metrics test json logs
+        uses: actions/upload-artifact@v4
+        with:
+          name: all-artifacts
+          path: |
+            *
 
   finalize:
     if: "!cancelled()"

--- a/.github/workflows/_sandbox.yaml
+++ b/.github/workflows/_sandbox.yaml
@@ -25,7 +25,7 @@ jobs:
           a smooth integration process once the changes are ready to be merged.
 
           Usage:
-          
+
           1. In your development branch, modify the sandbox.yml workflow file
              to include the new actions you want to test. Make sure to commit
              the changes to the development branch.
@@ -39,3 +39,9 @@ jobs:
              revert the changes to the sandbox.yml file in the main branch to
              keep it empty for future testing.
           EOF
+
+
+  finalize:
+    if: "!cancelled()"
+    uses: ./.github/workflows/_finalize.yaml
+    secrets: inherit

--- a/.github/workflows/_sitrep_mgmn.yaml
+++ b/.github/workflows/_sitrep_mgmn.yaml
@@ -149,3 +149,4 @@ jobs:
           path: |
             sitrep.json
             ${{ inputs.BADGE_FILENAME }}
+            metrics_summary.json


### PR DESCRIPTION
Combine sitrep, status, and metric_summary for each test into a single summary json at the end.

The goal is capturing a complete picture of a Workflow Run: each build success/fail, each test success/fail, the metrics for each test and also metadata like what image the tests ran on and such. This data should be all pulled from a single artifact file.