### PR TITLE
t5x arm64: No longer build grain from source

### DIFF
--- a/.github/container/Dockerfile.t5x.arm64
+++ b/.github/container/Dockerfile.t5x.arm64
@@ -3,10 +3,8 @@
 #   docker buildx build -f Dockerfile.t5x.arm64 --tag t5x --build-arg BASE_IMAGE=ghcr.io/nvidia/jax:mealkit-2024-01-22 .
 
 ARG BASE_IMAGE=ghcr.io/nvidia/jax-mealkit:jax
-ARG URLREF_GRAIN=https://github.com/google/grain.git#main
 ARG URLREF_TFTEXT=https://github.com/tensorflow/text.git#v2.13.0
 ARG URLREF_T5X=https://github.com/google-research/t5x.git#main
-ARG SRC_PATH_GRAIN=/opt/grain
 ARG SRC_PATH_TFTEXT=/opt/tensorflow-text
 ARG SRC_PATH_T5X=/opt/t5x
 
@@ -23,140 +21,6 @@ FROM ${BASE_IMAGE} as wheel-builder
 RUN wget https://github.com/bazelbuild/bazelisk/releases/download/v1.17.0/bazelisk-linux-arm64 -O /usr/bin/bazel && \
     chmod a+x /usr/bin/bazel
 
