### PR TITLE
triage-tool: fixups for pyxis backend

### DIFF
--- a/.github/container/build-jax.sh
+++ b/.github/container/build-jax.sh
@@ -38,7 +38,6 @@ usage() {
     echo "    --debug                        Build in debug mode"
     echo "    --dry                          Dry run, parse arguments only"
     echo "    -h, --help                     Print usage."
-    echo "    --jaxlib_only                  Only build and install jaxlib"
     echo "    --no-clean                     Do not delete local configuration and bazel cache (default)"
     echo "    --src-path-jax                 Path to JAX source"
     echo "    --src-path-xla                 Path to XLA source"
@@ -61,12 +60,11 @@ CPU_ARCH="$(dpkg --print-architecture)"
 CUDA_COMPUTE_CAPABILITIES="local"
 DEBUG=0
 DRY=0
-JAXLIB_ONLY=0
 SRC_PATH_JAX="/opt/jax"
 SRC_PATH_XLA="/opt/xla"
 XLA_ARM64_PATCH_LIST=""
 
-args=$(getopt -o h --long bazel-cache:,bazel-cache-namespace:,build-param:,build-path-jaxlib:,clean,cpu-arch:,debug,jaxlib_only,no-clean,clean-only,dry,help,src-path-jax:,src-path-xla:,sm:,xla-arm64-patch: -- "$@")
+args=$(getopt -o h --long bazel-cache:,bazel-cache-namespace:,build-param:,build-path-jaxlib:,clean,cpu-arch:,debug,no-clean,clean-only,dry,help,src-path-jax:,src-path-xla:,sm:,xla-arm64-patch: -- "$@")
 if [[ $? -ne 0 ]]; then
     exit 1
 fi
@@ -115,10 +113,6 @@ while [ : ]; do
             ;;
         --dry)
             DRY=1
-            shift 1
-            ;;
-        --jaxlib_only)
-            JAXLIB_ONLY=1
             shift 1
             ;;
         --src-path-jax)
@@ -313,11 +307,7 @@ fi
 ## Install the built packages
 
 # Uninstall jaxlib in case this script was used before.
-if [[ "$JAXLIB_ONLY" == "0" ]]; then
-    pip uninstall -y jax jaxlib jax-cuda${TF_CUDA_MAJOR_VERSION}-pjrt jax-cuda${TF_CUDA_MAJOR_VERSION}-plugin
-else
-    pip uninstall -y jaxlib jax-cuda${TF_CUDA_MAJOR_VERSION}-pjrt jax-cuda${TF_CUDA_MAJOR_VERSION}-plugin
-fi
+pip uninstall -y jax jaxlib jax-cuda${TF_CUDA_MAJOR_VERSION}-pjrt jax-cuda${TF_CUDA_MAJOR_VERSION}-plugin
 
 # install jax and jaxlib
 pip --disable-pip-version-check install -e ${BUILD_PATH_JAXLIB}/jaxlib -e ${BUILD_PATH_JAXLIB}/jax_cuda${TF_CUDA_MAJOR_VERSION}_pjrt -e ${BUILD_PATH_JAXLIB}/jax_cuda${TF_CUDA_MAJOR_VERSION}_plugin -e ${BUILD_PATH_JAXLIB}/jax

--- a/.github/triage/jax_toolbox_triage/args.py
+++ b/.github/triage/jax_toolbox_triage/args.py
@@ -130,6 +130,7 @@ def parse_args(args=None):
         "-v",
         "--container-mount",
         action="append",
