### PR TITLE
Do not add leading "//tests:" for given test targets

### DIFF
--- a/.github/container/test-jax.sh
+++ b/.github/container/test-jax.sh
@@ -109,9 +109,6 @@ else
 fi
 
 for t in $*; do
-    if [[ "$t" != "//tests:"* ]]; then
-        t="//tests:${t}"
-    fi
     BAZEL_TARGET="${BAZEL_TARGET} $t"
 done
 


### PR DESCRIPTION
The original logic is if the given test targets do not start with `//tests:`, then add this prefix for them.

I'm removing this logic as:
1. We don't actually see any use cases in the workflow
2. It will block us running per-directory suite targets such as `//tests/mosaic:gpu_tests`