### PR TITLE
Use upstream seqio to meet multiple requirements from different libraries

### DIFF
--- a/.github/container/Dockerfile.maxtext
+++ b/.github/container/Dockerfile.maxtext
@@ -22,10 +22,18 @@ for pattern in \
     "s|absl-py|absl-py>=2.1.0|g" \
     "s|protobuf==3.20.3|protobuf>=3.19.0|g" \
     "s|tensorflow-datasets|tensorflow-datasets>=4.8.0|g" \
+    "s|sentencepiece==0.1.97|sentencepiece>=0.2|g" \
   ; do
     sed -i "${pattern}" ${SRC_PATH_MAXTEXT}/requirements.txt;
 done
-echo -e "\ntensorflow-metadata>=1.15.0" >> ${SRC_PATH_MAXTEXT}/requirements.txt
+# add new line in case requirements.txt does not end with a new line
+echo >> ${SRC_PATH_MAXTEXT}/requirements.txt
+for requirement in \
+    "tensorflow-metadata>=1.15.0" \
+    "seqio@git+https://github.com/google/seqio.git" \
+  ; do
+    echo "${requirement}" >> ${SRC_PATH_MAXTEXT}/requirements.txt
+done
 EOF
 
 ###############################################################################


### PR DESCRIPTION
This is what we did for `25.01-devel` too. Without using the usptream seqio, seqio will end up with `seqio-0.0.16` which will not work with any MaxText inference benchmark.