### PR TITLE
Disabled gcp autoconfig.

### DIFF
--- a/.github/container/Dockerfile.base
+++ b/.github/container/Dockerfile.base
@@ -184,7 +184,8 @@ COPY check-shm.sh /opt/nvidia/entrypoint.d/
 ## Add the GCP - TCPX check to the entrypoint.
 ###############################################################################
 
-COPY gcp-autoconfig.sh /opt/nvidia/entrypoint.d/
+# TODO(chaserileyroberts): Reenable once fully tested on GCP.
+# COPY gcp-autoconfig.sh /opt/nvidia/entrypoint.d/
 
 ###############################################################################
 ## Add helper scripts for profiling with Nsight Systems


### PR DESCRIPTION
The `host metadata.google.internal` was causing slow startups on certain environments. In stead of adding a timeout or changing the check, for now I recommend we just disable the auto config. There are some other issues with the current gcp auto config (for instance, incorrectly relying on $SLURM_JOBID).

I'll take a pass at making that better later this week, but for now lets turn it off. 