### PR TITLE
CUDA_MODULE_LOADING: use default lazy loading

### DIFF
--- a/.github/container/Dockerfile.jax
+++ b/.github/container/Dockerfile.jax
@@ -67,8 +67,6 @@ ENV XLA_FLAGS="${XLA_FLAGS} --xla_gpu_enable_latency_hiding_scheduler=true"
 ENV XLA_FLAGS="${XLA_FLAGS} --xla_gpu_enable_triton_gemm=false"
 ENV CUDA_DEVICE_MAX_CONNECTIONS=1
 ENV NCCL_NVLS_ENABLE=0
-ENV CUDA_MODULE_LOADING=EAGER
-
 
 COPY --from=builder ${SRC_PATH_JAX} ${SRC_PATH_JAX}
 COPY --from=builder ${SRC_PATH_XLA} ${SRC_PATH_XLA}


### PR DESCRIPTION
Prefer to set fewer magic variables. Eager loading cuDNN/cuBLAS during XLA compilation can also be noticably slow.

This was added in https://github.com/NVIDIA/JAX-Toolbox/pull/329