### PR TITLE
chore: Add `orbax-checkpoint` to manifest

### DIFF
--- a/.github/container/manifest.yaml
+++ b/.github/container/manifest.yaml
@@ -175,4 +175,7 @@ panopticapi:
   tracking_ref: mute
   latest_verified_commit: a698a12deb21e4cf0f99ef0581b2c30c466bf355
   mode: git-clone
-  
+orbax-checkpoint:
+  url: https://github.com/google/orbax/#subdirectory=checkpoint
+  tracking_ref: main
+  latest_verified_commit: 16c2d409e365576284dbaf190ac002b24c1f927f


### PR DESCRIPTION
Since they changed to vcs install