### PR TITLE
Increase SLURM job timeout

### DIFF
--- a/.github/workflows/_runner_ondemand_slurm.yaml
+++ b/.github/workflows/_runner_ondemand_slurm.yaml
@@ -14,7 +14,7 @@ on:
       TIME:
         type: string
         description: 'SLURM time limit'
-        default: '01:00:00'
+        default: '02:00:00'
         required: true
 
 jobs:

--- a/.github/workflows/_test_te.yaml
+++ b/.github/workflows/_test_te.yaml
@@ -34,7 +34,7 @@ jobs:
       GPUS_PER_NODE: ${{ matrix.N_GPU }}
       NTASKS: 1
       NTASKS_PER_NODE: 1
-      TIME_LIMIT: '00:10:00'
+      TIME_LIMIT: '00:20:00'
       EXTRA_EXPORTS: 'VOCAB_PATH=gs://t5-data/vocabs/cc_all.32000.100extra/sentencepiece.model'
       IMAGE: ${{ inputs.TE_IMAGE }}
       SRUN_PREAMBLE: |

--- a/.github/workflows/_test_unit.yaml
+++ b/.github/workflows/_test_unit.yaml
@@ -26,7 +26,7 @@ jobs:
     with:
       NAME: "A100"
       LABELS: "A100,${{ github.run_id }}"
-      TIME: "01:00:00"
+      TIME: "02:00:00"
     secrets: inherit
 
   run-unit-test:

--- a/.github/workflows/mjx-build-test.yaml
+++ b/.github/workflows/mjx-build-test.yaml
@@ -148,7 +148,7 @@ jobs:
     with:
       NAME: "A100-${{ github.run_id }}"
       LABELS: "A100:${{ github.run_id }}"
-      TIME: "01:00:00"
+      TIME: "02:00:00"
     secrets: inherit
 
   mjx-unit-test:


### PR DESCRIPTION
There are many unit tests that are run on OCI SLURM cluster, so it's natural, that some jobs are timed out duty to amount of scheduled jobs. Need to increase time out to be able to run all jobs.