### PR TITLE
Adds bump*.sh & create-distribution.sh into base container

### DIFF
--- a/.github/container/Dockerfile.base
+++ b/.github/container/Dockerfile.base
@@ -119,6 +119,8 @@ COPY check-shm.sh /opt/nvidia/entrypoint.d/
 # Set the manifest env vars
 ENV MANIFEST_FILE=${DEST_MANIFEST_DIR}/${SRC_MANIFEST_FILE}
 # Copy all required files for manifestation
-COPY ${SRC_MANIFEST_FILE} ${DEST_MANIFEST_DIR}/${SRC_MANIFEST_FILE}
-COPY patches/ ${DEST_MANIFEST_DIR}/patches/
+ADD ${SRC_MANIFEST_FILE} \
+    patches \
+    bump.sh \
+    ${DEST_MANIFEST_DIR}/
 

--- a/.github/container/Dockerfile.base
+++ b/.github/container/Dockerfile.base
@@ -122,5 +122,7 @@ ENV MANIFEST_FILE=${DEST_MANIFEST_DIR}/${SRC_MANIFEST_FILE}
 ADD ${SRC_MANIFEST_FILE} \
     patches \
     bump.sh \
+    bump-openxla-triton.sh \
+    create-distribution.sh \
     ${DEST_MANIFEST_DIR}/
 

--- a/.github/container/Dockerfile.jax
+++ b/.github/container/Dockerfile.jax
@@ -1,6 +1,5 @@
 # syntax=docker/dockerfile:1-labs
 ARG BASE_IMAGE=ghcr.io/nvidia/jax:base
-ARG DEST_MANIFEST_DIR=/opt/manifest.d
 ARG SRC_PATH_JAX=/opt/jax
 ARG SRC_PATH_XLA=/opt/xla
 ARG SRC_PATH_FLAX=/opt/flax
@@ -16,14 +15,12 @@ ARG BUILD_DATE
 ###############################################################################
 
 FROM ${BASE_IMAGE} as builder
-ARG DEST_MANIFEST_DIR
 ARG SRC_PATH_JAX
 ARG SRC_PATH_XLA
 ARG BAZEL_CACHE
 ARG GIT_USER_NAME
 ARG GIT_USER_EMAIL
 
-ADD --chmod=777 create-distribution.sh ${DEST_MANIFEST_DIR}/
 
 RUN get-source.sh -l jax -m ${MANIFEST_FILE}
 RUN --mount=type=ssh \
@@ -47,7 +44,6 @@ RUN build-jax.sh \
 
 ARG BASE_IMAGE
 FROM ${BASE_IMAGE} as mealkit
-ARG DEST_MANIFEST_DIR
 ARG SRC_PATH_JAX
 ARG SRC_PATH_XLA
 ARG SRC_PATH_TE
@@ -64,7 +60,6 @@ ENV CUDA_DEVICE_MAX_CONNECTIONS=1
 ENV NCCL_NVLS_ENABLE=0
 ENV CUDA_MODULE_LOADING=EAGER
 
-ADD --chmod=777 create-distribution.sh ${DEST_MANIFEST_DIR}/
 
 COPY --from=builder ${SRC_PATH_JAX} ${SRC_PATH_JAX}
 COPY --from=builder ${SRC_PATH_XLA} ${SRC_PATH_XLA}


### PR DESCRIPTION
This helps the base container be self-contained since it now has all the
scripts and patches to build downstream containers like the rosetta
containers.

Prior to this change, if you wanted to build a rosetta container, you
would need to check out JAX-Toolbox and use these build scripts at a
commit that may not align with the base container.

After this change we can use the container to build the rosetta
container. As an example, you would be able to do something like this:

```sh
id=$(docker create ghcr.io/nvidia/jax:upstream-pax)
docker cp $id:/opt /local

bash /local/bump.sh ...

docker buildx build --build-context jax-toolbox=/local -f /local/rosetta/Dockerfile.pax
```

## Note:
mirrors #685 