### PR TITLE
test-maxtext.sh: do not compare strings as integers

### DIFF
--- a/.github/container/test-maxtext.sh
+++ b/.github/container/test-maxtext.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -exou pipefail
 
 # # Parse command-line arguments
 
@@ -179,7 +180,6 @@ MAXTEXT_DIR="/opt/maxtext"
 pushd ${MAXTEXT_DIR}
 
 ## Launch
-set -ex
 
 export NVTE_FUSED_ATTN=${ENABLE_FUSED_ATTN}
 export XLA_PYTHON_CLIENT_MEM_FRACTION=${MEM_FRACTION}
@@ -217,5 +217,4 @@ RUN_SETTINGS="MaxText/train.py MaxText/configs/base.yml run_name=${RUN_NAME} log
 echo "Command: python3 $RUN_SETTINGS"
 python3 $RUN_SETTINGS
 
-set +x
 echo "Output at ${OUTPUT}"

--- a/.github/container/test-maxtext.sh
+++ b/.github/container/test-maxtext.sh
@@ -151,7 +151,7 @@ else
     ici_DP=$DP
 fi
 
-if [ $ATTN_TYPE -eq 'cudnn_flash_te' ]; then
+if [[ $ATTN_TYPE == 'cudnn_flash_te' ]]; then
     ENABLE_FUSED_ATTN=1
     REMAT_POLICY="minimal_flash"
 fi


### PR DESCRIPTION
Also `set -eo pipefail` earlier, which should have caught this.

Error message in 2024-05-05 is
```
/usr/local/bin/test-maxtext.sh: line 148: [: dot_product: integer expression expected
```