### PR TITLE
Fix for jax build including cuda plugin

### DIFF
--- a/.github/container/Dockerfile.jax
+++ b/.github/container/Dockerfile.jax
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1-labs
 ARG BASE_IMAGE=ghcr.io/nvidia/jax:base
-ARG BUILD_PATH_JAXLIB=/opt/jaxlib
+ARG BUILD_PATH_JAXLIB=/opt/jax/dist
 ARG URLREF_JAX=https://github.com/google/jax.git#main
 ARG URLREF_XLA=https://github.com/openxla/xla.git#main
 ARG URLREF_FLAX=https://github.com/google/flax.git#main

--- a/.github/container/Dockerfile.jax
+++ b/.github/container/Dockerfile.jax
@@ -89,7 +89,9 @@ RUN mkdir -p /opt/pip-tools.d
 
 ## Editable installations of jax and jaxlib
 RUN <<"EOF" bash -ex
-echo "-e file://${BUILD_PATH_JAXLIB}" > /opt/pip-tools.d/requirements-jax.in
+for component in $(ls ${BUILD_PATH_JAXLIB}); do
+    echo "-e file://${BUILD_PATH_JAXLIB}/${component}" > /opt/pip-tools.d/requirements-jax.in;
+done
 echo "-e file://${SRC_PATH_JAX}" >> /opt/pip-tools.d/requirements-jax.in
 echo "numpy<2.0.0" >> /opt/pip-tools.d/requirements-jax.in
 EOF

--- a/.github/container/Dockerfile.jax
+++ b/.github/container/Dockerfile.jax
@@ -90,7 +90,7 @@ RUN mkdir -p /opt/pip-tools.d
 ## Editable installations of jax and jaxlib
 RUN <<"EOF" bash -ex
 for component in $(ls ${BUILD_PATH_JAXLIB}); do
-    echo "-e file://${BUILD_PATH_JAXLIB}/${component}" > /opt/pip-tools.d/requirements-jax.in;
+    echo "-e file://${BUILD_PATH_JAXLIB}/${component}" >> /opt/pip-tools.d/requirements-jax.in;
 done
 echo "-e file://${SRC_PATH_JAX}" >> /opt/pip-tools.d/requirements-jax.in
 echo "numpy<2.0.0" >> /opt/pip-tools.d/requirements-jax.in