-RUN python -c 'import sys; vi = sys.version_info; print(f"{vi.major}.{vi.minor}")'  > /mealkit-python-version
-
-
-#------------------------------------------------------------------------------
-# build array_record 0.5.0 from source
-#------------------------------------------------------------------------------
-# TODO: Remove this once array_record maintainers have published an arm64 wheel.
-
-FROM linaro/tensorflow-arm64-build:2.12-multipython as array_record-builder
-
-COPY --from=wheel-builder /mealkit-python-version /mealkit-python-version
-
-# The bazel build of array_record makes some strong assumptions on where the cpp toolchain lives.
-# We therefore replicate (part of) its Dockerfile, which ensures everything is in the right place:
-#   https://github.com/google/array_record/tree/v0.5.0/oss/build.Dockerfile.aarch64
-#
-# BEGIN
-ENV DEBIAN_FRONTEND=noninteractive
-
-# Install supplementary Python interpreters
-RUN export PYTHON_BIN_PATH=/usr/bin/python$(cat /mealkit-python-version) && \
-    ln -s ${PYTHON_BIN_PATH} /usr/local/bin/python && \
-    ln -s ${PYTHON_BIN_PATH} /usr/local/bin/python3 && \
-    ln -s ${PYTHON_BIN_PATH} /usr/bin/python
-
-# h5py: The newest release of of h5py (3.11.0) does not include ARM wheels and causes pip to build h5py.
-#       pkg-config & libhdf5-dev ensure that 3.11.0, or any future version missing ARM, can be built.
-#       Related: https://github.com/h5py/h5py/issues/2408
-RUN apt update && \
-    apt install -yqq \
-    apt-utils \
-    build-essential \
-    checkinstall \
-    libffi-dev \
-    pkg-config libhdf5-dev
-
-# Install pip dependencies needed for array_record
-RUN /usr/bin/python -m pip install -U pip && \
-    /usr/bin/python -m pip install -U \
-    absl-py \
-    auditwheel \
-    etils[epath] \
-    patchelf \
-    setuptools \
-    twine \
-    wheel
-# END
-
-RUN <<"EOT" bash -exu
-set -o pipefail
-
-git clone https://github.com/google/array_record.git /tmp/array_record
-cd /tmp/array_record
-git checkout v0.5.0
-
-export CROSSTOOL_TOP="@ml2014_aarch64_config_aarch64//crosstool:toolchain"
-export AUDITWHEEL_PLATFORM="manylinux2014_aarch64"
-./oss/build_whl.sh
-EOT
-
-
-#------------------------------------------------------------------------------
-# build grain from source
-#------------------------------------------------------------------------------
-# TODO: Remove this once grain maintainers have published an arm64 wheel.
-
-FROM wheel-builder as grain-builder
-ARG URLREF_GRAIN
-ARG SRC_PATH_GRAIN
-
-COPY --from=array_record-builder /tmp/array_record/all_dist/array_record*linux_aarch64.whl /opt/
-
-# The following setup steps are based on
-#   https://github.com/google/grain/blob/ab557c31672cc2ac6f9b31e33aea2df00a7da5bf/grain/oss/build.Dockerfile
-#
-# BEGIN
-# Setup python
-RUN export MEALKIT_PYTHON_VERSION=$(cat /mealkit-python-version) && \
-    apt-get update && apt-get install -y \
-    python3-dev python3-pip python3-venv && \
-    rm -rf /var/lib/apt/lists/* && \
-    python${MEALKIT_PYTHON_VERSION} -m pip install pip --upgrade && \
-    update-alternatives --install /usr/bin/python python /usr/bin/python${MEALKIT_PYTHON_VERSION} 0
-
-# Install pip dependencies needed for grain
-RUN pip install \
-    absl-py \
-    /opt/array_record*.whl \
-    build \
-    cloudpickle \
-    dm-tree \
-    etils[epath] \
-    jaxtyping \
-    "more-itertools>=9.1.0" \
-    numpy
-
-# Install pip dependencies needed for grain tests
-RUN pip install \
-    auditwheel \
-    dill \
-    jax \
-    jaxlib \
-    tensorflow \
-    tensorflow-datasets
-# END
-
-RUN git-clone.sh "${URLREF_GRAIN}" "${SRC_PATH_GRAIN}"
-
-RUN <<"EOT" bash -exu
-set -o pipefail
-
-pushd ${SRC_PATH_GRAIN}
-
-# Make bazel stop complaining about sharding and disable some tests with missing bazel build deps
-sed -i 's| bazel test | bazel test --test_sharding_strategy=disabled |' ./grain/oss/build_whl.sh
-sed -i 's| setup.py bdist_wheel .*| -m build|' ./grain/oss/build_whl.sh
-sed -i 's|auditwheel|#auditwheel|' ./grain/oss/build_whl.sh
-
-export MEALKIT_PYTHON_VERSION=$(cat /mealkit-python-version)
-export PYTHON_MAJOR_VERSION=${MEALKIT_PYTHON_VERSION%.*}
-export PYTHON_MINOR_VERSION=${MEALKIT_PYTHON_VERSION#*.}
-
-# Grain has a very specific location that it expects python binary
-CP_VERSION=cp${PYTHON_MAJOR_VERSION}${PYTHON_MINOR_VERSION}
-mkdir -p /opt/python/${CP_VERSION}-${CP_VERSION}/bin
-ln -sf /usr/bin/python$(cat /mealkit-python-version) /opt/python/${CP_VERSION}-${CP_VERSION}/bin/python
-
-chmod a+x ./grain/oss/build_whl.sh
-PYTHON_VERSION=$MEALKIT_PYTHON_VERSION ./grain/oss/build_whl.sh
-
-ls /tmp/grain/all_dist/*.whl
-EOT
-
-
 #------------------------------------------------------------------------------
 # build tensorflow-text from source
 #------------------------------------------------------------------------------
@@ -164,8 +28,6 @@ EOT
 FROM wheel-builder as tftext-builder
 ARG URLREF_TFTEXT
 ARG SRC_PATH_TFTEXT
-# Preserve version information of grain
-COPY --from=grain-builder /opt/manifest.d/git-clone.yaml /opt/manifest.d/git-clone.yaml
 RUN <<"EOF" bash -exu -o pipefail
 pip install tensorflow_datasets==4.9.2 auditwheel tensorflow==2.13.0
 git-clone.sh ${URLREF_TFTEXT} ${SRC_PATH_TFTEXT}
@@ -194,14 +56,8 @@ ARG URLREF_T5X
 ARG SRC_PATH_TFTEXT
 ARG SRC_PATH_T5X
 
-# Preserve version information of grain and tensorflow-text
+# Preserve version information of tensorflow-text
 COPY --from=tftext-builder /opt/manifest.d/git-clone.yaml /opt/manifest.d/git-clone.yaml
-
-COPY --from=array_record-builder /tmp/array_record/all_dist/array_record*linux_aarch64.whl /opt/
-RUN echo "array_record @ file://$(ls /opt/array_record*.whl)" >> /opt/pip-tools.d/requirements-t5x.in
-
-COPY --from=grain-builder /tmp/grain/all_dist/grain*.whl /opt/
-RUN echo "grain-nightly @ file://$(ls /opt/grain*.whl)" >> /opt/pip-tools.d/requirements-t5x.in
 
 COPY --from=tftext-builder ${SRC_PATH_TFTEXT}/tensorflow_text*.whl /opt/
 RUN echo "tensorflow-text @ file://$(ls /opt/tensorflow_text*.whl)" >> /opt/pip-tools.d/requirements-t5x.in

--- a/.github/container/manifest.yaml
+++ b/.github/container/manifest.yaml
@@ -73,7 +73,7 @@ fiddle:
 airio:
   url: https://github.com/google/airio.git
   tracking_ref: main
-  latest_verified_commit: 3e13fd16038f3f376cddd289bd10eef53a4933f4
+  latest_verified_commit: cfca4a10de1491d76d2d00fcbd7142079837ca99
   mode: pip-vcs
 clu:
   url: https://github.com/google/CommonLoopUtils.git
@@ -124,12 +124,6 @@ mujoco:
   url: https://github.com/google-deepmind/mujoco.git
   tracking_ref: main
   latest_verified_commit: e95159b4f6d48d114b16a8dc13ad26b3e44bc3e2
-  mode: git-clone
-grain:
-  # Used only in ARM t5x builds
-  url: https://github.com/google/grain.git
-  tracking_ref: main
-  latest_verified_commit: 10600a3f5510bcb696a90e72c6e6cb1ac2bb016f
   mode: git-clone
 mujoco-mpc:
   url: https://github.com/google-deepmind/mujoco_mpc.git


### PR DESCRIPTION
Starting from version 0.0.7 grain publishes arm64 wheels ([pypi](https://pypi.org/project/grain-nightly/0.0.7/#files)). airio currently pins grain to 0.0.6, but once that dependency has been bumped ([PR here](https://github.com/google/airio/pull/226)) we can remove all of our special handling for grain (and array_record).