### PR TITLE
ci: Add `watchdog`

### DIFF
--- a/.github/workflows/_watchdog.yaml
+++ b/.github/workflows/_watchdog.yaml
@@ -1,0 +1,68 @@
+name: watchdog
+
+on:
+  issue_comment:
+    types: [created]
+
+jobs:
+  woof:
+    runs-on: ubuntu-22.04
+    if: >
+      github.event_name == 'issue_comment' &&
+      github.event.issue.pull_request &&
+      startsWith(github.event.comment.body, '/ci') &&
+      contains('ko3n1g,nouiz,joker-eph,yhtang,terrykong,hemildesai,chaserileyroberts,CliveUnger,DwarKapex,mingxu1067,kocchop,SahilJain314,ashors1,maanug-nv,hmonishN,gspschmid', format('{0},', github.actor))
+    steps:
+      - name: Get PR number
+        shell: bash
+        id: get-pr-num
+        run: |
+          PR_URL="${{ github.event.issue.pull_request.url }}"
+          PR_NUM=${PR_URL##*/}
+          echo "pr_number=$PR_NUM" >> $GITHUB_OUTPUT
+
+      - name: Get Pull Request Information
+        uses: actions/github-script@v6
+        id: get-pr-branch
+        with:
+          result-encoding: string
+          script: |
+            const pr = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: ${{ steps.get-pr-num.outputs.pr_number }}
+            });
+            console.log('Pull Request Information:', pr.data);
+            return pr.data.head.ref;
+
+      - name: Trigger `CI` workflow on subset of tests          
+        uses: aurelien-baudet/workflow-dispatch@v2.1.1
+        id: trigger
+        with:
+          workflow: "CI"
+          token: ${{ secrets.GITHUB_TOKEN }}
+          wait-for-completion: false
+          ref: ${{ steps.get-pr-branch.outputs.result }}
+
+      - name: Update `GITHUB_STEP_SUMMARY`
+        shell: bash
+        run: echo "Click [here](${{ steps.trigger.outputs.workflow-url }}) to navigate to the workflow run." >> $GITHUB_STEP_SUMMARY
+
+      - name: Update PR issue comment
+        shell: bash
+        run: |
+          message="${{ github.event.comment.body}}
+
+          ---
+
+          Watchdog 🤖: presubmit CI was automatically triggered. Click [here](${{ steps.trigger.outputs.workflow-url }}) to navigate to the workflow run.
+          "
+          message="${message//$'\n'/<br>}"
+
+          curl -L \
+            -X PATCH \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            https://api.github.com/repos/${{ github.repository }}/issues/comments/${{ github.event.comment.id }} \
+            -d '{"body":"'"$message"'"}'


### PR DESCRIPTION
We'd need to merge this before working on #775 as workflows only run if they are present in `main`. Therefore, this PR does not reflect the additional inputs required for selective triggering, I would add these in #775  