### PR TITLE
Temporarily disable 2-node tests

### DIFF
--- a/.github/workflows/_test_maxtext.yaml
+++ b/.github/workflows/_test_maxtext.yaml
@@ -183,7 +183,8 @@ jobs:
         - [1, 1, 1, 8]
         - [1, 1, 4, 2]
         - [1, 2, 2, 2]
-        - [1, 4, 2, 2]
+        # 2-node config temporarily disabled
+        # - [1, 4, 2, 2]
       fail-fast: false
     runs-on: jumpbox
     steps:

--- a/.github/workflows/_test_pax_rosetta.yaml
+++ b/.github/workflows/_test_pax_rosetta.yaml
@@ -232,10 +232,11 @@ jobs:
             PARALLEL_CONFIG: [1, 4, 1, 2]
             BATCH_SIZE: 4
             ADDITIONAL_ARGS: ""
-          - TEST_NAME: 16DP1FSDP1TP1PP_TE
-            PARALLEL_CONFIG: [1, 16, 1, 1]
-            BATCH_SIZE: 4
-            ADDITIONAL_ARGS: ""
+          # 2-node config temporarily disabled
+          # - TEST_NAME: 16DP1FSDP1TP1PP_TE
+          #   PARALLEL_CONFIG: [1, 16, 1, 1]
+          #   BATCH_SIZE: 4
+          #   ADDITIONAL_ARGS: ""
           - TEST_NAME: 5B_fused_attn_1
             PARALLEL_CONFIG: [1, 1, 8, 1]
             BATCH_SIZE: 2
@@ -446,7 +447,8 @@ jobs:
         - [1, 8, 1, 1]
         - [1, 4, 1, 2]
         - [4, 2, 1, 1]
-        - [4, 2, 1, 2]
+        # 2-node config temporarily disabled
+        # - [4, 2, 1, 2]
       fail-fast: false
     runs-on: jumpbox
     env:

