### PR TITLE
disable cloud logger in test-maxtext.sh

### DIFF
--- a/.github/container/test-maxtext.sh
+++ b/.github/container/test-maxtext.sh
@@ -259,6 +259,7 @@ if [ -z "$DECODER_BLOCK" ]; then
         hardware=${HARDWARE} \
         enable_goodput_recording=false \
         monitor_goodput=false \
+        enable_checkpoint_cloud_logger=false \
         dcn_fsdp_parallelism=${dcn_FSDP} \
         ici_fsdp_parallelism=${ici_FSDP} \
         ici_data_parallelism=${ici_DP} \
@@ -284,6 +285,7 @@ else
         head_dim=128 \
         logits_via_embedding=true \
         enable_checkpointing=false \
+        enable_checkpoint_cloud_logger=false \
         base_output_directory=${OUTPUT} \
         dataset_path=local \
         dataset_type=synthetic \


### PR DESCRIPTION
`enable_checkpoint_cloud_logger=true` is causing the pipelines to break. Turned off the argument in `test-maxtext.sh`