### PR TITLE
Bump to CUDA 12.6.3

### DIFF
--- a/.github/container/Dockerfile.base
+++ b/.github/container/Dockerfile.base
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1-labs
-ARG BASE_IMAGE=nvidia/cuda:12.6.2-devel-ubuntu24.04
+ARG BASE_IMAGE=nvidia/cuda:12.6.3-devel-ubuntu24.04
 ARG GIT_USER_NAME="JAX Toolbox"
 ARG GIT_USER_EMAIL=jax@nvidia.com
 ARG CLANG_VERSION=18


### PR DESCRIPTION
This is a hotfix bump to fix the JAX `sph_harm` method due to a [known ptxas compiler bug](https://docs.nvidia.com/cuda/archive/12.6.3/cuda-toolkit-release-notes/index.html#id2).