### PR TITLE
Bump clang to 18

### DIFF
--- a/.github/container/Dockerfile.base
+++ b/.github/container/Dockerfile.base
@@ -2,7 +2,7 @@
 ARG BASE_IMAGE=nvidia/cuda:12.5.0-devel-ubuntu22.04
 ARG GIT_USER_NAME="JAX Toolbox"
 ARG GIT_USER_EMAIL=jax@nvidia.com
-ARG CLANG_VERSION=17
+ARG CLANG_VERSION=18
 
 ###############################################################################
 ## Obtain GCP's NCCL TCPx plugin


### PR DESCRIPTION
Temporary WAR for this change in JAX build system: https://github.com/jax-ml/jax/pull/23787/