### PR TITLE
Fix Triton container build

### DIFF
--- a/.github/container/Dockerfile.triton
+++ b/.github/container/Dockerfile.triton
@@ -6,7 +6,7 @@ ARG SRC_PATH_JAX_TRITON=/opt/jax-triton
 ARG SRC_PATH_TRITON=/opt/triton
 ARG SRC_PATH_XLA=/opt/xla
 
-FROM ${BASE_IMAGE} as base
+FROM ${BASE_IMAGE} AS base
 # Triton setup.py downloads and installs CUDA binaries at specific versions
 # hardcoded in the script itself:
 # https://github.com/openxla/triton/blob/84f9d9de158fb866fac67970f0f5d323999d9db1/python/setup.py#L373-L393
@@ -23,7 +23,7 @@ RUN [ -x "${TRITON_PTXAS_PATH}" ] && [ -x "${TRITON_CUOBJDUMP_PATH}" ] && [ -x "
 ## llvm-head branch and apply XLA's extra patches to it. Also fetches the
 ## compatible LLVM sources.
 ###############################################################################
-FROM base as builder
+FROM base AS builder
 ARG SRC_PATH_JAX
 ARG SRC_PATH_XLA
 RUN <<"EOF" bash -ex
@@ -85,7 +85,7 @@ EOF
 ###############################################################################
 ## Copy Triton source/wheel from the builder, checkout JAX-Triton
 ###############################################################################
-FROM base as mealkit
+FROM base AS mealkit
 ARG URLREF_JAX_TRITON
 ARG SRC_PATH_JAX_TRITON
 ARG SRC_PATH_TRITON
@@ -104,6 +104,6 @@ EOF
 ###############################################################################
 ## Install accumulated packages from the base image and the previous stage
 ###############################################################################
-FROM mealkit as final
+FROM mealkit AS final
 
 RUN pip-finalize.sh

--- a/.github/container/Dockerfile.triton
+++ b/.github/container/Dockerfile.triton
@@ -70,7 +70,6 @@ sed -i -e '/include_directories(${PROJECT_BINARY_DIR}\/third_party)/a include_di
 XLA_TRITON_PATCHES="${SRC_PATH_XLA}/third_party/triton"
 # This patch adds two files that are not known to CMake
 if [[ -f "${XLA_TRITON_PATCHES}/xla_extensions/sparse_dot.patch" ]]; then
-  sed -i -e '/ConvertLayoutOpToLLVM.cpp/a ConvertLayoutOpToLLVM/SharedToSparseDotOperand.cpp' third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/CMakeLists.txt
   sed -i -e '/DotOpToLLVM.cpp/a DotOpToLLVM/Sparse.cpp' third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/CMakeLists.txt
 fi
 # Use clang to match Google etc.


### PR DESCRIPTION
- Fix build issue due to https://github.com/openxla/xla/commit/80a2ef69c44426716357f2178557a410c8fdad3c
- Fix new warnings from Docker due to `FROM x as y` having a case mismatch between `FROM` and `as`