### PR TITLE
Add extra new line before .local_cuda.bazelrc

### DIFF
--- a/.github/container/build-jax.sh
+++ b/.github/container/build-jax.sh
@@ -264,7 +264,10 @@ if [[ ! -e "/usr/local/cuda/lib" ]]; then
     ln -s /usr/local/cuda/lib64 /usr/local/cuda/lib
 fi
 
-cat > "${SRC_PATH_JAX}/.bazelrc.user" << EOF
+if ! grep 'try-import %workspace%/.local_cuda.bazelrc' "${SRC_PATH_JAX}/.bazelrc"; then
+  echo -e '\ntry-import %workspace%/.local_cuda.bazelrc' >> "${SRC_PATH_JAX}/.bazelrc"
+fi
+cat > "${SRC_PATH_JAX}/.local_cuda.bazelrc" << EOF
 build:cuda --repo_env=LOCAL_CUDA_PATH="/usr/local/cuda"
 build:cuda --repo_env=LOCAL_CUDNN_PATH="/opt/nvidia/cudnn"
 build:cuda --repo_env=LOCAL_NCCL_PATH="/opt/nvidia/nccl"

--- a/.github/container/build-jax.sh
+++ b/.github/container/build-jax.sh
@@ -264,10 +264,7 @@ if [[ ! -e "/usr/local/cuda/lib" ]]; then
     ln -s /usr/local/cuda/lib64 /usr/local/cuda/lib
 fi
 
-if ! grep 'try-import %workspace%/.local_cuda.bazelrc' "${SRC_PATH_JAX}/.bazelrc"; then
-  echo 'try-import %workspace%/.local_cuda.bazelrc' >> "${SRC_PATH_JAX}/.bazelrc"
-fi
-cat > "${SRC_PATH_JAX}/.local_cuda.bazelrc" << EOF
+cat > "${SRC_PATH_JAX}/.bazelrc.user" << EOF
 build:cuda --repo_env=LOCAL_CUDA_PATH="/usr/local/cuda"
 build:cuda --repo_env=LOCAL_CUDNN_PATH="/opt/nvidia/cudnn"
 build:cuda --repo_env=LOCAL_NCCL_PATH="/opt/nvidia/nccl"


### PR DESCRIPTION
Sometimes when there is no new line at the end of `.bazelrc` file, it will end up with `try-import %workspace%/.bazelrc.usertry-import %workspace%/.local_cuda.bazelrc`.

For example this commit did not contain a new line at the end: https://github.com/jax-ml/jax/commit/a2bc8c2e07912fac6d847423a7fbe42bdd33f42b