### PR TITLE
triton: build LLVM to match XLA

### DIFF
--- a/.github/container/Dockerfile.triton
+++ b/.github/container/Dockerfile.triton
@@ -18,53 +18,64 @@ ENV TRITON_NVDISASM_PATH=/usr/local/cuda/bin/nvdisasm
 RUN [ -x "${TRITON_PTXAS_PATH}" ] && [ -x "${TRITON_CUOBJDUMP_PATH}" ] && [ -x "${TRITON_NVDISASM_PATH}" ]
 
 ###############################################################################
-## Check out Triton source
+## Check out LLVM and Triton sources that match XLA, build them.
 ###############################################################################
-# Use XLA's Bazel configuration to get the relevant tag from the openxla/triton
-# fork's llvm-head branch and apply XLA's extra patches to it
-FROM ${BASE_IMAGE} as checkout
+FROM base as builder
 ARG SRC_PATH_JAX
 ARG SRC_PATH_XLA
 RUN <<"EOF" bash -ex
+# Use XLA's Bazel configuration to get the relevant tag from the openxla/triton
+# fork's llvm-head branch and apply XLA's extra patches to it. Also fetches the
+# compatible LLVM sources.
 pushd "${SRC_PATH_XLA}"
 BAZEL=$(find "${SRC_PATH_JAX}/build" -type f -executable -name 'bazel-*')
-"${BAZEL}" --output_base=/opt/triton-checkout fetch @triton//:BUILD
-EOF
-
-###############################################################################
-## Get (only) the Triton source from the checkout step
-###############################################################################
-FROM base as builder
-ARG SRC_PATH_TRITON
-ARG SRC_PATH_XLA
-COPY --from=checkout /opt/triton-checkout/external/triton "${SRC_PATH_TRITON}"
-RUN <<"EOF" bash -ex
-mkdir -p "${SRC_PATH_TRITON}/dist"
-sed -i -e 's|^add_subdirectory(unittest)|# unit tests disabled|' "${SRC_PATH_TRITON}/CMakeLists.txt"
-sed -i -e 's|BackendInstaller.copy(\["nvidia", "amd"\])|BackendInstaller.copy(["nvidia"])|g' "${SRC_PATH_TRITON}/python/setup.py"
-# Extra patches to Triton maintained in XLA. These are already applied in the checkout stage.
+"${BAZEL}" --output_base=/opt/checkout fetch @triton//:BUILD
+# Build XLA's version of LLVM
+mkdir /opt/llvm-build
+pushd /opt/llvm-build
+cmake -G Ninja \
+  -DCMAKE_BUILD_TYPE=Release \
+  -DCMAKE_C_COMPILER=clang \
+  -DCMAKE_CXX_COMPILER=clang++ \
+  -DLLVM_ENABLE_ASSERTIONS=ON \
+  -DLLVM_ENABLE_PROJECTS="mlir;llvm" \
+  -DLLVM_TARGETS_TO_BUILD="host;NVPTX" \
+  /opt/checkout/external/llvm-raw/llvm
+ninja
+# Build XLA's version of Triton against that LLVM
+pushd /opt/checkout/external/triton
+mkdir dist
+# Do not compile with -Werror
+sed -i -e 's|-Werror||g' CMakeLists.txt
+# The LLVM build above does not enable these libraries
+sed -i -e 's|\(LLVMAMDGPU.*\)|# \1|g' CMakeLists.txt
+# Do not build tests
+sed -i -e 's|^add_subdirectory(unittest)|# unit tests disabled|' CMakeLists.txt
+# Do not build the AMD GPU backend
+sed -i -e 's|BackendInstaller.copy(\["nvidia", "amd"\])|BackendInstaller.copy(["nvidia"])|g' python/setup.py
+# Extra patches to Triton maintained in XLA. These are already applied in the working directory.
 XLA_TRITON_PATCHES="${SRC_PATH_XLA}/third_party/triton"
-# This patch only works with a newer LLVM than is pinned in the branch.
-PATCH_FILE="${XLA_TRITON_PATCHES}/llvm_integration/cl623185214.patch"
-if [[ $(cat "${SRC_PATH_TRITON}/cmake/llvm-hash.txt") == "6f44bb7717897191be25aa01161831c67cdf5b84" && -f "${PATCH_FILE}" ]]; then
-  pushd "${SRC_PATH_TRITON}"
-  patch -p1 -R < "${PATCH_FILE}"
-  popd
-fi
 # This patch adds two files that are not known to CMake
 if [[ -f "${XLA_TRITON_PATCHES}/xla_extensions/sparse_dot_base.patch" ]]; then
