### PR TITLE
fix: Re-add `bump.sh` into base container

### DIFF
--- a/.github/container/Dockerfile.base
+++ b/.github/container/Dockerfile.base
@@ -204,5 +204,6 @@ RUN ln -s /opt/jax_nsys/nsys-jax-ensure-protobuf /usr/local/bin/
 ###############################################################################
 
 ENV MANIFEST_FILE="/opt/manifest.d/manifest.yaml"
-ADD manifest.yaml create-distribution.sh /opt/manifest.d/
+ADD manifest.yaml create-distribution.sh bump.sh /opt/manifest.d/
+
 COPY patches/ /opt/manifest.d/patches/


### PR DESCRIPTION
This script is required for other tests internally