### PR TITLE
fix: Pin webdataset

### DIFF
--- a/rosetta/setup.py
+++ b/rosetta/setup.py
@@ -30,7 +30,7 @@ setuptools.setup(
         'nvidia-pytriton',
         'einops',
         'pillow',
-        'webdataset',
+        'webdataset>=0.1.10',  # Earlier versions require a pip-package that is not hosted on pypi anymore. This will lead to an exception in pip-compile.
         'matplotlib',
         'nvidia-dali-cuda120',
     ],


### PR DESCRIPTION
During conflicts, pip-compiles checks all version of a package to test if there's a release the resolves the current conflict. If one of these releases depends on a dependency that cannot be found anymore (due to a rename), pip-compile will crash.

While iterating all versions of webdataset, it stumbled over a very old version which required the package `objio` (nowadays named: `objectio`). By excluding those old version, we can fix the issue.

Not super important but as a side-note: While digging through the logs, I found that while pip-compile iterated all versions webdataset there was a version conflict between `chex` (`0.1.86`) (via `optax`, via `t5x`) and `tensorflow-cpu` (`2.12.0`). These packages conflicted on numpy. For a reason I don't understand, pip-compile tried to resolve that issue while working on webdataset by iterating all versions and crashed then as explained above. 