### PR TITLE
Fix tensorflow-text source build on LLVM 17

### DIFF
--- a/.github/container/Dockerfile.pax.arm64
+++ b/.github/container/Dockerfile.pax.arm64
@@ -18,15 +18,26 @@ RUN wget https://github.com/bazelbuild/bazelisk/releases/download/v1.17.0/bazeli
     chmod a+x /usr/bin/bazel
 
 #------------------------------------------------------------------------------
-# build tensorflow-text 2.13.0 from source
+# build tensorflow-text from source
 #------------------------------------------------------------------------------
 
 FROM wheel-builder as tftext-builder
 ARG SRC_PATH_TFTEXT
 RUN <<"EOF" bash -exu -o pipefail
-pip install tensorflow_datasets==4.9.2 auditwheel tensorflow==2.13.0
+pip install tensorflow_datasets==4.9.2 auditwheel tensorflow==2.16.1
 get-source.sh -l tensorflow-text -m ${MANIFEST_FILE}
 cd ${SRC_PATH_TFTEXT}
+
+# The tftext build script queries GitHub, but these requests are sometimes
+# throttled by GH, resulting in a corrupted uri for tensorflow in WORKSPACE.
+# A workaround (needs to be updated when the tensorflow version changes):
+sed -i "s/# Update TF dependency to installed tensorflow./commit_slug=5bc9d26649cca274750ad3625bd93422617eed4b/" oss_scripts/prepare_tf_dep.sh
+
+# Newer versions of LLVM make lld's --undefined-version check of lld is strict
+# by default (https://reviews.llvm.org/D135402), but the tftext build seems to
+# rely on this behavior.
+echo "write_to_bazelrc \"build --linkopt='-Wl,--undefined-version'\"" >> oss_scripts/configure.sh
+
 ./oss_scripts/run_build.sh
 EOF
 

--- a/.github/container/Dockerfile.pax.arm64
+++ b/.github/container/Dockerfile.pax.arm64
@@ -24,14 +24,14 @@ RUN wget https://github.com/bazelbuild/bazelisk/releases/download/v1.17.0/bazeli
 FROM wheel-builder as tftext-builder
 ARG SRC_PATH_TFTEXT
 RUN <<"EOF" bash -exu -o pipefail
-pip install tensorflow_datasets==4.9.2 auditwheel tensorflow==2.16.1
+pip install tensorflow_datasets==4.9.2 auditwheel tensorflow==2.13.0
 get-source.sh -l tensorflow-text -m ${MANIFEST_FILE}
 cd ${SRC_PATH_TFTEXT}
 
 # The tftext build script queries GitHub, but these requests are sometimes
 # throttled by GH, resulting in a corrupted uri for tensorflow in WORKSPACE.
 # A workaround (needs to be updated when the tensorflow version changes):
-sed -i "s/# Update TF dependency to installed tensorflow./commit_slug=5bc9d26649cca274750ad3625bd93422617eed4b/" oss_scripts/prepare_tf_dep.sh
+sed -i "s/# Update TF dependency to installed tensorflow/commit_sha=1cb1a030a62b169d90d34c747ab9b09f332bf905/" oss_scripts/prepare_tf_dep.sh
 
 # Newer versions of LLVM make lld's --undefined-version check of lld is strict
 # by default (https://reviews.llvm.org/D135402), but the tftext build seems to

--- a/.github/container/Dockerfile.t5x.arm64
+++ b/.github/container/Dockerfile.t5x.arm64
@@ -150,15 +150,26 @@ EOT
 
 
 #------------------------------------------------------------------------------
-# build tensorflow-text 2.13.0 from source
+# build tensorflow-text from source
 #------------------------------------------------------------------------------
 
 FROM wheel-builder as tftext-builder
 ARG SRC_PATH_TFTEXT
 RUN <<"EOF" bash -exu -o pipefail
-pip install tensorflow_datasets==4.9.2 auditwheel tensorflow==2.13.0
+pip install tensorflow_datasets==4.9.2 auditwheel tensorflow==2.16.1
 get-source.sh -l tensorflow-text -m ${MANIFEST_FILE}
 cd ${SRC_PATH_TFTEXT}