+        default=[],
         help="""
             Takes a SRC:DST value and mounts the (host) directory SRC into the container
             at DST; this can be used to pass in a test script, e.g. -v $PWD:/work before

--- a/.github/triage/jax_toolbox_triage/docker.py
+++ b/.github/triage/jax_toolbox_triage/docker.py
@@ -19,6 +19,7 @@ class DockerContainer:
         self._url = url
 
     def __enter__(self):
+        self._logger.debug(f"Launching {self}")
         result = subprocess.run(
             [
                 "docker",
@@ -50,6 +51,9 @@ class DockerContainer:
             stderr=subprocess.PIPE,
             stdout=subprocess.PIPE,
         )
+
+    def __repr__(self):
+        return f"Docker({self._url})"
 
     def exec(
         self, command: typing.List[str], workdir=None

--- a/.github/triage/jax_toolbox_triage/docker.py
+++ b/.github/triage/jax_toolbox_triage/docker.py
@@ -77,3 +77,16 @@ class DockerContainer:
             self._logger.fatal(result.stderr)
             result.check_returncode()
         return result
+
+    def exists(self) -> bool:
+        """
+        Check if the given container exists.
+        """
+        result = subprocess.run(
+            ["docker", "pull", self._url],
+            stderr=subprocess.STDOUT,
+            stdout=subprocess.PIPE,
+            encoding="utf-8",
+        )
+        self._logger.debug(result.stdout)
+        return result.returncode == 0

--- a/.github/triage/jax_toolbox_triage/logic.py
+++ b/.github/triage/jax_toolbox_triage/logic.py
@@ -229,7 +229,9 @@ def commit_search(
             logger.fatal("Vanilla rebuild did not reproduce test failure")
             logger.fatal(stdout)
             logger.fatal(stderr)
-            raise Exception("Could not reproduce")
+            raise Exception(
+                "Could not reproduce failure after rebuild in 'bad' container"
+            )
 
     # Verify that we can build the commit at the start of the range and reproduce the
     # test success there in the end-of-range container.
@@ -246,7 +248,9 @@ def commit_search(
         )
         logger.fatal(stdout)
         logger.fatal(stderr)
-        raise Exception("Could not reproduce")
+        raise Exception(
+            "Could not reproduce success with 'good' commits in 'bad' container"
+        )
 
     # Finally, start bisecting. This is XLA-centric; JAX is moved too but is secondary.
     while len(xla_commits) > 2:

--- a/.github/triage/jax_toolbox_triage/main.py
+++ b/.github/triage/jax_toolbox_triage/main.py
@@ -18,7 +18,7 @@ from .utils import (
 
 
 def get_commit(
-    container: DockerContainer | PyxisContainer, repo: str
+    container: typing.Union[DockerContainer, PyxisContainer], repo: str
 ) -> typing.Tuple[str, str]:
     """
     Get the commit of the given repository that was used in the given nightly container

--- a/.github/triage/jax_toolbox_triage/main.py
+++ b/.github/triage/jax_toolbox_triage/main.py
@@ -195,25 +195,8 @@ def main():
             logger.info(f"Checking out XLA {xla_commit} JAX {jax_commit}")
             # Build JAX
             before = time.monotonic()
-            # Next two are workarounds for bugs in old containers
-            worker.check_exec(["sh", "-c", f"rm -vf {jax_dir}/dist/jaxlib-*.whl"])
-            # This will error out on newer containers, but that should be harmless
-            worker.exec(
-                [
-                    "cp",
-                    f"{jax_dir}/jax/version.py",
-                    f"{jax_dir}/build/lib/jax/version.py",
-                ]
-            )
-            # It seemed that this might be the origin of flaky behaviour.
-            worker.check_exec(
-                ["sh", "-c", "echo 'test --cache_test_results=no' > /root/.bazelrc"]
-            )
             build_jax = [
                 "build-jax.sh",
-                # Workaround bugs in old containers where the default was wrong.
-                "--src-path-jax",
-                jax_dir,
                 f"--bazel-cache={args.bazel_cache}",
             ]
             worker.check_exec(build_jax, workdir=jax_dir)

--- a/.github/triage/jax_toolbox_triage/main.py
+++ b/.github/triage/jax_toolbox_triage/main.py
@@ -199,9 +199,12 @@ def main():
                 "build-jax.sh",
                 f"--bazel-cache={args.bazel_cache}",
             ]
-            worker.check_exec(build_jax, workdir=jax_dir)
+            build_result = worker.check_exec(build_jax, workdir=jax_dir)
             middle = time.monotonic()
             logger.info(f"Build completed in {middle - before:.1f}s")
+            logger.debug(
+                f"Build stdout:\n{build_result.stdout}\nBuild stderr:\n{build_result.stderr}"
+            )
             # Run the test
             test_result = worker.exec(args.test_command)
             test_time = time.monotonic() - middle

