### PR TITLE
Add NCCL sanity check

### DIFF
--- a/.github/container/Dockerfile.base
+++ b/.github/container/Dockerfile.base
@@ -174,6 +174,14 @@ ADD install-efa.sh /usr/local/bin
 ENV LD_LIBRARY_PATH=/opt/amazon/efa/lib:${LD_LIBRARY_PATH}
 ENV PATH=/opt/amazon/efa/bin:${PATH}
 
+##############################################################################
+## NCCL sanity check utility
+##############################################################################
+
+ADD install-nccl-sanity-check.sh /usr/local/bin
+ADD nccl-sanity-check.cu /opt
+RUN install-nccl-sanity-check.sh
+
 ###############################################################################
 ## Add the systemcheck to the entrypoint.
 ###############################################################################

--- a/.github/container/install-nccl-sanity-check.sh
+++ b/.github/container/install-nccl-sanity-check.sh
@@ -14,6 +14,7 @@ cat <<"EOF" > "$BIN_DIR/$NAME.sh"
 set -e
 export NCCL_SANITY_CHECK_LATENCY_US=1000
 NCCL_SANITY_CHECK_ARGS=$(python3 -c 'import jax; import jax.distributed; jax.distributed.initialize(); lds = jax.local_devices(); assert(len(lds) == 1); from jax._src.distributed import global_state as gs; print(gs.num_processes, gs.process_id, lds[0].local_hardware_id, gs.coordinator_address)')
+set -x
 nccl-sanity-check $NCCL_SANITY_CHECK_ARGS
 EOF
 chmod +x "$BIN_DIR/$NAME.sh"

--- a/.github/container/install-nccl-sanity-check.sh
+++ b/.github/container/install-nccl-sanity-check.sh
@@ -13,10 +13,7 @@ cat <<"EOF" > "$BIN_DIR/$NAME.sh"
 #!/bin/bash
 set -e
 export NCCL_SANITY_CHECK_LATENCY_US=1000
-NCCL_SANITY_CHECK_ARGS=$(python3 -c 'import jax; jax.distributed.initialize(); from jax._src.distributed import global_state as gs; print(gs.process_id, gs.num_processes, gs.coordinator_address)')
+NCCL_SANITY_CHECK_ARGS=$(python3 -c 'import jax; import jax.distributed; jax.distributed.initialize(); lds = jax.local_devices(); assert(len(lds) == 1); from jax._src.distributed import global_state as gs; print(gs.num_processes, gs.process_id, lds[0].local_hardware_id, gs.coordinator_address)')
 nccl-sanity-check $NCCL_SANITY_CHECK_ARGS
 EOF
 chmod +x "$BIN_DIR/$NAME.sh"
-
-# REMOVE ME: To test with base container (rather than jax-from-source container)
-pip3 install jax

--- a/.github/container/install-nccl-sanity-check.sh
+++ b/.github/container/install-nccl-sanity-check.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+set -ex
+
+BIN_DIR=/usr/local/bin
+NAME=nccl-sanity-check
+
+# Build binary from source
+nvcc -o "$BIN_DIR/$NAME" "/opt/$NAME.cu" -lcudart -lnccl
+
+# Create the wrapper script that queries jax for the configuration
+cat <<"EOF" > "$BIN_DIR/$NAME.sh"
+#!/bin/bash
+set -e
+export NCCL_SANITY_CHECK_LATENCY_US=1000
+NCCL_SANITY_CHECK_ARGS=$(python3 -c 'import jax; jax.distributed.initialize(); from jax._src.distributed import global_state as gs; print(gs.process_id, gs.num_processes, gs.coordinator_address)')
+nccl-sanity-check $NCCL_SANITY_CHECK_ARGS
+EOF
+chmod +x "$BIN_DIR/$NAME.sh"
+
+# REMOVE ME: To test with base container (rather than jax-from-source container)
+pip3 install jax

--- a/.github/container/nccl-sanity-check.cu
+++ b/.github/container/nccl-sanity-check.cu
@@ -50,7 +50,8 @@ void printUsageAndAbort(char* progName) {
 }
 
 