+
+# The tftext build script queries GitHub, but these requests are sometimes
+# throttled by GH, resulting in a corrupted uri for tensorflow in WORKSPACE.
+# A workaround (needs to be updated when the tensorflow version changes):
+sed -i "s/# Update TF dependency to installed tensorflow./commit_slug=5bc9d26649cca274750ad3625bd93422617eed4b/" oss_scripts/prepare_tf_dep.sh
+
+# Newer versions of LLVM make lld's --undefined-version check of lld is strict
+# by default (https://reviews.llvm.org/D135402), but the tftext build seems to
+# rely on this behavior.
+echo "write_to_bazelrc \"build --linkopt='-Wl,--undefined-version'\"" >> oss_scripts/configure.sh
+
 ./oss_scripts/run_build.sh
 EOF
 

--- a/.github/container/Dockerfile.t5x.arm64
+++ b/.github/container/Dockerfile.t5x.arm64
@@ -156,14 +156,14 @@ EOT
 FROM wheel-builder as tftext-builder
 ARG SRC_PATH_TFTEXT
 RUN <<"EOF" bash -exu -o pipefail
-pip install tensorflow_datasets==4.9.2 auditwheel tensorflow==2.16.1
+pip install tensorflow_datasets==4.9.2 auditwheel tensorflow==2.13.0
 get-source.sh -l tensorflow-text -m ${MANIFEST_FILE}
 cd ${SRC_PATH_TFTEXT}
 
 # The tftext build script queries GitHub, but these requests are sometimes
 # throttled by GH, resulting in a corrupted uri for tensorflow in WORKSPACE.
 # A workaround (needs to be updated when the tensorflow version changes):
-sed -i "s/# Update TF dependency to installed tensorflow./commit_slug=5bc9d26649cca274750ad3625bd93422617eed4b/" oss_scripts/prepare_tf_dep.sh
+sed -i "s/# Update TF dependency to installed tensorflow/commit_sha=1cb1a030a62b169d90d34c747ab9b09f332bf905/" oss_scripts/prepare_tf_dep.sh
 
 # Newer versions of LLVM make lld's --undefined-version check of lld is strict
 # by default (https://reviews.llvm.org/D135402), but the tftext build seems to

--- a/.github/container/manifest.yaml
+++ b/.github/container/manifest.yaml
@@ -57,8 +57,8 @@ lingvo:
 tensorflow-text:
   # Used only in ARM pax and t5x builds
   url: https://github.com/tensorflow/text.git
-  tracking_ref: v2.13.0
-  latest_verified_commit: 917a681d7220ebf9b62a08b6f9ce7b7db886ddef
+  tracking_ref: v2.16.1
+  latest_verified_commit: 0f9f6df5b4da19bc7a734ba05fc4fa12bccbedbe
   mode: git-clone
 pydantic:
   version: X.Y.Z

--- a/.github/container/manifest.yaml
+++ b/.github/container/manifest.yaml
@@ -57,8 +57,8 @@ lingvo:
 tensorflow-text:
   # Used only in ARM pax and t5x builds
   url: https://github.com/tensorflow/text.git
-  tracking_ref: v2.16.1
-  latest_verified_commit: 0f9f6df5b4da19bc7a734ba05fc4fa12bccbedbe
+  tracking_ref: v2.13.0
+  latest_verified_commit: 917a681d7220ebf9b62a08b6f9ce7b7db886ddef
   mode: git-clone
 pydantic:
   version: X.Y.Z


### PR DESCRIPTION
Yesterday's update from LLVM 14 to LLVM 17 broke the source builds of tensorflow-text on arm64 ([example](https://github.com/NVIDIA/JAX-Toolbox/actions/runs/8598999090/job/23561812951#step:10:861)).

~~Let's see if this is resolved by upgrading to a newer version (2.13.0 -> 2.16.1). (We might even just want to track main instead?)~~
Actually, bumping tensorflow-text from 2.13.0 -> 2.16.1 doesn't work, because it's in sync with tensorflow, and lingvo (used in pax) is only compatible with 2.13.0 (even on the [most recent main](https://github.com/tensorflow/lingvo/blob/05a076b0783a8bbf4a770095966c472bb37bbf65/WORKSPACE#L8)). Luckily, merely disabling the `--no-undefined-version` check in `lld` alone seems to do the trick.