### PR TITLE
Use LLVM 17, avoid installing LLVM 14

### DIFF
--- a/.github/container/Dockerfile.base
+++ b/.github/container/Dockerfile.base
@@ -31,7 +31,6 @@ apt-get install -y \
   git \
   gnupg \
   liblzma-dev \
-  lld \
   python-is-python3 \
   python3-pip \
   rsync \
@@ -43,6 +42,19 @@ apt-get install -y \
 bash -c "$(wget -O - https://apt.llvm.org/llvm.sh)" -- ${CLANG_VERSION}
 apt-get remove -y software-properties-common lsb-release
 apt-get autoremove -y  # removes python3-blinker which conflicts with pip-compile in JAX
+
+# Make sure that clang and clang++ point to the new version. This list is based
+# on the symlinks installed by the `clang` (as opposed to `clang-14`) and `lld`
+# (as opposed to `lld-14`) packages available in Ubuntu 22.04. 100 is an
+# arbitrary priority.
+update-alternatives --verbose \
+  --install /usr/bin/clang          clang          /usr/lib/llvm-${CLANG_VERSION}/bin/clang 100 \
+  --slave   /usr/bin/asan_symbolize asan_symbolize /usr/bin/asan_symbolize-${CLANG_VERSION} \
+  --slave   /usr/bin/clang++        clang++        /usr/lib/llvm-${CLANG_VERSION}/bin/clang++ \
+  --slave   /usr/bin/ld.lld         ld.lld         /usr/lib/llvm-${CLANG_VERSION}/bin/lld \
+  --slave   /usr/bin/lld            lld            /usr/lib/llvm-${CLANG_VERSION}/bin/lld \
+  --slave   /usr/bin/lld-link       lld-link       /usr/lib/llvm-${CLANG_VERSION}/bin/lld \
+  --slave   /usr/bin/wasm-ld        wasm-ld        /usr/lib/llvm-${CLANG_VERSION}/bin/lld
 
 apt-get clean
 rm -rf /var/lib/apt/lists/*

--- a/.github/container/Dockerfile.base
+++ b/.github/container/Dockerfile.base
@@ -56,6 +56,20 @@ update-alternatives --verbose \
   --slave   /usr/bin/lld-link       lld-link       /usr/lib/llvm-${CLANG_VERSION}/bin/lld \
   --slave   /usr/bin/wasm-ld        wasm-ld        /usr/lib/llvm-${CLANG_VERSION}/bin/lld
 
+# Make sure that any later attempt to install `clang` or `lld` will fail.
+cat >/etc/apt/preferences.d/no-unversioned-clang-lld <<EOL
+# LLVM is installed from apt.llvm.org using versioned packages, whereas the
+# unversioned clang and lld packages come from Ubuntu and refer to older
+# versions of LLVM. Please use versioned packages in this container.
+Package: clang
+Pin: release *
+Pin-Priority: -1
+
+Package: lld
+Pin: release *
+Pin-Priority: -1
+EOL
+
 apt-get clean
 rm -rf /var/lib/apt/lists/*
 EOF

--- a/.github/container/build-jax.sh
+++ b/.github/container/build-jax.sh
@@ -238,9 +238,7 @@ apt-get update
 apt-get install -y \
     build-essential \
     checkinstall \
-    clang \
     git \
-    lld \
     wget \
     curl
 

--- a/.github/workflows/_build_base.yaml
+++ b/.github/workflows/_build_base.yaml
@@ -132,7 +132,7 @@ jobs:
             GIT_USER_NAME=${{ inputs.GIT_USER_NAME }}
             GIT_USER_EMAIL=${{ inputs.GIT_USER_EMAIL }}
             BUILD_DATE=${{ inputs.BUILD_DATE }}
-            ${{ inputs.BASE_IMAGE != 'latest' && format('BASE_IMAGE={0}', inputs.BASE_IMAGE) }}
+            ${{ inputs.BASE_IMAGE != 'latest' && format('BASE_IMAGE={0}', inputs.BASE_IMAGE) || '' }}
         
       - name: Generate sitrep
         if: "!cancelled()"


### PR DESCRIPTION
Since #600 we have installed LLVM 17 from https://apt.llvm.org, but JAX with `--use_clang` prefers the `clang` found from `PATH`, unless `--clang_path` is passed.

This extends #600 to point the `clang`, `clang++` and so on symlinks to LLVM 17, and removes some `apt-get install clang lld` that pull in LLVM 14.

It also blocks `apt-get install clang`, which would install LLVM 14 and point the `clang` symlink to it, from working (likewise `lld`). Those versions can still be installed via `clang-14` and `lld-14` if needed.