### PR TITLE
Pin IPython version to 8.2

### DIFF
--- a/.github/workflows/_ci.yaml
+++ b/.github/workflows/_ci.yaml
@@ -500,7 +500,7 @@ jobs:
       EXECUTE: |
         docker run --shm-size=1g --gpus all ${{ needs.build-gemma.outputs.DOCKER_TAG_FINAL }} \
         bash -ec \
-        "cd /opt/gemma && pip install -e .[test] && pytest . && python /opt/gemma/tests/test_paligemma.py" | tee test-gemma.log
+        "cd /opt/gemma && pip install -e .[test] && pytest ." | tee test-gemma.log
       STATISTICS_SCRIPT: |
         summary_line=$(tail -n1 test-gemma.log)
         errors=$(echo $summary_line | grep -oE '[0-9]+ error' | awk '{print $1} END { if (!NR) print 0}')

--- a/rosetta/Dockerfile.gemma
+++ b/rosetta/Dockerfile.gemma
@@ -39,7 +39,8 @@ echo "-e file://${SRC_PATH_GEMMA}" >> /opt/pip-tools.d/requirements-gemma.in
 echo "-e file://${SRC_PATH_COMMON_LOOP_UTILS}" >> /opt/pip-tools.d/requirements-gemma.in
 echo "-e file://${SRC_PATH_FLAXFORMER}" >> /opt/pip-tools.d/requirements-gemma.in
 echo "-e file://${SRC_PATH_PANOPTICAPI}" >> /opt/pip-tools.d/requirements-gemma.in
-echo "jupyterlab
+echo "ipython==8.2
+jupyterlab
 gcloud
 overrides
 ml_collections


### PR DESCRIPTION
Gemma container installs `jupyterlab` package to run a jupyter-notebook example. Unfortunately, the latest version of `IPython`(8.23) requires `typing-extension` of 4.6.1 or higher, which creates conflict with installed version of `typing-extension` (4.5.0 required by tensorflow).
The solution is to ping `IPython` to 8.2.