### PR TITLE
Measure final docker image size

### DIFF
--- a/.github/workflows/_build.yaml
+++ b/.github/workflows/_build.yaml
@@ -174,6 +174,12 @@ jobs:
             BUILD_DATE=${{ inputs.BUILD_DATE }}
             ${{ inputs.EXTRA_BUILD_ARGS }}
 
+      - name: Docker image compressed size
+        shell: bash -x -e {0}
+        run: |
+          . .github/workflows/scripts/compressed_image_size.sh
+          compressed_docker_size ${{ steps.final-metadata.outputs.tags }}
+
       - name: Generate sitrep
         if: "!cancelled()"
         shell: bash -x -e {0}

--- a/.github/workflows/_build_base.yaml
+++ b/.github/workflows/_build_base.yaml
@@ -133,7 +133,13 @@ jobs:
             GIT_USER_EMAIL=${{ inputs.GIT_USER_EMAIL }}
             BUILD_DATE=${{ inputs.BUILD_DATE }}
             ${{ inputs.BASE_IMAGE != 'latest' && format('BASE_IMAGE={0}', inputs.BASE_IMAGE) || '' }}
-        
+
+      - name: Docker image compressed size
+        shell: bash -x -e {0}
+        run: |
+          . .github/workflows/scripts/compressed_image_size.sh
+          compressed_docker_size ${{ steps.meta.outputs.tags }}
+
       - name: Generate sitrep
         if: "!cancelled()"
         shell: bash -x -e {0}

--- a/.github/workflows/scripts/docker_image_size.sh
+++ b/.github/workflows/scripts/docker_image_size.sh
@@ -1,0 +1,6 @@
+function compressed_docker_size() { 
+    docker manifest inspect -v "$1" \
+    | jq -c 'if type == "array" then .[] else . end' \
+    | jq -r '[ ( .Descriptor.platform | [ .os, .architecture, .variant, ."os.version" ] | del(..|nulls) | join("/") ), ( [ .SchemaV2Manifest.layers[].size ] | add ) ] | join(" ")' \
+    | numfmt --to iec --format '%.2f' --field 2 | column -t ; 
+}


### PR DESCRIPTION
JAX-Core container keeps getting fat. Add a step to track the compressed size of the the containers (except for Rosetta) 