### PR TITLE
Fixes t5x build issue where pip fails to pull every single version of seqio-nightly

### DIFF
--- a/.github/container/Dockerfile.t5x.amd64
+++ b/.github/container/Dockerfile.t5x.amd64
@@ -15,6 +15,10 @@ ARG SRC_PATH_T5X
 RUN <<"EOF" bash -ex
 git-clone.sh ${URLREF_T5X} ${SRC_PATH_T5X}
 echo "-e file://${SRC_PATH_T5X}[gpu]" >> /opt/pip-tools.d/requirements-t5x.in
+# This is required because pip can sometimes try to pull every version of seqio-nightly during
+# resolution which leads to a ResolutionTooDeep error. The latest nightlies appear to work
+# so setting the lower-bound to something recent
+echo "seqio-nightly>=0.0.18.dev20240714" >> /opt/pip-tools.d/requirements-t5x.in
 
 # remove head-of-tree specs from select dependencies
 pushd ${SRC_PATH_T5X}

--- a/.github/container/Dockerfile.t5x.arm64
+++ b/.github/container/Dockerfile.t5x.arm64
@@ -57,6 +57,10 @@ RUN <<"EOF" bash -ex
 # 1. Fetch T5X
 git-clone.sh "${URLREF_T5X}" "${SRC_PATH_T5X}"
 echo "-e file://${SRC_PATH_T5X}[gpu]" >> /opt/pip-tools.d/requirements-t5x.in
+# This is required because pip can sometimes try to pull every version of seqio-nightly during
+# resolution which leads to a ResolutionTooDeep error. The latest nightlies appear to work
+# so setting the lower-bound to something recent
+echo "seqio-nightly>=0.0.18.dev20240714" >> /opt/pip-tools.d/requirements-t5x.in
 
 # 2. Remove head-of-tree specs from select dependencies
 pushd ${SRC_PATH_T5X}


### PR DESCRIPTION
T5x has been failing to build for the past few days due to t5 requiring an unpinned version of seqio-nightly.

Normally the build resolves, but for some reason, something recently introduced in the dependency tree is causing the all of the seqio-nightly versions to be pulled and eventually pip complains it can't pull anymore. Since the latest nightly usually works, I'm setting the lower-bound to something recent so that pip will exit early and try to find a resolution with the versions we currently have.

In the worst case, this version may have to get updated, but I suspect it won't happen for a long time.