### PR TITLE
Add configuration for bazel 

### DIFF
--- a/.github/container/Dockerfile.jax
+++ b/.github/container/Dockerfile.jax
@@ -127,3 +127,6 @@ EOF
 
 FROM mealkit AS final
 RUN pip-finalize.sh
+
+# Bazelrc file configuration 
+RUN python ${SRC_PATH_XLA}/configure.py --backend cuda --cuda_compiler clang


### PR DESCRIPTION
This PR adds bazel's configuration step directly in the JAX container, so developers won't have to run it. 
In particular, this is to avoid having devs experiencing problems such as: 
```
RROR: /opt/xla/xla/service/gpu/kernels/BUILD:170:19: Compiling xla/service/gpu/kernels/topk_kernel_float.cu.cc failed: (Exit 1): crosstool_wrapper_driver_is_not_gcc failed: error executing command (from target //xla/service/gpu/kernels:topk_kernel_gpu_cuda) external/local_config_cuda/crosstool/clang/bin/crosstool_wrapper_driver_is_not_gcc -MD -MF bazel-out/k8-opt/bin/xla/service/gpu/kernels/_objs/topk_kernel_gpu_cuda/topk_kernel_float.cu.d ... (remaining 207 arguments skipped)
/root/.cache/bazel/_bazel_root/172c56c881f24dddf5d15d4e92df59d7/execroot/xla/external/local_config_cuda/crosstool/clang/bin/crosstool_wrapper_driver_is_not_gcc:227: SyntaxWarning: invalid escape sequence '\.'
  re.search('\.cpp$|\.cc$|\.c$|\.cxx$|\.C$', f)]
nvcc fatal   : Unsupported gpu architecture 'compute_100'
Target //xla/tools/multihost_hlo_runner:hlo_runner_main failed to build
Use --verbose_failures to see the command lines of failed build steps.
```

As @sergachev suggested, this problem can be solved by running the configuration with `clang` as: 
``python /opt/xla/configure.py --backend cuda --cuda_compiler clang`

