### PR TITLE
nsys-jax post-processing: treat host-device copies as 1-device collectives

### DIFF
--- a/.github/container/install-nsight.sh
+++ b/.github/container/install-nsight.sh
@@ -17,11 +17,12 @@ apt-get clean
 
 rm -rf /var/lib/apt/lists/*
 
-NSYS202451=/opt/nvidia/nsight-systems-cli/2024.5.1
-if [[ -d "${NSYS202451}" ]]; then
-  # * can match at least sbsa-armv8 and x86
-  (cd ${NSYS202451}/target-linux-*/python/packages && git apply < /opt/nvidia/nsys-2024.5-tid-export.patch)
-fi
+for NSYS in /opt/nvidia/nsight-systems-cli/2024.5.1 /opt/nvidia/nsight-systems-cli/2024.6.1; do
+  if [[ -d "${NSYS}" ]]; then
+    # * can match at least sbsa-armv8 and x86
+    (cd ${NSYS}/target-linux-*/python/packages && git apply < /opt/nvidia/nsys-2024.5-tid-export.patch)
+  fi
+done
 
 # Install extra dependencies needed for `nsys recipe ...` commands. These are
 # used by the nsys-jax wrapper script.

--- a/.github/container/jax_nsys/python/jax_nsys/jax_nsys/analysis.py
+++ b/.github/container/jax_nsys/python/jax_nsys/jax_nsys/analysis.py
@@ -6,7 +6,7 @@ import pandas as pd  # type: ignore
 import pathlib
 from typing import Any
 
-from .protobuf import HloInstruction, HloProto, _host_memory_space, xla_module_metadata
+from .protobuf import HloProto, _host_memory_space, xla_module_metadata
 from .utils import make_child_mask, ProfilerData
 
 pd.options.mode.copy_on_write = True
@@ -204,7 +204,7 @@ def _get_message_size(
         }
     ), f"{instruction}: message size calculation for {comm_inst.opcode} has not yet been validated"
 
-    def _byte_size(inst: HloInstruction) -> int:
+    def _byte_size(inst) -> int:
         size_bits = math.prod(
             inst.shape.dimensions,
             start=element_type_width(inst.shape.element_type),


### PR DESCRIPTION
This adds logic to treat `dynamic[-update]-slice` operations that have a source/destination operand in the host memory space as being communication operations, labelling them as single-device "collectives".

The goal is to improve support for analysing profiles of execution including offloading to host memory.

Also fix using nsys 2024.6 by applying the same patch as 2024.5 that adds the thread ID.