--- a/.github/triage/jax_toolbox_triage/main.py
+++ b/.github/triage/jax_toolbox_triage/main.py
@@ -211,9 +211,6 @@ def main():
             )
             build_jax = [
                 "build-jax.sh",
-                # Leave the editable /opt/jax[-source] installation alone. Otherwise
-                # test-jax.sh is broken by having a /usr/... installation directory.
-                "--jaxlib_only",
                 # Workaround bugs in old containers where the default was wrong.
                 "--src-path-jax",
                 jax_dir,

--- a/.github/triage/jax_toolbox_triage/pyxis.py
+++ b/.github/triage/jax_toolbox_triage/pyxis.py
@@ -20,6 +20,15 @@ class PyxisContainer:
         self._url = url
 
     def __enter__(self):
+        # Workaround for pyxis backend with some bazel versions
+        # https://github.com/bazelbuild/bazel/issues/22955#issuecomment-2293899428
+        self.check_exec(
+            [
+                "sh",
+                "-c",
+                "echo 'startup --host_jvm_args=-XX:-UseContainerSupport' > /root/.bazelrc",
+            ]
+        )
         return self
 
     def __exit__(self, *exc_info):

--- a/.github/triage/jax_toolbox_triage/pyxis.py
+++ b/.github/triage/jax_toolbox_triage/pyxis.py
@@ -63,3 +63,18 @@ class PyxisContainer:
             self._logger.fatal(result.stderr)
             result.check_returncode()
         return result
+
+    def exists(self) -> bool:
+        result = subprocess.run(
+            [
+                "srun",
+                f"--container-image={self._url}",
+                f"--container-name={self._name}",
+                "true",
+            ],
+            encoding="utf-8",
+            stderr=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+        )
+        self._logger.debug(result.stdout)
+        return result.returncode == 0

--- a/.github/triage/jax_toolbox_triage/pyxis.py
+++ b/.github/triage/jax_toolbox_triage/pyxis.py
@@ -74,16 +74,4 @@ class PyxisContainer:
         return result
 
     def exists(self) -> bool:
-        result = subprocess.run(
-            [
-                "srun",
-                f"--container-image={self._url}",
-                f"--container-name={self._name}",
-                "true",
-            ],
-            encoding="utf-8",
-            stderr=subprocess.PIPE,
-            stdout=subprocess.PIPE,
-        )
-        self._logger.debug(result.stdout)
-        return result.returncode == 0
+        return self.exec(["true"]).returncode == 0

--- a/.github/triage/jax_toolbox_triage/pyxis.py
+++ b/.github/triage/jax_toolbox_triage/pyxis.py
@@ -20,6 +20,7 @@ class PyxisContainer:
         self._url = url
 
     def __enter__(self):
+        self._logger.debug(f"Launching {self}")
         # Workaround for pyxis backend with some bazel versions
         # https://github.com/bazelbuild/bazel/issues/22955#issuecomment-2293899428
         self.check_exec(
@@ -33,6 +34,9 @@ class PyxisContainer:
 
     def __exit__(self, *exc_info):
         pass
+
+    def __repr__(self):
+        return f"Pyxis({self._url})"
 
     def exec(
         self, command: typing.List[str], workdir=None

--- a/.github/triage/jax_toolbox_triage/utils.py
+++ b/.github/triage/jax_toolbox_triage/utils.py
@@ -1,7 +1,6 @@
 import datetime
 import logging
 import pathlib
-import subprocess
 import typing
 
 
@@ -17,22 +16,6 @@ def container_url(date: datetime.date, *, container: str) -> str:
         return f"ghcr.io/nvidia/jax:{container}-{date.isoformat()}"
     else:
         return f"ghcr.io/nvidia/{container}:nightly-{date.isoformat()}"
-
-
-def container_exists(
-    date: datetime.date, *, container: str, logger: logging.Logger
-) -> bool:
-    """
-    Check if the given container exists.
-    """
-    result = subprocess.run(
-        ["docker", "pull", container_url(date, container=container)],
-        stderr=subprocess.STDOUT,
-        stdout=subprocess.PIPE,
-        encoding="utf-8",
-    )
-    logger.debug(result.stdout)
-    return result.returncode == 0
 
 
 def get_logger(output_prefix: pathlib.Path) -> logging.Logger:


### PR DESCRIPTION
- container-level search didn't work with the `pyxis` backend
- **not** passing `--container-mount` / `-v` was broken
- auto-inject workaround for https://github.com/bazelbuild/bazel/issues/22955#issuecomment-2293899428 with `pyxis` backend
- `build-jax.sh`: drop old `--jaxlib_only` option