### PR TITLE
Fix pax commits to known good versions

### DIFF
--- a/.github/container/manifest.yaml
+++ b/.github/container/manifest.yaml
@@ -25,7 +25,7 @@ paxml:
   url: https://github.com/google/paxml.git
   mirror_url: https://github.com/nvjax-svc-0/paxml.git
   tracking_ref: main
-  latest_verified_commit: 051795784f8ddaba57eb51218addb5f1db8e04f4
+  latest_verified_commit: 378c6addf21837e3e4d487e990e29c1487dd8c91
   mode: git-clone
   patches:
     pull/46/head: file://patches/paxml/PR-46.patch # adds Transformer Engine support
@@ -33,7 +33,7 @@ praxis:
   url: https://github.com/google/praxis.git
   mirror_url: https://github.com/nvjax-svc-0/praxis.git
   tracking_ref: main
-  latest_verified_commit: c58bcc4e82c80489a7f8a2c3366e7f6b32d271d4
+  latest_verified_commit: 25981e8e27dc4cea81fde727921077dd30e687ed
   mode: git-clone
   patches:
     pull/27/head: file://patches/praxis/PR-27.patch # This PR allows XLA:GPU to detect the MHA pattern more easily to call fused kernels from cublas.


### PR DESCRIPTION
Commits were from last known working nightly on 3/14 where rosetta-pax was all green: https://github.com/NVIDIA/JAX-Toolbox/actions/runs/8278396687/job/22659250931