### PR TITLE
Avoid compiling non-compiling file; Bazel config does not build it

### DIFF
--- a/.github/container/Dockerfile.triton
+++ b/.github/container/Dockerfile.triton
@@ -65,6 +65,8 @@ sed -i -e 's|-Werror||g' CMakeLists.txt
 sed -i -e 's|\(LLVMAMDGPU.*\)|# \1|g' CMakeLists.txt
 # Do not build tests
 sed -i -e 's|^\s*add_subdirectory(unittest)|# unit tests disabled|' CMakeLists.txt
+# Avoid building GPUHello.cpp, which does not compile with cl693214397 of OpenXLA Triton
+sed -i -e 's|^add_subdirectory(Instrumentation)|# Instrumentation test disabled|' test/lib/CMakeLists.txt
 # Avoid error due to forward declaration of Module
 sed -i -e '/#include "llvm\/IR\/IRBuilder.h"/a #include "llvm/IR/Module.h"' test/lib/Instrumentation/GPUHello.cpp
 # Google has patches that mess with include paths in source files

--- a/.github/workflows/_ci.yaml
+++ b/.github/workflows/_ci.yaml
@@ -458,8 +458,9 @@ jobs:
         docker run -i --shm-size=1g --gpus all --volume $PWD:/output \
         ${{ needs.build-triton.outputs.DOCKER_TAG_FINAL }} \
         bash <<"EOF" |& tee test-triton.log
-          # autotuner tests from jax-triton now hit a triton code path that uses utilities from pytorch...
-          pip install --no-deps torch --index-url https://download.pytorch.org/whl/cpu
+          # autotuner tests from jax-triton now hit a triton code path that uses utilities from pytorch; this relies on
+          # actually having a CUDA backend for pytoch
+          pip install --no-deps torch
           python /opt/jax-triton/tests/triton_call_test.py --xml_output_file /output/triton_test.xml
         EOF
       STATISTICS_SCRIPT: |


### PR DESCRIPTION
- Without the first commit, `build-triton` was failing due to [this line](https://github.com/openxla/triton/blame/cl693214397/test/lib/Instrumentation/GPUHello.cpp#L64) not compiling (this file is not compiled by Bazel)
- Without the second commit, `test-triton` was failing as Triton's autotuning utilities now rely on a GPU-enabled PyTorch installation