### PR TITLE
Add google-jetstream into manifest.yaml

### DIFF
--- a/.github/container/manifest.yaml
+++ b/.github/container/manifest.yaml
@@ -75,6 +75,7 @@ google-jetstream:
   url: https://github.com/AI-Hypercomputer/JetStream.git
   tracking_ref: main
   latest_verified_commit: b8b9cb2ea4668da2c5012fc4c7ba958424d82ac9
+  mode: pip-vcs
 maxtext:
   url: https://github.com/google/maxtext.git
   tracking_ref: main

--- a/.github/container/manifest.yaml
+++ b/.github/container/manifest.yaml
@@ -71,6 +71,10 @@ seqio:
   tracking_ref: main
   latest_verified_commit: 11706e4a1e01a81ea6b3e02c5ad147028d5b94bb
   mode: pip-vcs
+google-jetstream:
+  url: https://github.com/AI-Hypercomputer/JetStream.git
+  tracking_ref: main
+  latest_verified_commit: b8b9cb2ea4668da2c5012fc4c7ba958424d82ac9
 maxtext:
   url: https://github.com/google/maxtext.git
   tracking_ref: main


### PR DESCRIPTION
https://github.com/AI-Hypercomputer/maxtext/pull/1439 Changed MaxText to directly install `google-jetstream` library from git repo. We need to add this item into `manifest.yaml` file to allow `pip-finalize.sh` to correctly fetch the commit SHA.

This will fix the current MaxText build failure.