--- a/.github/container/build-jax.sh
+++ b/.github/container/build-jax.sh
@@ -51,7 +51,7 @@ usage() {
 
 # Set defaults
 BAZEL_CACHE=""
-BUILD_PATH_JAXLIB="/opt/jaxlib"
+BUILD_PATH_JAXLIB="/opt/jax/dist"
 BUILD_PARAM=""
 CLEAN=0
 CLEANONLY=0
@@ -257,6 +257,7 @@ popd
 ## Build jaxlib
 mkdir -p "${BUILD_PATH_JAXLIB}"
 time python "${SRC_PATH_JAX}/build/build.py" \
+    --editable \
     --use_clang \
     --enable_cuda \
     --build_gpu_plugin \
@@ -279,6 +280,10 @@ for wheel in `ls ${BUILD_PATH_JAXLIB}/*.whl`; do
     echo -e "\n$wheel" >> build/requirements.in
 done
 
+python "${SRC_PATH_JAX}/build/build.py" \
+    --requirements_update \
+    --python_version="${PYTHON_VERSION}"
+
 PYTHON_VERSION=$(python -c 'import sys; print("{}.{}".format(*sys.version_info[:2]))')
 bazel run //build:requirements_dev.update --repo_env=HERMETIC_PYTHON_VERSION="${PYTHON_VERSION}"
 popd
@@ -294,7 +299,8 @@ else
 fi
 
 # install jaxlib
-pip --disable-pip-version-check install ${BUILD_PATH_JAXLIB}/*.whl
+for 
+pip --disable-pip-version-check install -e ${BUILD_PATH_JAXLIB}/
 
 # install jax
 if [[ "$JAXLIB_ONLY" == "0" ]]; then

--- a/.github/container/build-jax.sh
+++ b/.github/container/build-jax.sh
@@ -304,9 +304,9 @@ fi
 
 # after installation (example)
 #  jax                     0.4.32.dev20240808+9c2caedab /opt/jax
-#  jax-cuda12-pjrt         0.4.32.dev20240808           /opt/jaxlibs/jax_gpu_pjrt
-#  jax-cuda12-plugin       0.4.32.dev20240808           /opt/jaxlibs/jax_gpu_plugin
-#  jaxlib                  0.4.32.dev20240808           /opt/jaxlibs/jaxlib
+#  jax-cuda12-pjrt         0.4.32.dev20240808           /opt/jax/dist/jax_gpu_pjrt
+#  jax-cuda12-plugin       0.4.32.dev20240808           /opt/jax/dist/jax_gpu_plugin
+#  jaxlib                  0.4.32.dev20240808           /opt/jax/dist/jaxlib
 pip list | grep jax
 
 ## Cleanup

--- a/.github/container/test-jax.sh
+++ b/.github/container/test-jax.sh
@@ -134,13 +134,13 @@ case "${BATTERY}" in
         JOBS_PER_GPU=1
         JOBS=$((NGPUS * JOBS_PER_GPU))
         EXTRA_FLAGS="--local_test_jobs=${JOBS} --test_env=JAX_TESTS_PER_ACCELERATOR=${JOBS_PER_GPU} --test_env=JAX_EXCLUDE_TEST_TARGETS=PmapTest.testSizeOverflow"
-        BAZEL_TARGET="${BAZEL_TARGET} //tests:image_test_gpu //tests:scipy_stats_test_gpu"
+        BAZEL_TARGET="${BAZEL_TARGET} --@local_config_cuda//:enable_cuda //tests:image_test_gpu //tests:scipy_stats_test_gpu"
         ;;
     gpu)
         JOBS_PER_GPU=8
         JOBS=$((NGPUS * JOBS_PER_GPU))
         EXTRA_FLAGS="--local_test_jobs=${JOBS} --test_env=JAX_TESTS_PER_ACCELERATOR=${JOBS_PER_GPU} --test_env=JAX_EXCLUDE_TEST_TARGETS=PmapTest.testSizeOverflow"
-        BAZEL_TARGET="${BAZEL_TARGET} //tests:gpu_tests"
+        BAZEL_TARGET="${BAZEL_TARGET} --@local_config_cuda//:enable_cuda //tests:gpu_tests"
         ;;
     backend-independent)
         JOBS_PER_GPU=4

--- a/.github/container/test-jax.sh
+++ b/.github/container/test-jax.sh
@@ -116,6 +116,7 @@ for t in $*; do
 done
 
 COMMON_FLAGS=$(cat << EOF
+--@local_config_cuda//:enable_cuda
 --cache_test_results=${CACHE_TEST_RESULTS}
 --test_timeout=600
 --test_tag_filters=-multiaccelerator 
@@ -134,13 +135,13 @@ case "${BATTERY}" in
         JOBS_PER_GPU=1
         JOBS=$((NGPUS * JOBS_PER_GPU))
         EXTRA_FLAGS="--local_test_jobs=${JOBS} --test_env=JAX_TESTS_PER_ACCELERATOR=${JOBS_PER_GPU} --test_env=JAX_EXCLUDE_TEST_TARGETS=PmapTest.testSizeOverflow"
-        BAZEL_TARGET="${BAZEL_TARGET} --@local_config_cuda//:enable_cuda //tests:image_test_gpu //tests:scipy_stats_test_gpu"
+        BAZEL_TARGET="${BAZEL_TARGET} //tests:image_test_gpu //tests:scipy_stats_test_gpu"
         ;;
     gpu)
         JOBS_PER_GPU=8
         JOBS=$((NGPUS * JOBS_PER_GPU))
         EXTRA_FLAGS="--local_test_jobs=${JOBS} --test_env=JAX_TESTS_PER_ACCELERATOR=${JOBS_PER_GPU} --test_env=JAX_EXCLUDE_TEST_TARGETS=PmapTest.testSizeOverflow"
-        BAZEL_TARGET="${BAZEL_TARGET} --@local_config_cuda//:enable_cuda //tests:gpu_tests"
+        BAZEL_TARGET="${BAZEL_TARGET} //tests:gpu_tests"
         ;;
     backend-independent)
         JOBS_PER_GPU=4


### PR DESCRIPTION
Recently Google migrated (and completely abandoned) from jaxlib[cuda] (for instance, include CUDA backend in jaxlib) to CUDA plugin, which needs to be enabled separately along with --enable_cuda such as 
```
python build/build.py --enable_cuda --build_gpu_plugin --gpu_plugin_cuda_version=<CUDA_VERSION>.
```

It would build three wheels: 
1. jaxlib without CUDA
2. jax-cuda-plugin (for CUDA support)
3. jax-cuda-pjrt. 

They all need to be installed and added as build requirements.