### PR TITLE
Fix nsys-jax-archive test

### DIFF
--- a/.github/container/nsys_jax/nsys_jax/analyses/Analysis.ipynb
+++ b/.github/container/nsys_jax/nsys_jax/analyses/Analysis.ipynb
@@ -628,16 +628,17 @@
     "\n",
     "\n",
     "detailed_index = high_variance_means[high_variance_means > mean_threshold].index\n",
-    "axs[1].violinplot(\n",
-    "    list(map(durations_ms, detailed_index)),\n",
-    "    positions=np.arange(len(detailed_index)),\n",
-    "    vert=False,\n",
-    ")\n",
-    "axs[1].set_xlabel(\"Execution time [ms]\")\n",
-    "axs[1].set_yticks(\n",
-    "    np.arange(len(detailed_index)),\n",
-    "    labels=map(lambda idx: f\"{idx[1]} ({idx[0]})\", detailed_index),\n",
-    ");"
+    "if len(detailed_index):\n",
+    "    axs[1].violinplot(\n",
+    "        list(map(durations_ms, detailed_index)),\n",
+    "        positions=np.arange(len(detailed_index)),\n",
+    "        vert=False,\n",
+    "    )\n",
+    "    axs[1].set_xlabel(\"Execution time [ms]\")\n",
+    "    axs[1].set_yticks(\n",
+    "        np.arange(len(detailed_index)),\n",
+    "        labels=map(lambda idx: f\"{idx[1]} ({idx[0]})\", detailed_index),\n",
+    "    )"
    ]
   },
   {

--- a/.github/container/nsys_jax/nsys_jax/scripts/nsys_jax.py
+++ b/.github/container/nsys_jax/nsys_jax/scripts/nsys_jax.py
@@ -76,10 +76,10 @@ fi
 export NSYS_JAX_DEFAULT_PREFIX="${{PWD}}"
 # https://setuptools.pypa.io/en/latest/userguide/datafiles.html#accessing-data-files-at-runtime
 NOTEBOOK=$("${{BIN}}/python" -c 'from importlib.resources import files; print(files("nsys_jax") / "analyses" / "Analysis.ipynb")')
-if [ -z ${{NSYS_JAX_IPYTHON_NOT_JUPYTER_LAB+x}} ]; then
+if [ -z ${{NSYS_JAX_JUPYTER_EXECUTE_NOT_LAB+x}} ]; then
   CMD="${{BIN}}/jupyter-lab"
 else
-  CMD="${{BIN}}/ipython"
+  CMD="${{BIN}}/jupyter-execute"
 fi
 echo "Launching: cd ${{SCRIPT_DIR}} && ${{CMD}} ${{NOTEBOOK}}"
 cd "${{SCRIPT_DIR}}" && "${{CMD}}" "${{NOTEBOOK}}"

--- a/.github/workflows/_ci.yaml
+++ b/.github/workflows/_ci.yaml
@@ -436,7 +436,7 @@ jobs:
           chmod 755 install.sh
           # Run the notebook with IPython, not Jupyter Lab, so it exits and prints something informative to stdout
           # Skip executing Jupyter lab
-          NSYS_JAX_IPYTHON_NOT_JUPYTER_LAB=1 ./install.sh
+          NSYS_JAX_JUPYTER_EXECUTE_NOT_LAB=1 ./install.sh
           popd
         done
 


### PR DESCRIPTION
- This relies on profile data generated in CI; the test was a bit flaky because those data didn't always contain any "high variance" kernels
- Running `.ipynb` files with `ipython` on the macOS runner seems not to work; I think this slipped through when the test was first added