### PR TITLE
jax-toolbox-triage: support srun --container-XXX as an alternative backend to Docker

### DIFF
--- a/.github/triage/jax_toolbox_triage/args.py
+++ b/.github/triage/jax_toolbox_triage/args.py
@@ -127,6 +127,16 @@ def parse_args(args=None):
             directory including the name of the current user.""",
     )
     parser.add_argument(
+        "-v",
+        "--container-mount",
+        action="append",
+        help="""
+            Takes a SRC:DST value and mounts the (host) directory SRC into the container
+            at DST; this can be used to pass in a test script, e.g. -v $PWD:/work before
+            using /work/test.sh as a test command.""",
+        type=lambda s: s.split(":", 1),
+    )
+    parser.add_argument(
         "--container-runtime",
         default="docker",
         help="Container runtime used, this can be either docker or pyxis.",

--- a/.github/triage/jax_toolbox_triage/args.py
+++ b/.github/triage/jax_toolbox_triage/args.py
@@ -126,7 +126,14 @@ def parse_args(args=None):
             significantly speed up the commit-level search. By default, uses a temporary
             directory including the name of the current user.""",
     )
+    parser.add_argument(
+        "--container-runtime",
+        default="docker",
+        help="Container runtime used, this can be either docker or pyxis.",
+        type=lambda s: s.lower(),
+    )
     args = parser.parse_args(args=args)
+    assert args.container_runtime in {"docker", "pyxis"}, args.container_runtime
     num_explicit_containers = (args.passing_container is not None) + (
         args.failing_container is not None
     )

--- a/.github/triage/jax_toolbox_triage/main.py
+++ b/.github/triage/jax_toolbox_triage/main.py
@@ -239,7 +239,8 @@ def main():
                     "xla": xla_commit,
                 },
             )
-            logger.info(f"Test completed in {test_time:.1f}s")
+            result_str = 'pass' if test_result.returncode == 0 else 'fail'
+            logger.info(f"Test completed in {test_time:.1f}s ({result_str})")
             logger.debug(
                 f"Test stdout:\n{test_result.stdout}\nTest stderr:\n{test_result.stderr}"
             )

--- a/.github/triage/jax_toolbox_triage/main.py
+++ b/.github/triage/jax_toolbox_triage/main.py
@@ -232,7 +232,7 @@ def main():
                 "commit",
                 {
                     "build_time": middle - before,
-                    "container": container_url(range_end),
+                    "container": failing_url,
                     "jax": jax_commit,
                     "result": test_result.returncode == 0,
                     "test_time": test_time,
@@ -253,5 +253,5 @@ def main():
             logger=logger,
             skip_precondition_checks=args.skip_precondition_checks,
         )
-        result["container"] = container_url(range_end)
+        result["container"] = failing_url
         add_summary_record("result", result, scalar=True)

--- a/.github/triage/jax_toolbox_triage/main.py
+++ b/.github/triage/jax_toolbox_triage/main.py
@@ -9,6 +9,7 @@ import typing
 from .args import parse_args
 from .docker import DockerContainer
 from .logic import commit_search, container_search, TestResult
+from .pyxis import PyxisContainer
 from .utils import (
     container_exists as container_exists_base,
     container_url as container_url_base,
@@ -30,7 +31,9 @@ def main():
         container_exists_base, container=args.container, logger=logger
     )
     Container = functools.partial(
-        DockerContainer, logger=logger, mounts=bazel_cache_mounts
+        DockerContainer if args.container_runtime == "docker" else PyxisContainer,
+        logger=logger,
+        mounts=bazel_cache_mounts,
     )
     bazel_cache_mount_args = []
     for src, dst in bazel_cache_mounts:

--- a/.github/triage/jax_toolbox_triage/main.py
+++ b/.github/triage/jax_toolbox_triage/main.py
@@ -239,7 +239,7 @@ def main():
                     "xla": xla_commit,
                 },
             )
-            result_str = 'pass' if test_result.returncode == 0 else 'fail'
+            result_str = "pass" if test_result.returncode == 0 else "fail"
             logger.info(f"Test completed in {test_time:.1f}s ({result_str})")
             logger.debug(
                 f"Test stdout:\n{test_result.stdout}\nTest stderr:\n{test_result.stderr}"

--- a/.github/triage/jax_toolbox_triage/main.py
+++ b/.github/triage/jax_toolbox_triage/main.py
@@ -33,7 +33,7 @@ def main():
     Container = functools.partial(
         DockerContainer if args.container_runtime == "docker" else PyxisContainer,
         logger=logger,
-        mounts=bazel_cache_mounts,
+        mounts=bazel_cache_mounts + args.container_mount,
     )
     bazel_cache_mount_args = []
     for src, dst in bazel_cache_mounts:

--- a/.github/triage/jax_toolbox_triage/pyxis.py
+++ b/.github/triage/jax_toolbox_triage/pyxis.py
@@ -14,7 +14,7 @@ class PyxisContainer:
         mounts: typing.List[typing.Tuple[pathlib.Path, pathlib.Path]],
     ):
         self._logger = logger
