### PR TITLE
Ping numpy to 1.24.3

### DIFF
--- a/.github/container/Dockerfile.jax
+++ b/.github/container/Dockerfile.jax
@@ -34,6 +34,10 @@ RUN --mount=type=ssh \
     --mount=type=secret,id=SSH_KNOWN_HOSTS,target=/root/.ssh/known_hosts \
 <<"EOF" bash -ex
     git-clone.sh ${URLREF_JAX} ${SRC_PATH_JAX}
+    pushd ${SRC_PATH_JAX}/build
+    sed -i '/^numpy/,/^[a-z]/{/^[a-z]/!{/^[a-z]/!d}}' requirements_lock_3_10.txt
+    sed -i '/^numpy/d' requirements_lock_3_10.txt
+    popd
     git-clone.sh ${URLREF_XLA} ${SRC_PATH_XLA}
 EOF
 
@@ -90,7 +94,7 @@ RUN mkdir -p /opt/pip-tools.d
 RUN <<"EOF" bash -ex
 echo "-e file://${BUILD_PATH_JAXLIB}" > /opt/pip-tools.d/requirements-jax.in
 echo "-e file://${SRC_PATH_JAX}" >> /opt/pip-tools.d/requirements-jax.in
-echo "numpy<2.0" >> /opt/pip-tools.d/requirements-jax.in
+echo "numpy=<1.26.4" >> /opt/pip-tools.d/requirements-jax.in
 EOF
 
 ## Flax

--- a/.github/container/Dockerfile.jax
+++ b/.github/container/Dockerfile.jax
@@ -90,7 +90,7 @@ RUN mkdir -p /opt/pip-tools.d
 RUN <<"EOF" bash -ex
 echo "-e file://${BUILD_PATH_JAXLIB}" > /opt/pip-tools.d/requirements-jax.in
 echo "-e file://${SRC_PATH_JAX}" >> /opt/pip-tools.d/requirements-jax.in
-echo "numpy==1.26.4" >> /opt/pip-tools.d/requirements-jax.in
+echo "numpy==1.24.3" >> /opt/pip-tools.d/requirements-jax.in
 EOF
 
 ## Flax

--- a/.github/container/Dockerfile.jax
+++ b/.github/container/Dockerfile.jax
@@ -34,7 +34,7 @@ RUN --mount=type=ssh \
     --mount=type=secret,id=SSH_KNOWN_HOSTS,target=/root/.ssh/known_hosts \
 <<"EOF" bash -ex
     git-clone.sh ${URLREF_JAX} ${SRC_PATH_JAX}
-    sed 's/^numpy.*/numpy<2.0.0/' ${SRC_PATH_JAX}/build/requirements.txt
+    sed 's/^numpy.*/numpy<2.0.0/' ${SRC_PATH_JAX}/build/requirements.in
     git-clone.sh ${URLREF_XLA} ${SRC_PATH_XLA}
 EOF
 

--- a/.github/container/Dockerfile.jax
+++ b/.github/container/Dockerfile.jax
@@ -90,7 +90,7 @@ RUN mkdir -p /opt/pip-tools.d
 RUN <<"EOF" bash -ex
 echo "-e file://${BUILD_PATH_JAXLIB}" > /opt/pip-tools.d/requirements-jax.in
 echo "-e file://${SRC_PATH_JAX}" >> /opt/pip-tools.d/requirements-jax.in
-echo "numpy==1.24.3" >> /opt/pip-tools.d/requirements-jax.in
+echo "numpy<2.0" >> /opt/pip-tools.d/requirements-jax.in
 EOF
 
 ## Flax

--- a/.github/container/Dockerfile.jax
+++ b/.github/container/Dockerfile.jax
@@ -34,10 +34,7 @@ RUN --mount=type=ssh \
     --mount=type=secret,id=SSH_KNOWN_HOSTS,target=/root/.ssh/known_hosts \
 <<"EOF" bash -ex
     git-clone.sh ${URLREF_JAX} ${SRC_PATH_JAX}
-    pushd ${SRC_PATH_JAX}/build
-    sed -i '/^numpy/,/^[a-z]/{/^[a-z]/!{/^[a-z]/!d}}' requirements_lock_3_10.txt
-    sed -i '/^numpy/d' requirements_lock_3_10.txt
-    popd
+    sed 's/^numpy.*/numpy<2.0.0/' ${SRC_PATH_JAX}/build/requirements.txt
     git-clone.sh ${URLREF_XLA} ${SRC_PATH_XLA}
 EOF
 

--- a/.github/container/Dockerfile.jax
+++ b/.github/container/Dockerfile.jax
@@ -91,7 +91,7 @@ RUN mkdir -p /opt/pip-tools.d
 RUN <<"EOF" bash -ex
 echo "-e file://${BUILD_PATH_JAXLIB}" > /opt/pip-tools.d/requirements-jax.in
 echo "-e file://${SRC_PATH_JAX}" >> /opt/pip-tools.d/requirements-jax.in
-echo "numpy=<1.26.4" >> /opt/pip-tools.d/requirements-jax.in
+echo "numpy<2.0.0" >> /opt/pip-tools.d/requirements-jax.in
 EOF
 
 ## Flax

--- a/.github/container/Dockerfile.jax
+++ b/.github/container/Dockerfile.jax
@@ -90,6 +90,7 @@ RUN mkdir -p /opt/pip-tools.d
 RUN <<"EOF" bash -ex
 echo "-e file://${BUILD_PATH_JAXLIB}" > /opt/pip-tools.d/requirements-jax.in
 echo "-e file://${SRC_PATH_JAX}" >> /opt/pip-tools.d/requirements-jax.in
+echo "numpy==1.26.4" >> /opt/pip-tools.d/requirements-jax.in
 EOF
 
 ## Flax


### PR DESCRIPTION
Jax-Core container fails to build with Recently released numpy 2. Pin numpy to 1.26.2 until TF adds support for numpy 2.