### PR TITLE
fixed XLA flag for simplify fp conversion

### DIFF
--- a/.github/container/test-maxtext.sh
+++ b/.github/container/test-maxtext.sh
@@ -187,7 +187,6 @@ export CUDA_DEVICE_MAX_CONNECTIONS=1
 
 export BASE_XLA_FLAGS=${BASE_XLA_FLAGS:---xla_gpu_enable_latency_hiding_scheduler=true 
                 --xla_gpu_enable_triton_gemm=false
-                --xla_allow_excess_precision
                 --xla_gpu_graph_level=0 
                 --xla_gpu_enable_highest_priority_async_stream=true
                 --xla_gpu_all_reduce_combine_threshold_bytes=1073741824 

--- a/.github/container/test-maxtext.sh
+++ b/.github/container/test-maxtext.sh
@@ -187,7 +187,7 @@ export CUDA_DEVICE_MAX_CONNECTIONS=1
 
 export BASE_XLA_FLAGS=${BASE_XLA_FLAGS:---xla_gpu_enable_latency_hiding_scheduler=true 
                 --xla_gpu_enable_triton_gemm=false
-                --xla_gpu_simplify_all_fp_conversions 
+                --xla_allow_excess_precision
                 --xla_gpu_graph_level=0 
                 --xla_gpu_enable_highest_priority_async_stream=true
                 --xla_gpu_all_reduce_combine_threshold_bytes=1073741824 


### PR DESCRIPTION
removed the deprecated `--xla_gpu_simplify_all_fp_conversions`
replaced with `--xla_allow_excess_precision`