### PR TITLE
war: Add new line before appending requirements.txt file

### DIFF
--- a/.github/container/Dockerfile.maxtext
+++ b/.github/container/Dockerfile.maxtext
@@ -25,7 +25,7 @@ for pattern in \
   ; do
     sed -i "${pattern}" ${SRC_PATH_MAXTEXT}/requirements.txt;
 done
-echo "tensorflow-metadata>=1.15.0" >> ${SRC_PATH_MAXTEXT}/requirements.txt
+echo -e "\ntensorflow-metadata>=1.15.0" >> ${SRC_PATH_MAXTEXT}/requirements.txt
 EOF
 
 ###############################################################################


### PR DESCRIPTION
No new line added during the last update of MaxText requirements.txt file. This is a temporary workaround to unblock the builds

https://github.com/AI-Hypercomputer/maxtext/pull/1285#discussion_r1966482786