--- a/.github/workflows/_test_t5x_rosetta.yaml
+++ b/.github/workflows/_test_t5x_rosetta.yaml
@@ -218,201 +218,202 @@ jobs:
           name: ${{ steps.meta.outputs.JOB_NAME }}
           path: output/*
 
-  multi-gpu-multi-node:
-    strategy:
-      max-parallel: 1
-      matrix:
-        include:
-          - TEST_NAME: "2N8G-te-1"
-            N_GPU: 8
-            N_NODE: 2
-            ADDITIONAL_ARGS: ""
-            EXTRA_GIN_ARGS: "--gin.train/utils.DatasetConfig.pack=False --gin.train_eval/utils.DatasetConfig.pack=False"
-          - TEST_NAME: "2N2G_te-0"
-            N_GPU: 2
-            N_NODE: 2
-            ADDITIONAL_ARGS: "--enable-te 0"
-            EXTRA_GIN_ARGS: ""
-      fail-fast: false
-    runs-on: jumpbox
-    env:
-      BADGE_FILENAME_PREFIX: badge-rosetta-t5x-multi-gpu-multi-node
-    steps:
-      - name: Print environment variables
-        run: env
+  # 2-node configs temporarily disabled
+  # multi-gpu-multi-node:
+  #   strategy:
+  #     max-parallel: 1
+  #     matrix:
+  #       include:
+  #         - TEST_NAME: "2N8G-te-1"
+  #           N_GPU: 8
+  #           N_NODE: 2
+  #           ADDITIONAL_ARGS: ""
+  #           EXTRA_GIN_ARGS: "--gin.train/utils.DatasetConfig.pack=False --gin.train_eval/utils.DatasetConfig.pack=False"
+  #         - TEST_NAME: "2N2G_te-0"
+  #           N_GPU: 2
+  #           N_NODE: 2
+  #           ADDITIONAL_ARGS: "--enable-te 0"
+  #           EXTRA_GIN_ARGS: ""
+  #     fail-fast: false
+  #   runs-on: jumpbox
+  #   env:
+  #     BADGE_FILENAME_PREFIX: badge-rosetta-t5x-multi-gpu-multi-node
+  #   steps:
+  #     - name: Print environment variables
+  #       run: env
 
-      - name: Check out the repository under ${GITHUB_WORKSPACE}
-        uses: actions/checkout@v4
+  #     - name: Check out the repository under ${GITHUB_WORKSPACE}
+  #       uses: actions/checkout@v4
 
-      - name: Setup SSH agent
-        uses: webfactory/ssh-agent@v0.9.0
-        with:
-          ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
+  #     - name: Setup SSH agent
+  #       uses: webfactory/ssh-agent@v0.9.0
+  #       with:
+  #         ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
 
-      - name: Setup SSH known hosts
-        id: ssh-known-hosts
-        run: |
-          mkdir -p ~/.ssh
-          cat >> ~/.ssh/known_hosts << EOF
-          ${{ vars.SSH_KNOWN_HOSTS }}
-          EOF
-          chmod 600 ~/.ssh/known_hosts
-          echo "FILE=$(realpath ~/.ssh/known_hosts)" >> $GITHUB_OUTPUT
+  #     - name: Setup SSH known hosts
+  #       id: ssh-known-hosts
+  #       run: |
+  #         mkdir -p ~/.ssh
+  #         cat >> ~/.ssh/known_hosts << EOF
+  #         ${{ vars.SSH_KNOWN_HOSTS }}
+  #         EOF
+  #         chmod 600 ~/.ssh/known_hosts
+  #         echo "FILE=$(realpath ~/.ssh/known_hosts)" >> $GITHUB_OUTPUT
 
-      - name: Labels and metadata
-        id: meta
-        shell: bash -x -e {0}
-        run: |
-          IMAGE="$(echo ${{inputs.T5X_IMAGE}} | sed 's/\//#/')"
-          TEST_CASE_NAME=${{ matrix.TEST_NAME }}
-          TOTAL_TASKS=$((${{ matrix.N_GPU }} * ${{ matrix.N_NODE }}))
-          JOB_NAME=${{ inputs.FW_NAME }}-${GITHUB_RUN_ID}-${TEST_CASE_NAME}
-          LOG_FILE=/nfs/cluster/${JOB_NAME}.log
-          MODEL_PATH=/nfs/cluster/${JOB_NAME}
-          BATCH_SIZE=$((${{ env.BATCH_SIZE_PER_GPU }} * ${{ matrix.N_GPU }} * ${{ matrix.N_NODE }}))
-          for var in IMAGE TEST_CASE_NAME TOTAL_TASKS JOB_NAME LOG_FILE MODEL_PATH BATCH_SIZE; do
-            echo "$var=${!var}" >> $GITHUB_OUTPUT
-          done
+  #     - name: Labels and metadata
+  #       id: meta
+  #       shell: bash -x -e {0}
+  #       run: |
+  #         IMAGE="$(echo ${{inputs.T5X_IMAGE}} | sed 's/\//#/')"
+  #         TEST_CASE_NAME=${{ matrix.TEST_NAME }}
+  #         TOTAL_TASKS=$((${{ matrix.N_GPU }} * ${{ matrix.N_NODE }}))
+  #         JOB_NAME=${{ inputs.FW_NAME }}-${GITHUB_RUN_ID}-${TEST_CASE_NAME}
+  #         LOG_FILE=/nfs/cluster/${JOB_NAME}.log
+  #         MODEL_PATH=/nfs/cluster/${JOB_NAME}
+  #         BATCH_SIZE=$((${{ env.BATCH_SIZE_PER_GPU }} * ${{ matrix.N_GPU }} * ${{ matrix.N_NODE }}))
+  #         for var in IMAGE TEST_CASE_NAME TOTAL_TASKS JOB_NAME LOG_FILE MODEL_PATH BATCH_SIZE; do
+  #           echo "$var=${!var}" >> $GITHUB_OUTPUT
+  #         done
 
-      - name: Submit SLURM jobs over SSH
-        id: submit
-        shell: bash -O expand_aliases -x -e {0}
-        run: |
-          cd $GITHUB_WORKSPACE
-          alias sshx='ssh -o "ServerAliveInterval 7" ${{ secrets.CLUSTER_LOGIN_USER }}@${{ vars.HOSTNAME_SLURM_LOGIN }}'
-          sshx "date && hostname && sinfo"
-          sshx mkdir -p ${{ steps.meta.outputs.MODEL_PATH }}
-          JOB=$(sshx sbatch --parsable << EOF
-          #!/bin/bash
-          #SBATCH --job-name=${{ steps.meta.outputs.JOB_NAME }}
-          #SBATCH --exclusive
-          #SBATCH --nodes=${{ matrix.N_NODE }}
-          #SBATCH --gpus-per-node=${{ matrix.N_GPU }}
-          #SBATCH --time=00:30:00
-          #SBATCH --output=${{ steps.meta.outputs.LOG_FILE }}
-          #SBATCH --export="ENROOT_PASSWORD=${{ secrets.GITHUB_TOKEN }}"
+  #     - name: Submit SLURM jobs over SSH
+  #       id: submit
+  #       shell: bash -O expand_aliases -x -e {0}
+  #       run: |
+  #         cd $GITHUB_WORKSPACE
+  #         alias sshx='ssh -o "ServerAliveInterval 7" ${{ secrets.CLUSTER_LOGIN_USER }}@${{ vars.HOSTNAME_SLURM_LOGIN }}'
+  #         sshx "date && hostname && sinfo"
+  #         sshx mkdir -p ${{ steps.meta.outputs.MODEL_PATH }}
+  #         JOB=$(sshx sbatch --parsable << EOF
+  #         #!/bin/bash
+  #         #SBATCH --job-name=${{ steps.meta.outputs.JOB_NAME }}
+  #         #SBATCH --exclusive
+  #         #SBATCH --nodes=${{ matrix.N_NODE }}
+  #         #SBATCH --gpus-per-node=${{ matrix.N_GPU }}
+  #         #SBATCH --time=00:30:00
+  #         #SBATCH --output=${{ steps.meta.outputs.LOG_FILE }}
+  #         #SBATCH --export="ENROOT_PASSWORD=${{ secrets.GITHUB_TOKEN }}"
 
-          # preload enroot container using one task per node
-          time srun \
-            --ntasks-per-node=1 \
-            --container-name=runtime \
-            --container-image=${{ steps.meta.outputs.IMAGE }} \
-            true
+  #         # preload enroot container using one task per node
+  #         time srun \
+  #           --ntasks-per-node=1 \
+  #           --container-name=runtime \
+  #           --container-image=${{ steps.meta.outputs.IMAGE }} \
+  #           true
 
-          # run job with tasks on each node sharing one container
-          time srun \
-            --ntasks=${{ steps.meta.outputs.TOTAL_TASKS }} \
-            --ntasks-per-node=${{ matrix.N_GPU }} \
-            --container-name=runtime \
-            --container-mounts=${{ steps.meta.outputs.MODEL_PATH }}:/output \
-            --container-entrypoint \
-            bash -c 'wget -P /tmp/ https://raw.githubusercontent.com/NVIDIA/JAX-Toolbox/${{ github.sha }}/.github/container/test-t5x.sh && sleep 10 && bash /tmp/test-t5x.sh \
-              --output /output/${{ steps.meta.outputs.TEST_CASE_NAME }} \
-              --dtype bfloat16 \
-              --batch-size ${{ steps.meta.outputs.BATCH_SIZE }} \
-              --epochs 7 \
-              --steps-per-epoch 100 \
-              --multiprocess \
-              --use-contrib-configs \
-              ${{ matrix.ADDITIONAL_ARGS }} \
-              ${{ matrix.EXTRA_GIN_ARGS != '' && format('--additional-args "{0}"', matrix.EXTRA_GIN_ARGS) || '' }}'
-          EOF
-          )
+  #         # run job with tasks on each node sharing one container
+  #         time srun \
+  #           --ntasks=${{ steps.meta.outputs.TOTAL_TASKS }} \
+  #           --ntasks-per-node=${{ matrix.N_GPU }} \
+  #           --container-name=runtime \
+  #           --container-mounts=${{ steps.meta.outputs.MODEL_PATH }}:/output \
+  #           --container-entrypoint \
+  #           bash -c 'wget -P /tmp/ https://raw.githubusercontent.com/NVIDIA/JAX-Toolbox/${{ github.sha }}/.github/container/test-t5x.sh && sleep 10 && bash /tmp/test-t5x.sh \
+  #             --output /output/${{ steps.meta.outputs.TEST_CASE_NAME }} \
+  #             --dtype bfloat16 \
+  #             --batch-size ${{ steps.meta.outputs.BATCH_SIZE }} \
+  #             --epochs 7 \
+  #             --steps-per-epoch 100 \
+  #             --multiprocess \
+  #             --use-contrib-configs \
+  #             ${{ matrix.ADDITIONAL_ARGS }} \
+  #             ${{ matrix.EXTRA_GIN_ARGS != '' && format('--additional-args "{0}"', matrix.EXTRA_GIN_ARGS) || '' }}'
+  #         EOF
+  #         )
 
-          echo "SLURM_JOB_ID=${JOB}" >> $GITHUB_OUTPUT
+  #         echo "SLURM_JOB_ID=${JOB}" >> $GITHUB_OUTPUT
 
-          . .github/workflows/scripts/wait_for_slurm_job.sh
+  #         . .github/workflows/scripts/wait_for_slurm_job.sh
 
-          wait_for_slurm_job ${{ secrets.CLUSTER_LOGIN_USER }}@${{ vars.HOSTNAME_SLURM_LOGIN }} ${JOB}
+  #         wait_for_slurm_job ${{ secrets.CLUSTER_LOGIN_USER }}@${{ vars.HOSTNAME_SLURM_LOGIN }} ${JOB}
 
-          # Gather job info
-          SLURM_STATE=$(sshx sacct -j $JOB --format=State --parsable2 --noheader |& head -n 1)
-          SLURM_EXITCODE=$(sshx sacct -j $JOB --format=exitcode --parsable2 --noheader | sort -r -u | head -1 | cut -f 1 -d":" | sed 's/ //g')
-          echo "SLURM Job state is ${SLURM_STATE}"
-          echo "SLURM Job exit code is ${SLURM_EXITCODE}"
-          echo "SLURM_STATE=${SLURM_STATE}" >> "$GITHUB_OUTPUT"
-          echo "SLURM_EXITCODE=${SLURM_EXITCODE}" >> "$GITHUB_OUTPUT"
+  #         # Gather job info
+  #         SLURM_STATE=$(sshx sacct -j $JOB --format=State --parsable2 --noheader |& head -n 1)
+  #         SLURM_EXITCODE=$(sshx sacct -j $JOB --format=exitcode --parsable2 --noheader | sort -r -u | head -1 | cut -f 1 -d":" | sed 's/ //g')
+  #         echo "SLURM Job state is ${SLURM_STATE}"
+  #         echo "SLURM Job exit code is ${SLURM_EXITCODE}"
+  #         echo "SLURM_STATE=${SLURM_STATE}" >> "$GITHUB_OUTPUT"
+  #         echo "SLURM_EXITCODE=${SLURM_EXITCODE}" >> "$GITHUB_OUTPUT"
 
-          set -x
+  #         set -x
 
-      - name: Remove orphaned SLURM job if the CI job is canceled
-        if: cancelled()
-        shell: bash -x -e {0}
-        run: |
-          ssh ${{ secrets.CLUSTER_LOGIN_USER }}@${{ vars.HOSTNAME_SLURM_LOGIN }} \
-            scancel ${{ steps.submit.outputs.SLURM_JOB_ID }}
+  #     - name: Remove orphaned SLURM job if the CI job is canceled
+  #       if: cancelled()
+  #       shell: bash -x -e {0}
+  #       run: |
+  #         ssh ${{ secrets.CLUSTER_LOGIN_USER }}@${{ vars.HOSTNAME_SLURM_LOGIN }} \
+  #           scancel ${{ steps.submit.outputs.SLURM_JOB_ID }}
 
-      - name: Retrieve training logs and upload to TensorBoard server
-        shell: bash -x -e {0}
-        run: |
-          cd $GITHUB_WORKSPACE
-          mkdir output/
-          rsync -rtz --progress \
-            ${{ secrets.CLUSTER_LOGIN_USER }}@${{ vars.HOSTNAME_SLURM_LOGIN }}:${{ steps.meta.outputs.LOG_FILE }} \
-            output/${{ steps.meta.outputs.TEST_CASE_NAME }}.log || true
-          rsync -rtz --progress \
-            ${{ secrets.CLUSTER_LOGIN_USER }}@${{ vars.HOSTNAME_SLURM_LOGIN }}:${{ steps.meta.outputs.MODEL_PATH }}/* \
-            output/ || true
-          rsync -rtz --progress \
-            output/ \
-            ${{ secrets.TENSORBOARD_UPLOAD_USER }}@${{ vars.HOSTNAME_TENSORBOARD }}:/tensorboard-logs/${{ inputs.FW_NAME }}-${GITHUB_RUN_ID}/ || true
+  #     - name: Retrieve training logs and upload to TensorBoard server
+  #       shell: bash -x -e {0}
+  #       run: |
+  #         cd $GITHUB_WORKSPACE
+  #         mkdir output/
+  #         rsync -rtz --progress \
+  #           ${{ secrets.CLUSTER_LOGIN_USER }}@${{ vars.HOSTNAME_SLURM_LOGIN }}:${{ steps.meta.outputs.LOG_FILE }} \
+  #           output/${{ steps.meta.outputs.TEST_CASE_NAME }}.log || true
+  #         rsync -rtz --progress \
+  #           ${{ secrets.CLUSTER_LOGIN_USER }}@${{ vars.HOSTNAME_SLURM_LOGIN }}:${{ steps.meta.outputs.MODEL_PATH }}/* \
+  #           output/ || true
+  #         rsync -rtz --progress \
+  #           output/ \
+  #           ${{ secrets.TENSORBOARD_UPLOAD_USER }}@${{ vars.HOSTNAME_TENSORBOARD }}:/tensorboard-logs/${{ inputs.FW_NAME }}-${GITHUB_RUN_ID}/ || true
 
-      - name: Write SLURM job status to file
-        shell: bash -x -e {0}
-        run: |
-          python << EOF
-          import json
-          with open("output/${{ steps.meta.outputs.TEST_CASE_NAME }}-status.json", "w") as f:
-              dump = {'state': "${{ steps.submit.outputs.SLURM_STATE }}", 'exitcode': "${{ steps.submit.outputs.SLURM_EXITCODE }}"}
-              json.dump(dump, f)
-          EOF
+  #     - name: Write SLURM job status to file
+  #       shell: bash -x -e {0}
+  #       run: |
+  #         python << EOF
+  #         import json
+  #         with open("output/${{ steps.meta.outputs.TEST_CASE_NAME }}-status.json", "w") as f:
+  #             dump = {'state': "${{ steps.submit.outputs.SLURM_STATE }}", 'exitcode': "${{ steps.submit.outputs.SLURM_EXITCODE }}"}
+  #             json.dump(dump, f)
+  #         EOF
 
-      - name: Generate sitrep
-        if: success() || failure()
-        shell: bash -x -e {0}
-        run: |
-          # bring in utility functions
-          cd $GITHUB_WORKSPACE
-          source .github/workflows/scripts/to_json.sh
+  #     - name: Generate sitrep
+  #       if: success() || failure()
+  #       shell: bash -x -e {0}
+  #       run: |
+  #         # bring in utility functions
+  #         cd $GITHUB_WORKSPACE
+  #         source .github/workflows/scripts/to_json.sh
 
-          EXIT_STATUSES="output/*-status.json"
-          badge_label='ROSETTA T5X MULTI GPU MULTI NODE ${{ steps.meta.outputs.TEST_CASE_NAME }}'
-          passed_tests=$(jq -r '. | select ((.state == "COMPLETED") and (.exitcode == "0")) | .state' $EXIT_STATUSES | wc -l)
-          failed_tests=$(jq -r '. | select ((.state != "COMPLETED") or (.exitcode != "0")) | .state' $EXIT_STATUSES | wc -l)
-          total_tests=$(ls $EXIT_STATUSES | wc -l)
+  #         EXIT_STATUSES="output/*-status.json"
+  #         badge_label='ROSETTA T5X MULTI GPU MULTI NODE ${{ steps.meta.outputs.TEST_CASE_NAME }}'
+  #         passed_tests=$(jq -r '. | select ((.state == "COMPLETED") and (.exitcode == "0")) | .state' $EXIT_STATUSES | wc -l)
+  #         failed_tests=$(jq -r '. | select ((.state != "COMPLETED") or (.exitcode != "0")) | .state' $EXIT_STATUSES | wc -l)
+  #         total_tests=$(ls $EXIT_STATUSES | wc -l)
           
-          if [[ ${failed_tests} > 0 ]] || [[ ${total_tests} == 0 ]]; then
-            badge_message='error'
-            badge_color=red
-            summary="ROSETTA T5X MULTI GPU MULTI NODE ${{ steps.meta.outputs.TEST_CASE_NAME }}: $badge_message"
-          else
-            badge_message="${passed_tests}/${total_tests} passed"
-            if [[ ${failed_tests} == 0 ]]; then
-              badge_color=brightgreen
-            else
-              badge_color=yellow
-            fi
-            summary="ROSETTA T5X MULTI GPU MULTI NODE ${{ steps.meta.outputs.TEST_CASE_NAME }}: $badge_message"
-          fi
+  #         if [[ ${failed_tests} > 0 ]] || [[ ${total_tests} == 0 ]]; then
+  #           badge_message='error'
+  #           badge_color=red
+  #           summary="ROSETTA T5X MULTI GPU MULTI NODE ${{ steps.meta.outputs.TEST_CASE_NAME }}: $badge_message"
+  #         else
+  #           badge_message="${passed_tests}/${total_tests} passed"
+  #           if [[ ${failed_tests} == 0 ]]; then
+  #             badge_color=brightgreen
+  #           else
+  #             badge_color=yellow
+  #           fi
+  #           summary="ROSETTA T5X MULTI GPU MULTI NODE ${{ steps.meta.outputs.TEST_CASE_NAME }}: $badge_message"
+  #         fi
 
-          to_json \
-            summary \
-            total_tests passed_tests failed_tests \
-            badge_label badge_color badge_message \
-          > output/sitrep.json
+  #         to_json \
+  #           summary \
+  #           total_tests passed_tests failed_tests \
+  #           badge_label badge_color badge_message \
+  #         > output/sitrep.json
 
-          schemaVersion=1 \
-          label="${badge_label}" \
-          message="${badge_message}" \
-          color="${badge_color}" \
-          to_json schemaVersion label message color \
-          > output/${{ env.BADGE_FILENAME_PREFIX }}-${{ steps.meta.outputs.TEST_CASE_NAME }}.json
+  #         schemaVersion=1 \
+  #         label="${badge_label}" \
+  #         message="${badge_message}" \
+  #         color="${badge_color}" \
+  #         to_json schemaVersion label message color \
+  #         > output/${{ env.BADGE_FILENAME_PREFIX }}-${{ steps.meta.outputs.TEST_CASE_NAME }}.json
  
-      - name: Upload training logs as artifacts
-        uses: actions/upload-artifact@v4
-        with:
-          name: ${{ steps.meta.outputs.JOB_NAME }}
-          path: output/*
+  #     - name: Upload training logs as artifacts
+  #       uses: actions/upload-artifact@v4
+  #       with:
+  #         name: ${{ steps.meta.outputs.JOB_NAME }}
+  #         path: output/*
 
   vit-single-process-multi-device:
     strategy:
@@ -588,7 +589,8 @@ jobs:
       max-parallel: 1
       matrix:
         N_GPU: [1, 8]
-        N_NODE: [1, 2]
+        # 2-node configs temporarily disabled
+        N_NODE: [1] # , 2]
       fail-fast: false
     runs-on: jumpbox
     env:
@@ -758,7 +760,7 @@ jobs:
 
   metrics:
     name: test-t5x-rosetta-metrics
-    needs: [multi-gpu-multi-node, single-process-multi-device, vit-single-process-multi-device, vit-multi-gpu-multi-node]
+    needs: [single-process-multi-device, vit-single-process-multi-device, vit-multi-gpu-multi-node] # multi-gpu-multi-node
     runs-on: ubuntu-22.04
 
     steps:
@@ -804,7 +806,7 @@ jobs:
   summary:
     name: test-t5x-rosetta-summary
     runs-on: ubuntu-22.04
-    needs: [multi-gpu-multi-node, single-process-multi-device, vit-single-process-multi-device, vit-multi-gpu-multi-node]
+    needs: [single-process-multi-device, vit-single-process-multi-device, vit-multi-gpu-multi-node] # multi-gpu-multi-node
     if: "!cancelled()"
     steps:
       - name: Generate TensorBoard query URL

--- a/.github/workflows/_test_upstream_pax.yaml
+++ b/.github/workflows/_test_upstream_pax.yaml
@@ -190,13 +190,14 @@ jobs:
             PARALLEL_CONFIG: [1, 4, 1, 2]
             BATCH_SIZE: 4
             ADDITIONAL_ARGS: ""
-          - TEST_NAME: 16DP1FSDP1TP1PP
-            PARALLEL_CONFIG: [1, 16, 1, 1]
-            BATCH_SIZE: 4
-            ADDITIONAL_ARGS: ""
-          - TEST_NAME: 2DP1FSDP2TP4PP
-            PARALLEL_CONFIG: [4, 2, 1, 2]
-            BATCH_SIZE: 4
+          # 2-node tests temporarily disabled
+          # - TEST_NAME: 16DP1FSDP1TP1PP
+          #   PARALLEL_CONFIG: [1, 16, 1, 1]
+          #   BATCH_SIZE: 4
+          #   ADDITIONAL_ARGS: ""
+          # - TEST_NAME: 2DP1FSDP2TP4PP
+          #   PARALLEL_CONFIG: [4, 2, 1, 2]
+          #   BATCH_SIZE: 4
           - TEST_NAME: LLaMA_eval
             PARALLEL_CONFIG: [1, 1, 8, 1]
             BATCH_SIZE: 4

--- a/.github/workflows/_test_upstream_t5x.yaml
+++ b/.github/workflows/_test_upstream_t5x.yaml
@@ -168,157 +168,158 @@ jobs:
           name: ${{ steps.meta.outputs.JOB_NAME }}
           path: output/*
 
-  t5x-multi-node:
-    strategy:
-      max-parallel: 1
-      matrix:
-        include:
-          - TEST_NAME: "8G2N"
-            N_GPU: 8
-            N_NODE: 2
-            ADDITIONAL_ARGS: ""
-          - TEST_NAME: "8G2N_fmha"
-            N_GPU: 8
-            N_NODE: 2
-            ADDITIONAL_ARGS: "--enable-fmha 1"
-      fail-fast: false
-    runs-on: jumpbox
-    steps:
-      - name: Print environment variables
-        run: env
+  # 2-node tests temporarily disabled
+  # t5x-multi-node:
+  #   strategy:
+  #     max-parallel: 1
+  #     matrix:
+  #       include:
+  #         - TEST_NAME: "8G2N"
+  #           N_GPU: 8
+  #           N_NODE: 2
+  #           ADDITIONAL_ARGS: ""
+  #         - TEST_NAME: "8G2N_fmha"
+  #           N_GPU: 8
+  #           N_NODE: 2
+  #           ADDITIONAL_ARGS: "--enable-fmha 1"
+  #     fail-fast: false
+  #   runs-on: jumpbox
+  #   steps:
+  #     - name: Print environment variables
+  #       run: env
 
-      - name: Check out the repository under ${GITHUB_WORKSPACE}
-        uses: actions/checkout@v4
+  #     - name: Check out the repository under ${GITHUB_WORKSPACE}
+  #       uses: actions/checkout@v4
 
-      - name: Setup SSH agent
-        uses: webfactory/ssh-agent@v0.9.0
-        with:
-          ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
+  #     - name: Setup SSH agent
+  #       uses: webfactory/ssh-agent@v0.9.0
+  #       with:
+  #         ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
 
-      - name: Setup SSH known hosts
-        id: ssh-known-hosts
-        run: |
-          mkdir -p ~/.ssh
-          cat >> ~/.ssh/known_hosts << EOF
-          ${{ vars.SSH_KNOWN_HOSTS }}
-          EOF
-          chmod 600 ~/.ssh/known_hosts
-          echo "FILE=$(realpath ~/.ssh/known_hosts)" >> $GITHUB_OUTPUT
+  #     - name: Setup SSH known hosts
+  #       id: ssh-known-hosts
+  #       run: |
+  #         mkdir -p ~/.ssh
+  #         cat >> ~/.ssh/known_hosts << EOF
+  #         ${{ vars.SSH_KNOWN_HOSTS }}
+  #         EOF
+  #         chmod 600 ~/.ssh/known_hosts
+  #         echo "FILE=$(realpath ~/.ssh/known_hosts)" >> $GITHUB_OUTPUT
 
-      - name: Labels and metadata
-        id: meta
-        shell: bash -x -e {0}
-        run: |
-          IMAGE="$(echo ${{inputs.T5X_IMAGE}} | sed 's/\//#/')"
-          TEST_CASE_NAME=${{ matrix.TEST_NAME }}
-          TOTAL_TASKS=$((${{ matrix.N_GPU }} * ${{ matrix.N_NODE }}))
-          JOB_NAME=${{ inputs.FW_NAME }}-${GITHUB_RUN_ID}-${TEST_CASE_NAME};
-          LOG_FILE=/nfs/cluster/${JOB_NAME}.log
-          MODEL_PATH=/nfs/cluster/${JOB_NAME}
-          BATCH_SIZE=$((${{ inputs.BATCH_SIZE_PER_GPU }} * ${{ matrix.N_GPU }} * ${{ matrix.N_NODE }}))
-          for var in IMAGE TEST_CASE_NAME TOTAL_TASKS JOB_NAME LOG_FILE MODEL_PATH BATCH_SIZE; do
-            echo "$var=${!var}" >> $GITHUB_OUTPUT
-          done
+  #     - name: Labels and metadata
+  #       id: meta
+  #       shell: bash -x -e {0}
+  #       run: |
+  #         IMAGE="$(echo ${{inputs.T5X_IMAGE}} | sed 's/\//#/')"
+  #         TEST_CASE_NAME=${{ matrix.TEST_NAME }}
+  #         TOTAL_TASKS=$((${{ matrix.N_GPU }} * ${{ matrix.N_NODE }}))
+  #         JOB_NAME=${{ inputs.FW_NAME }}-${GITHUB_RUN_ID}-${TEST_CASE_NAME};
+  #         LOG_FILE=/nfs/cluster/${JOB_NAME}.log
+  #         MODEL_PATH=/nfs/cluster/${JOB_NAME}
+  #         BATCH_SIZE=$((${{ inputs.BATCH_SIZE_PER_GPU }} * ${{ matrix.N_GPU }} * ${{ matrix.N_NODE }}))
+  #         for var in IMAGE TEST_CASE_NAME TOTAL_TASKS JOB_NAME LOG_FILE MODEL_PATH BATCH_SIZE; do
+  #           echo "$var=${!var}" >> $GITHUB_OUTPUT
+  #         done
 
-      - name: Submit SLURM jobs over SSH
-        id: submit
-        shell: bash -O expand_aliases -x -e {0}
-        run: |
-          alias sshx='ssh -o "ServerAliveInterval 7" ${{ secrets.CLUSTER_LOGIN_USER }}@${{ vars.HOSTNAME_SLURM_LOGIN }}'
-          sshx "date && hostname && sinfo"
-          sshx mkdir -p ${{ steps.meta.outputs.MODEL_PATH }}
-          JOB=$(sshx sbatch --parsable << EOF
-          #!/bin/bash
-          #SBATCH --job-name=${{ steps.meta.outputs.JOB_NAME }}
-          #SBATCH --exclusive
-          #SBATCH --nodes=${{ matrix.N_NODE }}
-          #SBATCH --gpus-per-node=${{ matrix.N_GPU }}
-          #SBATCH --time=00:30:00
-          #SBATCH --output=${{ steps.meta.outputs.LOG_FILE }}
-          #SBATCH --export="ENROOT_PASSWORD=${{ secrets.GITHUB_TOKEN }}"
+  #     - name: Submit SLURM jobs over SSH
+  #       id: submit
+  #       shell: bash -O expand_aliases -x -e {0}
+  #       run: |
+  #         alias sshx='ssh -o "ServerAliveInterval 7" ${{ secrets.CLUSTER_LOGIN_USER }}@${{ vars.HOSTNAME_SLURM_LOGIN }}'
+  #         sshx "date && hostname && sinfo"
+  #         sshx mkdir -p ${{ steps.meta.outputs.MODEL_PATH }}
+  #         JOB=$(sshx sbatch --parsable << EOF
+  #         #!/bin/bash
+  #         #SBATCH --job-name=${{ steps.meta.outputs.JOB_NAME }}
+  #         #SBATCH --exclusive
+  #         #SBATCH --nodes=${{ matrix.N_NODE }}
+  #         #SBATCH --gpus-per-node=${{ matrix.N_GPU }}
+  #         #SBATCH --time=00:30:00
+  #         #SBATCH --output=${{ steps.meta.outputs.LOG_FILE }}
+  #         #SBATCH --export="ENROOT_PASSWORD=${{ secrets.GITHUB_TOKEN }}"
 
-          # preload enroot container using one task per node
-          time srun \
-            --ntasks-per-node=1 \
-            --container-name=runtime \
-            --container-image=${{ steps.meta.outputs.IMAGE }} \
-            true
+  #         # preload enroot container using one task per node
+  #         time srun \
+  #           --ntasks-per-node=1 \
+  #           --container-name=runtime \
+  #           --container-image=${{ steps.meta.outputs.IMAGE }} \
+  #           true
 
-          # run job with tasks on each node sharing one container
-          time srun \
-            --tasks=${{ steps.meta.outputs.TOTAL_TASKS }} \
-            --tasks-per-node=${{ matrix.N_GPU }} \
-            --container-name=runtime \
-            --container-mounts=${{ steps.meta.outputs.MODEL_PATH }}:/output \
-            --container-entrypoint \
-            test-t5x.sh \
-              --output /output/${{ steps.meta.outputs.TEST_CASE_NAME }} \
-              --dtype bfloat16 \
-              --batch-size ${{ steps.meta.outputs.BATCH_SIZE }} \
-              --epochs 7 \
-              --steps-per-epoch 100 \
-              --multiprocess \
-              ${{ matrix.ADDITIONAL_ARGS }}
-          EOF
-          )
+  #         # run job with tasks on each node sharing one container
+  #         time srun \
+  #           --tasks=${{ steps.meta.outputs.TOTAL_TASKS }} \
+  #           --tasks-per-node=${{ matrix.N_GPU }} \
+  #           --container-name=runtime \
+  #           --container-mounts=${{ steps.meta.outputs.MODEL_PATH }}:/output \
+  #           --container-entrypoint \
+  #           test-t5x.sh \
+  #             --output /output/${{ steps.meta.outputs.TEST_CASE_NAME }} \
+  #             --dtype bfloat16 \
+  #             --batch-size ${{ steps.meta.outputs.BATCH_SIZE }} \
+  #             --epochs 7 \
+  #             --steps-per-epoch 100 \
+  #             --multiprocess \
+  #             ${{ matrix.ADDITIONAL_ARGS }}
+  #         EOF
+  #         )
 
-          echo "SLURM_JOB_ID=${JOB}" >> $GITHUB_OUTPUT
+  #         echo "SLURM_JOB_ID=${JOB}" >> $GITHUB_OUTPUT
 
-          . .github/workflows/scripts/wait_for_slurm_job.sh
+  #         . .github/workflows/scripts/wait_for_slurm_job.sh
 
-          wait_for_slurm_job ${{ secrets.CLUSTER_LOGIN_USER }}@${{ vars.HOSTNAME_SLURM_LOGIN }} ${JOB}
+  #         wait_for_slurm_job ${{ secrets.CLUSTER_LOGIN_USER }}@${{ vars.HOSTNAME_SLURM_LOGIN }} ${JOB}
 
-          # Gather job info
-          SLURM_STATE=$(sshx sacct -j $JOB --format=State --parsable2 --noheader |& head -n 1)
-          SLURM_EXITCODE=$(sshx sacct -j $JOB --format=exitcode --parsable2 --noheader | sort -r -u | head -1 | cut -f 1 -d":" | sed 's/ //g')
-          echo "SLURM Job state is ${SLURM_STATE}"
-          echo "SLURM Job exit code is ${SLURM_EXITCODE}"
-          echo "SLURM_STATE=${SLURM_STATE}" >> "$GITHUB_OUTPUT"
-          echo "SLURM_EXITCODE=${SLURM_EXITCODE}" >> "$GITHUB_OUTPUT"
+  #         # Gather job info
+  #         SLURM_STATE=$(sshx sacct -j $JOB --format=State --parsable2 --noheader |& head -n 1)
+  #         SLURM_EXITCODE=$(sshx sacct -j $JOB --format=exitcode --parsable2 --noheader | sort -r -u | head -1 | cut -f 1 -d":" | sed 's/ //g')
+  #         echo "SLURM Job state is ${SLURM_STATE}"
+  #         echo "SLURM Job exit code is ${SLURM_EXITCODE}"
+  #         echo "SLURM_STATE=${SLURM_STATE}" >> "$GITHUB_OUTPUT"
+  #         echo "SLURM_EXITCODE=${SLURM_EXITCODE}" >> "$GITHUB_OUTPUT"
 
-          set -x
+  #         set -x
 
-      - name: Remove orphaned SLURM job if the CI job is canceled
-        if: cancelled()
-        shell: bash -x -e {0}
-        run: |
-          ssh ${{ secrets.CLUSTER_LOGIN_USER }}@${{ vars.HOSTNAME_SLURM_LOGIN }} \
-            scancel ${{ steps.submit.outputs.SLURM_JOB_ID }}
+  #     - name: Remove orphaned SLURM job if the CI job is canceled
+  #       if: cancelled()
+  #       shell: bash -x -e {0}
+  #       run: |
+  #         ssh ${{ secrets.CLUSTER_LOGIN_USER }}@${{ vars.HOSTNAME_SLURM_LOGIN }} \
+  #           scancel ${{ steps.submit.outputs.SLURM_JOB_ID }}
 
-      - name: Retrieve training logs and upload to TensorBoard server
-        shell: bash -x -e {0}
-        run: |
+  #     - name: Retrieve training logs and upload to TensorBoard server
+  #       shell: bash -x -e {0}
+  #       run: |
 
-          mkdir output/
-          rsync -rtz --progress \
-            ${{ secrets.CLUSTER_LOGIN_USER }}@${{ vars.HOSTNAME_SLURM_LOGIN }}:${{ steps.meta.outputs.LOG_FILE }} \
-            output/${{ steps.meta.outputs.TEST_CASE_NAME }}.log || true
-          rsync -rtz --progress \
-            ${{ secrets.CLUSTER_LOGIN_USER }}@${{ vars.HOSTNAME_SLURM_LOGIN }}:${{ steps.meta.outputs.MODEL_PATH }}/* \
-            output/ || true
-          rsync -rtz --progress \
-            output/ \
-            ${{ secrets.TENSORBOARD_UPLOAD_USER }}@${{ vars.HOSTNAME_TENSORBOARD }}:/tensorboard-logs/${{ inputs.FW_NAME }}-${GITHUB_RUN_ID}/ || true
+  #         mkdir output/
+  #         rsync -rtz --progress \
+  #           ${{ secrets.CLUSTER_LOGIN_USER }}@${{ vars.HOSTNAME_SLURM_LOGIN }}:${{ steps.meta.outputs.LOG_FILE }} \
+  #           output/${{ steps.meta.outputs.TEST_CASE_NAME }}.log || true
+  #         rsync -rtz --progress \
+  #           ${{ secrets.CLUSTER_LOGIN_USER }}@${{ vars.HOSTNAME_SLURM_LOGIN }}:${{ steps.meta.outputs.MODEL_PATH }}/* \
+  #           output/ || true
+  #         rsync -rtz --progress \
+  #           output/ \
+  #           ${{ secrets.TENSORBOARD_UPLOAD_USER }}@${{ vars.HOSTNAME_TENSORBOARD }}:/tensorboard-logs/${{ inputs.FW_NAME }}-${GITHUB_RUN_ID}/ || true
 
-      - name: Write SLURM job status to file
-        shell: bash -x -e {0}
-        run: |
-          python << EOF
-          import json
-          with open("output/${{ steps.meta.outputs.TEST_CASE_NAME }}-status.json", "w") as f:
-              dump = {'state': "${{ steps.submit.outputs.SLURM_STATE }}", 'exitcode': "${{ steps.submit.outputs.SLURM_EXITCODE }}"}
-              json.dump(dump, f)
-          EOF
+  #     - name: Write SLURM job status to file
+  #       shell: bash -x -e {0}
+  #       run: |
+  #         python << EOF
+  #         import json
+  #         with open("output/${{ steps.meta.outputs.TEST_CASE_NAME }}-status.json", "w") as f:
+  #             dump = {'state': "${{ steps.submit.outputs.SLURM_STATE }}", 'exitcode': "${{ steps.submit.outputs.SLURM_EXITCODE }}"}
+  #             json.dump(dump, f)
+  #         EOF
 
-      - name: Upload training logs as artifacts
-        uses: actions/upload-artifact@v4
-        with:
-          name: ${{ steps.meta.outputs.JOB_NAME }}
-          path: output/*
+  #     - name: Upload training logs as artifacts
+  #       uses: actions/upload-artifact@v4
+  #       with:
+  #         name: ${{ steps.meta.outputs.JOB_NAME }}
+  #         path: output/*
 
   metrics:
     name: test-upstream-t5x-metrics
-    needs: [t5x-multi-node, t5x-multi-gpu]
+    needs: [t5x-multi-gpu] # t5x-multi-node
     runs-on: ubuntu-22.04
 
     steps:
@@ -365,7 +366,7 @@ jobs:
   summary:
     name: test-upstream-t5x-summary
     runs-on: ubuntu-22.04
-    needs: [t5x-multi-node, t5x-multi-gpu]
+    needs: [t5x-multi-gpu] # t5x-multi-node
     if: "!cancelled()"
     steps:
       - name: Generate TensorBoard query URL

--- a/.github/workflows/mjx-build-test.yaml
+++ b/.github/workflows/mjx-build-test.yaml
@@ -142,62 +142,63 @@ jobs:
         type=raw,value=mjx-latest,priority=1000
         type=raw,value=mjx-nightly-${{ needs.metadata.outputs.BUILD_DATE }},priority=900
 
+  # disabled because the build is failing and this workflow needs reworking not to block the slurm cluster 
   # small perf tests
-  runner:
-    uses: ./.github/workflows/_runner_ondemand_slurm.yaml
-    with:
-      NAME: "A100-${{ github.run_id }}"
-      LABELS: "A100:${{ github.run_id }}"
-      TIME: "01:00:00"
-    secrets: inherit
+  # runner:
+  #   uses: ./.github/workflows/_runner_ondemand_slurm.yaml
+  #   with:
+  #     NAME: "A100-${{ github.run_id }}"
+  #     LABELS: "A100:${{ github.run_id }}"
+  #     TIME: "01:00:00"
+  #   secrets: inherit
 
-  mjx-unit-test:
-    needs: amd64
-    strategy:
-      fail-fast: false
-      matrix:
-        GPU_ARCH: [A100]
-    # ensures A100 job lands on dedicated runner for this particular job
-    runs-on: [self-hosted, "${{ matrix.GPU_ARCH == 'A100' && format('{0}:{1}', matrix.GPU_ARCH, github.run_id) || matrix.GPU_ARCH }}"]
-    steps:
-      - name: Print environment variables
-        run: env
+  # mjx-unit-test:
+  #   needs: amd64
+  #   strategy:
+  #     fail-fast: false
+  #     matrix:
+  #       GPU_ARCH: [A100]
+  #   # ensures A100 job lands on dedicated runner for this particular job
+  #   runs-on: [self-hosted, "${{ matrix.GPU_ARCH == 'A100' && format('{0}:{1}', matrix.GPU_ARCH, github.run_id) || matrix.GPU_ARCH }}"]
+  #   steps:
+  #     - name: Print environment variables
+  #       run: env
 
-      - name: Print GPU information
-        run: nvidia-smi  
+  #     - name: Print GPU information
+  #       run: nvidia-smi  
 
-      - name: Check out repository
-        uses: actions/checkout@v4
+  #     - name: Check out repository
+  #       uses: actions/checkout@v4
 
-      - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3
-        with:
-          registry: ghcr.io
-          username: ${{ github.repository_owner }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+  #     - name: Login to GitHub Container Registry
+  #       uses: docker/login-action@v3
+  #       with:
+  #         registry: ghcr.io
+  #         username: ${{ github.repository_owner }}
+  #         password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Pull MJX image
-        shell: bash -x -e {0}
-        run: |
-          docker pull ${{ needs.amd64.outputs.DOCKER_TAG_FINAL }}
+  #     - name: Pull MJX image
+  #       shell: bash -x -e {0}
+  #       run: |
+  #         docker pull ${{ needs.amd64.outputs.DOCKER_TAG_FINAL }}
 
-      - name: MJX speed test
-        shell: bash -x -e {0}
-        continue-on-error: true
-        run: |
-          docker run --gpus=all --shm-size=1g ${{ needs.amd64.outputs.DOCKER_TAG_FINAL }} bash -ec "mjx-testspeed --mjcf=humanoid/humanoid.xml --batch_size=8192 --unroll=4 --output=tsv" | tee -a test-mjx.log
+  #     - name: MJX speed test
+  #       shell: bash -x -e {0}
+  #       continue-on-error: true
+  #       run: |
+  #         docker run --gpus=all --shm-size=1g ${{ needs.amd64.outputs.DOCKER_TAG_FINAL }} bash -ec "mjx-testspeed --mjcf=humanoid/humanoid.xml --batch_size=8192 --unroll=4 --output=tsv" | tee -a test-mjx.log
       
-      - name: Save perf to summary
-        shell: bash -x -e {0}
-        continue-on-error: true
-        run: |
-          SUMMARY_PATTERN="^mjx-testspeed"
-          SUMMARY=$(cat test-mjx.log | grep "$SUMMARY_PATTERN")
-          echo "${SUMMARY}" | tee -a $GITHUB_STEP_SUMMARY
+  #     - name: Save perf to summary
+  #       shell: bash -x -e {0}
+  #       continue-on-error: true
+  #       run: |
+  #         SUMMARY_PATTERN="^mjx-testspeed"
+  #         SUMMARY=$(cat test-mjx.log | grep "$SUMMARY_PATTERN")
+  #         echo "${SUMMARY}" | tee -a $GITHUB_STEP_SUMMARY
 
-      - name: Upload artifacts
-        uses: actions/upload-artifact@v4
-        with:
-          name: ${{ env.DEFAULT_ARTIFACT_NAME }}-${{ matrix.GPU_ARCH }}
-          path: |
-            test-mjx.log
+  #     - name: Upload artifacts
+  #       uses: actions/upload-artifact@v4
+  #       with:
+  #         name: ${{ env.DEFAULT_ARTIFACT_NAME }}-${{ matrix.GPU_ARCH }}
+  #         path: |
+  #           test-mjx.log


### PR DESCRIPTION
One of the nodes backing these is not currently available, so attempting to run them leads to long delays and timeouts.