-  sed -i -e '/ConvertLayoutOpToLLVM.cpp/a ConvertLayoutOpToLLVM/SharedToSparseDotOperand.cpp' "${SRC_PATH_TRITON}/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/CMakeLists.txt"
-  sed -i -e '/DotOpToLLVM.cpp/a DotOpToLLVM/Sparse.cpp' "${SRC_PATH_TRITON}/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/CMakeLists.txt"
+  sed -i -e '/ConvertLayoutOpToLLVM.cpp/a ConvertLayoutOpToLLVM/SharedToSparseDotOperand.cpp' third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/CMakeLists.txt
+  sed -i -e '/DotOpToLLVM.cpp/a DotOpToLLVM/Sparse.cpp' third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/CMakeLists.txt
 fi
 # Use clang to match Google etc.
-TRITON_BUILD_WITH_CLANG_LLD=1  pip wheel --verbose --wheel-dir="${SRC_PATH_TRITON}/dist" "${SRC_PATH_TRITON}/python"
+LLVM_INCLUDE_DIRS=/opt/llvm-build/include \
+  LLVM_LIBRARY_DIR=/opt/llvm-build/lib \
+  LLVM_SYSPATH=/opt/llvm-build \
+  TRITON_BUILD_WITH_CLANG_LLD=1 \
+  pip wheel --verbose --wheel-dir=dist/ python/
+# Clean up the wheel build directory so it doesn't end up bloating the container
+rm -rf python/build
+# Make the layer for the *current* step smaller, so it is more likely to stay
+# resident in the Docker cache
+cp -r /opt/checkout/external/triton /opt/triton-copy
+rm -rf /opt/checkout /opt/llvm-build /root/.cache
 EOF
 
-# clean up the wheel build directory so it doesn't end up bloating the container
-RUN rm -rf "${SRC_PATH_TRITON}/python/build"
-
 ###############################################################################
-## Download source and add auxiliary scripts
+## Copy Triton source/wheel from the builder, checkout JAX-Triton
 ###############################################################################
 FROM base as mealkit
 ARG URLREF_JAX_TRITON
@@ -72,7 +83,7 @@ ARG SRC_PATH_JAX_TRITON
 ARG SRC_PATH_TRITON
 
 # Get the triton source + wheel from the build step
-COPY --from=builder ${SRC_PATH_TRITON} ${SRC_PATH_TRITON}
+COPY --from=builder /opt/triton-copy ${SRC_PATH_TRITON}
 RUN echo "triton @ file://$(ls ${SRC_PATH_TRITON}/dist/triton-*.whl)" >> /opt/pip-tools.d/requirements-triton.in
 
 # Check out jax-triton

--- a/.github/workflows/_ci.yaml
+++ b/.github/workflows/_ci.yaml
@@ -377,6 +377,8 @@ jobs:
         docker run -i --shm-size=1g --gpus all --volume $PWD:/output \
         ${{ needs.build-triton.outputs.DOCKER_TAG_FINAL }} \
         bash <<"EOF" |& tee test-triton.log
+          # autotuner tests from jax-triton now hit a triton code path that uses utilities from pytorch...
+          pip install --no-deps torch
           python /opt/jax-triton/tests/triton_call_test.py --xml_output_file /output/triton_test.xml
         EOF
       STATISTICS_SCRIPT: |

--- a/.github/workflows/_ci.yaml
+++ b/.github/workflows/_ci.yaml
@@ -72,6 +72,7 @@ jobs:
       BASE_IMAGE: ${{ needs.build-jax.outputs.DOCKER_TAG_MEALKIT }}
       CONTAINER_NAME: triton
       DOCKERFILE: .github/container/Dockerfile.triton
+      RUNNER_SIZE: large
       EXTRA_BUILD_ARGS: URLREF_JAX_TRITON=${{ fromJson(inputs.SOURCE_URLREFS).JAX_TRITON }}
     secrets: inherit
 


### PR DESCRIPTION
The current HEAD of XLA points to an openxla/triton tag that has [code](https://github.com/openxla/triton/blob/cl623533461/lib/Target/LLVMIR/LLVMDIScope.cpp#L94) that requires a [newer](https://github.com/llvm/llvm-project/commit/6f6336858e4588ebd113ebcc930f6384a4edca54) LLVM [than the tag claims](https://github.com/openxla/triton/blob/cl623533461/cmake/llvm-hash.txt). XLA builds with [a newer LLVM](https://github.com/openxla/xla/blob/7777ebe402cb6238c73ba00428421c548ef4aaea/third_party/llvm/workspace.bzl#L7), which is why this works there.

This PR makes the `triton` container build stage compile LLVM at the same commit as XLA and use that, ignoring `llvm-hash.txt`.

Also, by making the layer of the builder stage much smaller, this will hopefully stop the `final` stage from repeating the build work when run in CI. Interestingly just making the stage smaller didn't help, but using a `large` runner did.

Fixing the build exposes that the more recent Triton (https://github.com/openxla/triton/commit/c9800840489fbe04619ad2d4e0e46b868c589d48) requires `import torch` in a code path used by JAX-Triton tests.