### PR TITLE
fix t5x tests

### DIFF
--- a/.github/container/test-t5x.sh
+++ b/.github/container/test-t5x.sh
@@ -175,10 +175,10 @@ seqio.TaskRegistry.add(
     ],
     output_features=dict(
         inputs=seqio.Feature(
-            vocabulary=t5.data.get_default_vocabulary(), add_eos=True, required=False
+            vocabulary=seqio.SentencePieceVocabulary(sentencepiece_model_file="gs://t5-data/vocabs/cc_all.32000.100extra/sentencepiece.model"), add_eos=True, required=False
         ),
         targets=seqio.Feature(
-            vocabulary=t5.data.get_default_vocabulary(), add_eos=True
+            vocabulary=seqio.SentencePieceVocabulary(sentencepiece_model_file="gs://t5-data/vocabs/cc_all.32000.100extra/sentencepiece.model"), add_eos=True
         )
     ),
     metric_fns=[]


### PR DESCRIPTION
T5X tests are failing because the vocabulary specified in the dummy dataset does not match the vocabulary used by the model: https://github.com/google-research/t5x/blob/5f03619b0c5ebb44ae6adde1a2d8eea1a4b55fe0/t5x/examples/t5/t5_1_1/base.gin#L20-L21. This PR updates the dataset vocab to make it match the model's.