-        mount_str = ",".join(map(":".join, mounts))
+        mount_str = ",".join(map(lambda t: f"{t[0]}:{t[1]}", mounts))
         self._mount_args = [f"--container-mounts={mount_str}"] if mount_str else []
         self._name = secrets.token_urlsafe()
         self._url = url

--- a/.github/triage/jax_toolbox_triage/pyxis.py
+++ b/.github/triage/jax_toolbox_triage/pyxis.py
@@ -1,0 +1,65 @@
+import logging
+import pathlib
+import secrets
+import subprocess
+import typing
+
+
+class PyxisContainer:
+    def __init__(
+        self,
+        url: str,
+        *,
+        logger: logging.Logger,
+        mounts: typing.List[typing.Tuple[pathlib.Path, pathlib.Path]],
+    ):
+        self._logger = logger
+        mount_str = ",".join(map(":".join, mounts))
+        self._mount_args = [f"--container-mounts={mount_str}"] if mount_str else []
+        self._name = secrets.token_urlsafe()
+        self._url = url
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc_info):
+        pass
+
+    def exec(
+        self, command: typing.List[str], workdir=None
+    ) -> subprocess.CompletedProcess:
+        """
+        Run a command inside a persistent container.
+        """
+        workdir = [] if workdir is None else [f"--container-workdir={workdir}"]
+        command = (
+            [
+                "srun",
+                f"--container-image={self._url}",
+                f"--container-name={self._name}",
+                "--container-remap-root",
+            ]
+            + self._mount_args
+            + workdir
+            + command
+        )
+        result = subprocess.run(
+            command,
+            encoding="utf-8",
+            stderr=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+        )
+        return result
+
+    def check_exec(
+        self, cmd: typing.List[str], **kwargs
+    ) -> subprocess.CompletedProcess:
+        result = self.exec(cmd, **kwargs)
+        if result.returncode != 0:
+            self._logger.fatal(
+                f"{' '.join(cmd)} exited with return code {result.returncode}"
+            )
+            self._logger.fatal(result.stdout)
+            self._logger.fatal(result.stderr)
+            result.check_returncode()
+        return result

--- a/docs/triage-tool.md
+++ b/docs/triage-tool.md
@@ -54,7 +54,11 @@ virtualenv triage-venv
 ```
 
 The tool should be invoked on a machine with `docker` available and whatever GPUs are
-needed to execute the test case.
+needed to execute the test case if the default runtime (`--container-runtime=docker`)
+is used.
+If `--container-runtime=pyxis` is used instead, the tool should be invoked on a machine
+where `srun --container-image=XXX ... test_command` will execute the test case on one
+or more machines with appropriate GPUs, *e.g.* inside an `salloc` session.
 
 ## Usage
 
@@ -78,6 +82,10 @@ as fast and targeted as possible.
 
 If you want to run multiple commands, you might want to use something like
 `jax-toolbox-triage --container=jax sh -c "command1 && command2"`.
+
+Alternatively, you can use `-v` (`--container-mount`) to mount a host directory
+containing test scripts into the container and execute a script from there, *e.g.*
+`-v $PWD:/work /work/test.sh`.
 
 The expectation is that the test case will be executed successfully several times as
 part of the triage, so you may want to tune some parameters to reduce the execution
@@ -291,12 +299,7 @@ critical date, but the third stage will fail because it will try and fail to rep
 test success by building the JAX/XLA commits from `2024-10-14` in the `2024-10-15`
 container.
 
-Other limitations include that only `docker` is supported as a container runtime, which
-also implies that it is not currently possible to triage a test that requires a
-multi-node or multi-process test.
-
-The tool also does not currently handle skipping commits that do not compile, or test
-cases that require copying files (*e.g.* script files) into the container.
+The tool also does not currently handle skipping commits that do not compile.
 
 If you run into these limitations in real-world usage of this tool, please file a bug
 against JAX-Toolbox including details of manual steps you took to root-case the test


### PR DESCRIPTION
The main point is that this enables triaging on Slurm clusters whose nodes do not have `docker` installed. This should implicitly enable triaging multi-process tests too.