### PR TITLE
Do not emit arch-conditional PTX

### DIFF
--- a/.github/container/build-jax.sh
+++ b/.github/container/build-jax.sh
@@ -11,9 +11,9 @@ print_var() {
 supported_compute_capabilities() {
     ARCH=$1
     if [[ "${ARCH}" == "amd64" ]]; then
-        echo "5.2,6.0,6.1,7.0,7.5,8.0,8.6,8.9,9.0,9.0a,10.0,10.0a"
+        echo "sm_75,sm_80,sm_86,sm_90,sm_100,compute_120"
     elif [[ "${ARCH}" == "arm64" ]]; then
-        echo "5.3,6.2,7.0,7.2,7.5,8.0,8.6,8.7,8.9,9.0,9.0a,10.0,10.0a"
+        echo "sm_80,sm_86,sm_90,sm_100,compute_120"
     else
         echo "Invalid arch '$ARCH' (expected 'amd64' or 'arm64')" 1>&2
         return 1


### PR DESCRIPTION
Previously `build-jax.sh --sm all` would cause XLA to emit 9.0a, which cannot be PTX JIT compiled to 10.0 and beyond.

This is due to logic in XLA:
https://github.com/openxla/xla/blob/6b470af69810d93411ac8c83e476eeee84031432/third_party/tsl/third_party/gpus/cuda/hermetic/cuda_configure.bzl#L129-L193
that it not aware of the semantics of the arch-conditional (`a` suffix) architectures (and a lexicographic sort where a numerical one is needed).

This means that `--sm all` will produce binaries that do not support pre-Turing architectures, see https://docs.nvidia.com/cuda/cuda-toolkit-release-notes/index.html#deprecated-architectures.