### PR TITLE
Install [dev] dependecies instead of [test] dependencies for gemma tests

### DIFF
--- a/.github/workflows/_ci.yaml
+++ b/.github/workflows/_ci.yaml
@@ -582,7 +582,7 @@ jobs:
       EXECUTE: |
         docker run --shm-size=1g --gpus all ${{ needs.build-gemma.outputs.DOCKER_TAG_FINAL }} \
         bash -ec \
-        "cd /opt/gemma && pip install -e .[test] && pytest ." | tee test-gemma.log
+        "cd /opt/gemma && pip install -e .[dev] && pytest ." | tee test-gemma.log
       STATISTICS_SCRIPT: |
         summary_line=$(tail -n1 test-gemma.log)
         errors=$(echo $summary_line | grep -oE '[0-9]+ error' | awk '{print $1} END { if (!NR) print 0}')


### PR DESCRIPTION
Gemma poetry installation file was changed recently (moved all [test] stuff under [dev]), so need to reflect the changes in `test-gemma` job