### PR TITLE
Makes jaxlib wheel dirs readable for non-root users

### DIFF
--- a/.github/container/build-jax.sh
+++ b/.github/container/build-jax.sh
@@ -316,6 +316,9 @@ pip --disable-pip-version-check install -e ${BUILD_PATH_JAXLIB}/jaxlib -e ${BUIL
 #  jaxlib                  0.4.32.dev20240808           /opt/jaxlibs/jaxlib
 pip list | grep jax
 
+# Ensure directories are readable by all for non-root users
+chmod 755 $BUILD_PATH_JAXLIB/*
+
 ## Cleanup
 
 pushd $SRC_PATH_JAX


### PR DESCRIPTION
Example as of 8-28-2024

```
$ docker run --entrypoint='' --rm -it ghcr.io/nvidia/jax:pax-2024-08-28 ls -lah /opt/jaxlibs total 20K
drwxr-xr-x 1 root root 4.0K Aug 28 09:43 .
drwxr-xr-x 1 root root 4.0K Aug 28 10:04 ..
drwx------ 1 root root 4.0K Aug 28 09:43 jax_gpu_pjrt
drwx------ 1 root root 4.0K Aug 28 09:43 jax_gpu_plugin
drwx------ 1 root root 4.0K Aug 28 09:43 jaxlib
```