-void parseArgs(int argc, char* argv[], int* nRanks, int* myRank, int* localRank, char* coordinatorAddress) {
+void parseArgs(int argc, char* argv[], int* nRanks, int* myRank, int* localRank,
+    char* coordinatorAddress) {
   if (argc != 5) {
     printUsageAndAbort(argv[0]);
   }
@@ -66,14 +67,16 @@ void parseArgs(int argc, char* argv[], int* nRanks, int* myRank, int* localRank,
     printf("Expected local-rank to be a non-negative integer\n");
     printUsageAndAbort(argv[0]);
   }
-  if (sscanf(argv[4], "%127s", coordinatorAddress) != 1 || strlen(coordinatorAddress) >= 127) {
+  if (sscanf(argv[4], "%127s", coordinatorAddress) != 1 ||
+      strlen(coordinatorAddress) >= 127) {
     printf("Expected coordinator-address to be a string (ip:port)\n");
     printUsageAndAbort(argv[0]);
   }
 }
 
 
-std::tuple<uint64_t, uint64_t> sampleAllReduces(int rank, int nRanks, ncclUniqueId id, int size, int rounds) {
+std::tuple<uint64_t, uint64_t> sampleAllReduces(int rank, int nRanks, ncclUniqueId id,
+    int size, int rounds) {
   float *sendbuff, *recvbuff;
   CUDACHECK(cudaMalloc((void**) &sendbuff, size * sizeof(float)));
   CUDACHECK(cudaMalloc((void**) &recvbuff, size * sizeof(float)));
@@ -91,12 +94,12 @@ std::tuple<uint64_t, uint64_t> sampleAllReduces(int rank, int nRanks, ncclUnique
   for (int i=0; i<rounds; i++) {
     auto t_start = std::chrono::high_resolution_clock::now();
 
-    NCCLCHECK(ncclAllReduce((const void*)sendbuff, (void*)recvbuff, size, ncclFloat, ncclSum, comm, s));
+    NCCLCHECK(ncclAllReduce((const void*)sendbuff, (void*)recvbuff, size, ncclFloat,
+      ncclSum, comm, s));
     CUDACHECK(cudaStreamSynchronize(s));
 
     uint64_t duration = std::chrono::duration_cast<std::chrono::microseconds>(
       std::chrono::high_resolution_clock::now() - t_start).count();
-    // printf("[MPI Rank %d] round %d, duration %" PRIu64 "us\n", rank, i, duration);
     if (duration < minDuration) {
       minDuration = duration;
     }
@@ -152,7 +155,9 @@ int main(int argc, char* argv[])
 
   // Report result of the sanity check
   bool success = threshold >= minDuration;
-  printf("nccl-sanity-check success=%d rank=%d nRanks=%d rounds=%d threshold=%dus minDuration=%" PRIu64 "us maxDuration=%" PRIu64 "us\n",
+  printf(
+    "nccl-sanity-check success=%d rank=%d nRanks=%d rounds=%d threshold=%dus "
+    "minDuration=%" PRIu64 "us maxDuration=%" PRIu64 "us\n",
     success, myRank, nRanks, rounds, threshold, minDuration, maxDuration);
   return !success;
 }

--- a/.github/container/nccl-sanity-check.cu
+++ b/.github/container/nccl-sanity-check.cu
@@ -123,9 +123,6 @@ int main(int argc, char* argv[])
   // The minimum duration required to pass the sanity check.
   int threshold = getEnvAsInt("NCCL_SANITY_CHECK_LATENCY_US", 1000);
 
-  // int myRank = getEnvAsInt("OMPI_COMM_WORLD_RANK", -1);
-  // int nRanks = getEnvAsInt("OMPI_COMM_WORLD_SIZE", -1);
-  // int localRank = getEnvAsInt("OMPI_COMM_WORLD_LOCAL_RANK", -1);
   int nRanks, myRank, localRank;
   char coordinatorAddress[128];
   parseArgs(argc, argv, &nRanks, &myRank, &localRank, coordinatorAddress);
@@ -134,7 +131,7 @@ int main(int argc, char* argv[])
 
   // Compute same NCCL unique id in all ranks
   ncclUniqueId id;
-  if (!setenv("NCCL_COMM_ID", coordinatorAddress, 1)) {
+  if (setenv("NCCL_COMM_ID", coordinatorAddress, 1) != 0) {
     printf("Failed: Could not set NCCL_COMM_ID\n");
     exit(EXIT_FAILURE);
   }

--- a/.github/container/nccl-sanity-check.cu
+++ b/.github/container/nccl-sanity-check.cu
@@ -1,0 +1,161 @@
+#include <stdio.h>
+#include "cuda_runtime.h"
+#include "nccl.h"
+#include <unistd.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <inttypes.h>
+#include <chrono>
+#include <limits>
+#include <tuple>
+
+
+#define CUDACHECK(cmd) do {                         \
+  cudaError_t e = cmd;                              \
+  if( e != cudaSuccess ) {                          \
+    printf("Failed: CUDA error %s:%d '%s'\n",       \
+        __FILE__,__LINE__,cudaGetErrorString(e));   \
+    exit(EXIT_FAILURE);                             \
+  }                                                 \
+} while(0)
+
+
+#define NCCLCHECK(cmd) do {                         \
+  ncclResult_t r = cmd;                             \
+  if (r!= ncclSuccess) {                            \
+    printf("Failed: NCCL error %s:%d '%s'\n",       \
+        __FILE__,__LINE__,ncclGetErrorString(r));   \
+    exit(EXIT_FAILURE);                             \
+  }                                                 \
+} while(0)
+
+
+static int getEnvAsInt(const char* name, int default_val) {
+  char* str_val = getenv(name);
+  if (!str_val) {
+    return default_val;
+  }
+  int int_val;
+  if (sscanf(str_val, "%d", &int_val) != 1) {
+    printf("Failed: Could not parse env var %s as int: '%s'\n", name, str_val);
+    exit(EXIT_FAILURE);
+  }
+  return int_val;
+}
+
+
+void printUsageAndAbort(char* progName) {
+  printf("Usage: %s world-size world-rank local-rank coordinator-address\n", progName);
+  exit(EXIT_FAILURE);
+}
+
+
+void parseArgs(int argc, char* argv[], int* nRanks, int* myRank, int* localRank, char* coordinatorAddress) {
+  if (argc != 5) {
+    printUsageAndAbort(argv[0]);
+  }
+  if (sscanf(argv[1], "%d", nRanks) != 1 || *nRanks <= 0) {
+    printf("Expected world-size to be a positive integer\n");
+    printUsageAndAbort(argv[0]);
+  }
+  if (sscanf(argv[2], "%d", myRank) != 1 || *myRank < 0 || *myRank >= *nRanks) {
+    printf("Expected world-rank to be an integer in [0;world-size)\n");
+    printUsageAndAbort(argv[0]);
+  }
+  if (sscanf(argv[3], "%d", localRank) != 1 || *localRank < 0) {
+    printf("Expected local-rank to be a non-negative integer\n");
+    printUsageAndAbort(argv[0]);
+  }
+  if (sscanf(argv[4], "%127s", coordinatorAddress) != 1 || strlen(coordinatorAddress) >= 127) {
+    printf("Expected coordinator-address to be a string (ip:port)\n");
+    printUsageAndAbort(argv[0]);
+  }
+}
+
+
+std::tuple<uint64_t, uint64_t> sampleAllReduces(int rank, int nRanks, ncclUniqueId id, int size, int rounds) {
+  float *sendbuff, *recvbuff;
+  CUDACHECK(cudaMalloc((void**) &sendbuff, size * sizeof(float)));
+  CUDACHECK(cudaMalloc((void**) &recvbuff, size * sizeof(float)));
+  
+  cudaStream_t s;
+  CUDACHECK(cudaStreamCreate(&s));
+
+  //initializing NCCL
+  ncclComm_t comm;
+  NCCLCHECK(ncclCommInitRank(&comm, nRanks, id, rank));
+
+  // Sample a few rounds of minimal all-reduces
+  uint64_t minDuration = std::numeric_limits<uint64_t>::max();
+  uint64_t maxDuration = 0;
+  for (int i=0; i<rounds; i++) {
+    auto t_start = std::chrono::high_resolution_clock::now();
+
+    NCCLCHECK(ncclAllReduce((const void*)sendbuff, (void*)recvbuff, size, ncclFloat, ncclSum, comm, s));
+    CUDACHECK(cudaStreamSynchronize(s));
+
+    uint64_t duration = std::chrono::duration_cast<std::chrono::microseconds>(
+      std::chrono::high_resolution_clock::now() - t_start).count();
+    // printf("[MPI Rank %d] round %d, duration %" PRIu64 "us\n", rank, i, duration);
+    if (duration < minDuration) {
+      minDuration = duration;
+    }
+    if (duration > maxDuration) {
+      maxDuration = duration;
+    }
+  }
+
+  // Clean up
+  CUDACHECK(cudaFree(sendbuff));
+  CUDACHECK(cudaFree(recvbuff));
+  ncclCommDestroy(comm);
+
+  return {minDuration, maxDuration};
+}
+
+
+int main(int argc, char* argv[])
+{
+  // Number of floats communicated in all-reduce
+  int size = 1;
+  // Number of all-reduces to sample, only best result is considered.
+  int rounds = 10;
+  // The minimum duration required to pass the sanity check.
+  int threshold = getEnvAsInt("NCCL_SANITY_CHECK_LATENCY_US", 1000);
+
+  // int myRank = getEnvAsInt("OMPI_COMM_WORLD_RANK", -1);
+  // int nRanks = getEnvAsInt("OMPI_COMM_WORLD_SIZE", -1);
+  // int localRank = getEnvAsInt("OMPI_COMM_WORLD_LOCAL_RANK", -1);
+  int nRanks, myRank, localRank;
+  char coordinatorAddress[128];
+  parseArgs(argc, argv, &nRanks, &myRank, &localRank, coordinatorAddress);
+
+  CUDACHECK(cudaSetDevice(localRank));
+
+  // Compute same NCCL unique id in all ranks
+  ncclUniqueId id;
+  if (!setenv("NCCL_COMM_ID", coordinatorAddress, 1)) {
+    printf("Failed: Could not set NCCL_COMM_ID\n");
+    exit(EXIT_FAILURE);
+  }
+
+  // ncclUniqueId is just a ncclBootstrapHandle (with some padding), see:
+  //   https://github.com/NVIDIA/nccl/blob/v2.19/src/include/bootstrap.h#L14
+  // In the following call, the addr is initialized using NCCL_COMM_ID, but the
+  // magic is drawn from urandom bits. Usually this would only be done on rank 0
+  // and the resulting id would then be broadcast to all the other processes
+  // out-of-band (e.g. using standard MPI). Instead, here we've already settled
+  // on an appropriate ip and port for rank 0 (given in NCCL_COMMI_ID), and all
+  // that remains is fixing the magic.
+  ncclGetUniqueId(&id);
+  *((uint64_t*) &id) = 0xDEADBEEFDEADBEEF;
+
+  // Estimate latency by running several all-reduces
+  auto[minDuration, maxDuration] = sampleAllReduces(myRank, nRanks, id, size, rounds);
+
+  // Report result of the sanity check
+  bool success = threshold >= minDuration;
+  printf("nccl-sanity-check success=%d rank=%d nRanks=%d rounds=%d threshold=%dus minDuration=%" PRIu64 "us maxDuration=%" PRIu64 "us\n",
+    success, myRank, nRanks, rounds, threshold, minDuration, maxDuration);
+  return !success;
+}


### PR DESCRIPTION
Adds a small utility `nccl-sanity-check` that is intended to serve as a basic diagnostic for the NCCL setup. The utility connects all the ranks and performs several single-float all-reduces. When the minimum timing of these attempts is below a certain configurable thresholds (1ms, by default) the utility exits successfully.

The utility takes `world-size world-rank local-rank coordinator-address` as arguments. To simplify invocations a wrapper script `nccl-sanity-check.sh` uses `jax.distributed` to extract the configuration from slurm or openmpi environmental variables.

This was tested manually on multiple nodes via slurm using an invocation like
```
srun --container-image=ghcr.io/nvidia/jax:jax-2024-05-05 --container-mounts=... -N 4 --tasks-per-node 8 bin/bash -c "cd ... && ./nccl-sanity-check.sh"
```
