### PR TITLE
Temporarily disable bump-openxla-triton.sh

### DIFF
--- a/.github/container/bump.sh
+++ b/.github/container/bump.sh
@@ -113,8 +113,8 @@ done
 
 # unfortunately the openxla-triton commit must be derived from the content of
 # the xla repository
-if [[ $SKIP_BUMP_REFS -eq 0 ]]; then
-    "${SCRIPT_DIR}/bump-openxla-triton.sh" \
-      --base-patch-dir $BASE_PATCH_DIR \
-      --manifest "${MANIFEST_OUT}"
-fi
+#if [[ $SKIP_BUMP_REFS -eq 0 ]]; then
+#    "${SCRIPT_DIR}/bump-openxla-triton.sh" \
+#      --base-patch-dir $BASE_PATCH_DIR \
+#      --manifest "${MANIFEST_OUT}"
+#fi


### PR DESCRIPTION
The way patches are described upstream has changed. Disabling this to un-break the nightlies while a better fix is found.