### PR TITLE
nsys-jax: optimise data loading and .zip creation

### DIFF
--- a/.github/container/nsys_jax/nsys_jax/__init__.py
+++ b/.github/container/nsys_jax/nsys_jax/__init__.py
@@ -7,7 +7,7 @@ from .analysis import (
 from .data_loaders import load_profiler_data
 from .protobuf import xla_module_metadata
 from .protobuf_utils import compile_protos, ensure_compiled_protos_are_importable
-from .utils import remove_autotuning_detail, remove_child_ranges
+from .utils import default_data_prefix, remove_autotuning_detail, remove_child_ranges
 from .visualization import create_flamegraph, display_flamegraph
 
 __all__ = [
@@ -16,6 +16,7 @@ __all__ = [
     "calculate_collective_metrics",
     "compile_protos",
     "create_flamegraph",
+    "default_data_prefix",
     "display_flamegraph",
     "ensure_compiled_protos_are_importable",
     "generate_compilation_statistics",

--- a/.github/container/nsys_jax/nsys_jax/analyses/Analysis.ipynb
+++ b/.github/container/nsys_jax/nsys_jax/analyses/Analysis.ipynb
@@ -12,6 +12,7 @@
     "from nsys_jax import (\n",
     "    align_profiler_data_timestamps,\n",
     "    apply_warmup_heuristics,\n",
+    "    default_data_prefix,\n",
     "    display_flamegraph,\n",
     "    ensure_compiled_protos_are_importable,\n",
     "    generate_compilation_statistics,\n",
@@ -26,13 +27,25 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "7a91f0e7-17da-4534-8ea9-29bcf3742567",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Set the input data to use. default_data_prefix() checks the NSYS_JAX_DEFAULT_PREFIX environment variable, and if that is\n",
+    "# not set then the current working directory is used. Use pathlib.Path if setting this explicitly.\n",
+    "prefix = default_data_prefix()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
    "id": "ba438edc-1912-4c18-b4b7-60c2cba24e24",
    "metadata": {},
    "outputs": [],
    "source": [
     "# Make sure that the .proto files under protos/ have been compiled to .py, and\n",
     "# that those generated .py files are importable.]\n",
-    "compiled_dir = ensure_compiled_protos_are_importable()"
+    "compiled_dir = ensure_compiled_protos_are_importable(prefix=prefix)"
    ]
   },
   {
@@ -43,7 +56,7 @@
    "outputs": [],
    "source": [
     "# Load the runtime profile data\n",
-    "all_data = load_profiler_data()\n",
+    "all_data = load_profiler_data(prefix)\n",
     "# Remove some detail from the autotuner\n",
     "all_data = remove_autotuning_detail(all_data)\n",
     "# Align GPU timestamps across profiles collected by different Nsight Systems processes\n",
@@ -82,7 +95,7 @@
    "source": [
     "This data frame has a three-level index:\n",
     "- `ProgramId` is an integer ID that uniquely identifies the XLA module\n",
-    "- This is the `ProgramExecution`-th execution of the module within the profiles. You may see this starting from 1, not 0, because of the `warmup_removal_heuristics` option passed to `load_profiler_data`.\n",
+    "- This is the `ProgramExecution`-th execution of the module within the profiles. You may see this starting from 2, not 0, because of the `warmup_removal_heuristics` option passed to `load_profiler_data`.\n",
     "- `Device` is the global (across multiple nodes and processes) index of the GPU on which the module execution took place\n",
     "\n",
     "The columns are as follows:\n",
@@ -90,8 +103,6 @@
     "- `NumThunks`: the number of thunks executed inside this module execution\n",
     "- `ProjStartMs`: the timestamp of the start of the module execution on the GPU, in milliseconds\n",
     "- `ProjDurMs`: the duration of the module execution on the GPU, in milliseconds\n",
-    "- `OrigStartMs`: the timestamp of the start of the module launch **on the host**, in milliseconds. *i.e.* `ProjStartMs-OrigStartMs` is something like the launch latency of the first kernel\n",
-    "- `OrigDurMs`: the duration of the module launch **on the host**, in milliseconds\n",
     "- `LocalDevice`: the index within the node/slice of the GPU on which the module execution took place\n",
     "- `Process`: the global (across multiple nodes) index of the process\n",
     "- `Slice`: the global index of the node/slice; devices within the same node/slice should have faster interconnects than to devices in different slices\n",
@@ -117,13 +128,13 @@
    "id": "7727d800-13d3-4505-89e8-80a5fed63512",
    "metadata": {},
    "source": [
-    "Here the index has four levels. `ProgramId`, `ProgramExecution` and `Device` have the same meanings as in `module_df`.\n",
+    "Here the index has four levels. `ProgramId`, `ProgramExecution` and `Device` have the same meanings as in `steady_state.module`.\n",
     "The fourth level (in the 3rd position) shows that this row is the `ThunkIndex`-th thunk within the `ProgramExecution`-th execution of XLA module `ProgramId`.\n",
     "Note that a given thunk can be executed multiple times within the same module, so indexing on the thunk name would not be unique.\n",
     "\n",
     "The columns are as follows:\n",
     "- `Name`: the name of the thunk; this should be unique within a given `ProgramId` and can be used as a key to look up XLA metadata\n",
-    "- `ProjStartMs`, `OrigStartMs`, `OrigDurMs`: see above, same meaning as in `module_df`.\n",
+    "- `ProjStartMs`: see above, same meaning as in `steady_state.module`.\n",
     "- `Communication`: does this thunk represent communication between GPUs (*i.e.* a NCCL collective)? XLA overlaps communication and computation kernels, and `load_profiler_data` triggers an overlap calculation. `ProjDurMs` for a communication kernel shows only the duration that was **not** overlapped with computation kernels, while `ProjDurHiddenMs` shows the duration that **was** overlapped.\n",
     "- This is the `ThunkExecution`-th execution of this thunk for this `(ProgramId, ProgramExecution, Device)`\n",
     "\n",
@@ -299,7 +310,7 @@
     "# Print out the largest entries adding up to at least this fraction of the total\n",
     "threshold = 0.97\n",
     "compile_summary[\"FracNonChild\"] = compile_summary[\"DurNonChildMs\"] / total_compile_time\n",
-    "print(f\"Top {threshold:.0%}+ of {total_compile_time * 1e-9:.2f}s compilation time\")\n",
+    "print(f\"Top {threshold:.0%}+ of {total_compile_time*1e-3:.2f}s compilation time\")\n",
     "for row in compile_summary[\n",
     "    compile_summary[\"FracNonChild\"].cumsum() <= threshold\n",
     "].itertuples():\n",
@@ -378,7 +389,7 @@
     "    program_id, thunk_name = thunk_row.Index\n",
     "    # policy=\"all\" means we may get a set of HloProto instead of a single one, if\n",
     "    # nsys-jax-combine was used and the dumped metadata were not bitwise identical\n",
-    "    hlo_modules = xla_module_metadata(program_id, policy=\"all\")\n",
+    "    hlo_modules = xla_module_metadata(program_id, policy=\"all\", prefix=prefix)\n",
     "    thunk_opcode, inst_metadata, inst_frames = hlo_modules.unique_result(\n",
     "        lambda proto: instructions_and_frames(proto, thunk_name)\n",
     "    )\n",

--- a/.github/container/nsys_jax/nsys_jax/analyses/Analysis.ipynb
+++ b/.github/container/nsys_jax/nsys_jax/analyses/Analysis.ipynb
@@ -310,7 +310,7 @@
     "# Print out the largest entries adding up to at least this fraction of the total\n",
     "threshold = 0.97\n",
     "compile_summary[\"FracNonChild\"] = compile_summary[\"DurNonChildMs\"] / total_compile_time\n",
-    "print(f\"Top {threshold:.0%}+ of {total_compile_time*1e-3:.2f}s compilation time\")\n",
+    "print(f\"Top {threshold:.0%}+ of {total_compile_time * 1e-3:.2f}s compilation time\")\n",
     "for row in compile_summary[\n",
     "    compile_summary[\"FracNonChild\"].cumsum() <= threshold\n",
     "].itertuples():\n",

--- a/.github/container/nsys_jax/nsys_jax/analysis.py
+++ b/.github/container/nsys_jax/nsys_jax/analysis.py
@@ -286,17 +286,8 @@ def get_message_size(
     of the semantics. This implementation aims to follow the same conventions that NCCL
     uses in its NVTX payloads and tests.
     """
-    return pd.Series(
-        xla_module_metadata(program_id, prefix=prefix, policy="all").unique_result(
-            lambda proto: _get_message_size(proto, instruction)
-        ),
-        index=[
-            "MessageSize",
-            "Collective",
-            "CollectiveSize",
-            "BandwidthCorrection",
-            "BusBandwidthCorrection",
-        ],
+    return xla_module_metadata(program_id, prefix=prefix, policy="all").unique_result(
+        lambda proto: _get_message_size(proto, instruction)
     )
 
 
@@ -311,13 +302,26 @@ def calculate_collective_metrics(
     comm_df = thunk_df[thunk_df["Communication"]].drop(columns=["Communication"])
     if len(comm_df) == 0:
         return comm_df
+
+    def body(tup):
+        idx, name = tup
+        return get_message_size(idx[0], name, prefix=prefix)
+
+    metrics_df = pd.DataFrame.from_records(
+        map(body, comm_df["Name"].items()),
+        columns=[
+            "MessageSize",
+            "Collective",
+            "CollectiveSize",
+            "BandwidthCorrection",
+            "BusBandwidthCorrection",
+        ],
+        index=comm_df.index,
+    )
     comm_df = pd.concat(
         [
             comm_df,
-            comm_df.apply(
-                lambda row: get_message_size(row.name[0], row.Name, prefix=prefix),
-                axis=1,
-            ),
+            metrics_df,
         ],
         axis=1,
     )

--- a/.github/container/nsys_jax/nsys_jax/data_loaders.py
+++ b/.github/container/nsys_jax/nsys_jax/data_loaders.py
@@ -181,8 +181,8 @@ def _load_nvtx_gpu_proj_trace_single(
     except ValueError:
         print(
             "A duplicate key related error may indicate that you are using "
-            "Nsight Systems 2024.5 and have CUDA graphs enabled; as noted on "
-            "https://github.com/NVIDIA/JAX-Toolbox/blob/main/docs/profiling.md "
+            "Nsight Systems 2024.5 or 2024.6 and have CUDA graphs enabled; as noted "
+            "on https://github.com/NVIDIA/JAX-Toolbox/blob/main/docs/profiling.md "
             "you may want to disable CUDA graphs by adding "
             "--xla_gpu_enable_command_buffer= to the XLA_FLAGS environment "
             "variable."

--- a/.github/container/nsys_jax/nsys_jax/data_loaders.py
+++ b/.github/container/nsys_jax/nsys_jax/data_loaders.py
@@ -624,19 +624,19 @@ def _load_nvtx_pushpop_trace_single(name: pathlib.Path) -> pd.DataFrame:
     # Because the ProgramId and ProgramName ranges provide the same information,
     # remove those fields from the compilation range names.
     def remove_program_id_and_name(row):
-        row.Name = (
+        return (
             row.Name.removeprefix("TSL:")
             .replace(f",program_id={row.ProgramId}", "")
             .replace(f",module={row.ProgramName}", "")
             .replace(f":#module={row.ProgramName}#", "")
         )
-        return row
 
-    return (
-        compile_df.drop(columns=["EndMs"])
-        .astype({"ProgramId": np.int32})
-        .transform(remove_program_id_and_name, axis="columns")
-    )
+    compile_df = compile_df.drop(columns=["EndMs"]).astype({"ProgramId": np.int32})
+    if len(compile_df):
+        compile_df["Name"] = compile_df.apply(
+            remove_program_id_and_name, axis="columns"
+        )
+    return compile_df
 
 
 def _load_nvtx_pushpop_trace(prefix: pathlib.Path, frames: set[str]) -> pd.DataFrame:

--- a/.github/container/nsys_jax/nsys_jax/scripts/nsys_jax.py
+++ b/.github/container/nsys_jax/nsys_jax/scripts/nsys_jax.py
@@ -371,7 +371,7 @@ def main() -> None:
                 continue
             output_queue.put((ofile, full_path, COMPRESS_NONE))
         print(
-            f"{archive_name}: recipe post-processing finished in {time.time()-start:.2f}s"
+            f"{archive_name}: recipe post-processing finished in {time.time() - start:.2f}s"
         )
 
     def compress_and_archive(prefix, file, output_queue):
@@ -425,7 +425,7 @@ def main() -> None:
             # If there's no data, don't write a file to the output at all
             pass
         print(
-            f"{archive_name}: stats post-processing finished in {time.time()-start:.2f}s"
+            f"{archive_name}: stats post-processing finished in {time.time() - start:.2f}s"
         )
 
     def save_device_stream_thread_names(tmp_dir, report, output_queue):

--- a/.github/container/nsys_jax/nsys_jax/visualization.py
+++ b/.github/container/nsys_jax/nsys_jax/visualization.py
@@ -1,6 +1,5 @@
-from IPython.display import display, IFrame
+from typing import Any, Iterable
 import subprocess
-from typing import Iterable
 import xml.etree.ElementTree
 
 from .protobuf_utils import which
@@ -8,7 +7,7 @@ from .protobuf_utils import which
 
 def create_flamegraph(
     data: dict[Iterable[str], float], title: str, filename: str, width: int = 1200
-) -> tuple[str, IFrame]:
+) -> tuple[str, Any]:
     """
     Given a data structure of the form
       {
@@ -26,6 +25,8 @@ def create_flamegraph(
     Returns a tuple (svg_data, InlineIFrame), where the latter can be passed to
     IPython.display.display(...) to be rendered inline in a Jupyter notebook.
     """
+    from IPython.display import IFrame
+
     flat_data = ""
     for loc, value in data.items():
         assert not any(";" in x for x in loc)
@@ -50,5 +51,7 @@ def create_flamegraph(
 
 
 def display_flamegraph(**kwargs):
+    from IPython.display import display
+
     svg, iframe = create_flamegraph(**kwargs)
     display(iframe)

--- a/.github/container/nsys_jax/tests/test_df_helpers.py
+++ b/.github/container/nsys_jax/tests/test_df_helpers.py
@@ -1,0 +1,25 @@
+from nsys_jax.data_loaders import _find_overlapped as find_overlapped
+import pandas as pd  # type: ignore
+import pytest  # type: ignore
+
+
+@pytest.mark.parametrize(
+    "records,expected",
+    [
+        # no overlap
+        ([], []),
+        [[(0, 1)], []],
+        [[(0, 1), (1, 2)], []],
+        # overlap
+        [[(0, 1), (0.5, 1.5)], [0, 1]],
+        ([(0, 1), (0.5, 1.5), (8, 9), (9, 10)], [0, 1]),
+        ([(0, 1), (2, 3), (2.5, 3.5), (3, 4), (5, 6)], [1, 2, 3]),
+        ([(0, 1), (0.5, 1.5), (2, 3), (4.5, 5.5), (5, 6)], [0, 1, 3, 4]),
+        # overlap between non-neighbouring ranges
+        ([(0, 3), (0.1, 1), (2, 4), (5, 6)], [0, 1, 2]),  # 0-1, 0-2 overlap but not 1-2
+    ],
+)
+def test_find_overlapped(records, expected):
+    df = pd.DataFrame.from_records(records, columns=["start", "end"])
+    result = find_overlapped(df["start"], df["end"])
+    assert list(result) == expected

--- a/.github/workflows/_ci.yaml
+++ b/.github/workflows/_ci.yaml
@@ -322,7 +322,9 @@ jobs:
         set -o pipefail
         num_tests=0
         num_failures=0
-        # Run the pytest-driven tests
+        # Run the pytest-driven tests; failure is explicitly handled below so set +e to
+        # avoid an early abort here.
+        set +e
         docker run -i --shm-size=1g --gpus all \
           -v $PWD:/opt/output \
           ${{ needs.build-jax.outputs.DOCKER_TAG_FINAL }} \
@@ -333,6 +335,7 @@ jobs:
             test_path=$(python -c 'import importlib.resources; print(importlib.resources.files("nsys_jax").joinpath("..", "tests").resolve())')
             pytest --report-log=/opt/output/pytest-report.jsonl "${test_path}"
         EOF
+        set -e
         GPUS_PER_NODE=$(nvidia-smi -L | grep -c '^GPU')
         for mode in 1-process 2-process process-per-gpu; do
           DOCKER="docker run --shm-size=1g --gpus all --env XLA_FLAGS=--xla_gpu_enable_command_buffer= --env XLA_PYTHON_CLIENT_MEM_FRACTION=0.9 -v ${PWD}:/opt/output ${{ needs.build-jax.outputs.DOCKER_TAG_FINAL }}"


### PR DESCRIPTION
Some rough measurements on vanilla `jax-nccl-test` and 8xH100:

> Profile collection, whole execution: 52s (nsys), 58s (nsys-jax with this PR), 1m5s (nsys-jax without this PR)
> Profile collection, restricted range: 46s (nsys), 50s (nsys-jax with this PR), 55s (nsys-jax without this PR)
> Communication analysis, whole execution: 1.1s (with this PR), 2.1s (without this PR)
> Communication analysis, restricted range: 1.0s (with this PR), 1.7s (without this PR)

The differences are more pronounced on larger workloads with more activity.

The two bigger changes are:
- Convert `.csv` to `.parquet` as part of `nsys-jax` to avoid compressing `.csv` with Python's `lzma` module, which is slow and single-threaded. This speeds up `nsys-jax` *and* subsequent data-loading.
- A new algorithm for calculating the hidden/exposed time of communication kernels when loading profile data -- essentially this adds a fast pandas-friendly pass to identify [most] non-overlapping kernels and skip running the [relatively slow and pandas-unfriendly] overlap calculation on them. This also removes an assumption that there is no compute-compute overlap.

Otherwise there are some tweaks to pandas usage and minor reorganisations to make Python profiles more informative, and minor bugfixes in the example Jupyter notebook.