### PR TITLE
Try hermetic CUDA builds (matching system installed CUDA and cuDNN version)

### DIFF
--- a/.github/container/build-jax.sh
+++ b/.github/container/build-jax.sh
@@ -168,9 +168,9 @@ export TF_CUDA_MAJOR_VERSION=$(ls /usr/local/cuda/lib64/libcudart.so.*.*.* | cut
 export TF_CUBLAS_VERSION=$(ls /usr/local/cuda/lib64/libcublas.so.*.*.* | cut -d . -f 3)
 export TF_NCCL_VERSION=$(echo "${NCCL_VERSION}" | cut -d . -f 1)
 
-TF_CUDNN_MAJOR_VERSION=$(grep "CUDNN_MAJOR" /usr/include/cudnn_version.h | awk '{print $3}')
-TF_CUDNN_MINOR_VERSION=$(grep "CUDNN_MINOR" /usr/include/cudnn_version.h | awk '{print $3}')
-TF_CUDNN_PATCHLEVEL_VERSION=$(grep "CUDNN_PATCHLEVEL" /usr/include/cudnn_version.h | awk '{print $3}')
+TF_CUDNN_MAJOR_VERSION=$(grep "#define CUDNN_MAJOR" /usr/include/cudnn_version.h | awk '{print $3}')
+TF_CUDNN_MINOR_VERSION=$(grep "#define CUDNN_MINOR" /usr/include/cudnn_version.h | awk '{print $3}')
+TF_CUDNN_PATCHLEVEL_VERSION=$(grep "#define CUDNN_PATCHLEVEL" /usr/include/cudnn_version.h | awk '{print $3}')
 export TF_CUDNN_VERSION="${TF_CUDNN_MAJOR_VERSION}.${TF_CUDNN_MINOR_VERSION}.${TF_CUDNN_PATCHLEVEL_VERSION}"
 
 case "${CPU_ARCH}" in

--- a/.github/container/build-jax.sh
+++ b/.github/container/build-jax.sh
@@ -266,7 +266,7 @@ time python "${SRC_PATH_JAX}/build/build.py" \
     --enable_cuda \
     --build_gpu_plugin \
     --gpu_plugin_cuda_version=$TF_CUDA_MAJOR_VERSION \
-    --bazel_options=--repo_env=HERMETIC_CUDA_VERSION=$TF_CUDA_VERSION \
+    --bazel_options=--repo_env=HERMETIC_CUDA_VERSION=$CUDA_VERSION \
     --bazel_options=--repo_env=HERMETIC_CUDNN_VERSION=$TF_CUDNN_VERSION \
     --cuda_compute_capabilities=$TF_CUDA_COMPUTE_CAPABILITIES \
     --enable_nccl=true \


### PR DESCRIPTION
This is only a temporary WAR to unblock the JAX and DLFW image builds. The resulting image sizes do not change, compared to the ones we built using system CUDA libs.