### PR TITLE
cuda-dl-base: 25.03 release

### DIFF
--- a/.github/container/Dockerfile.base
+++ b/.github/container/Dockerfile.base
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1-labs
-ARG BASE_IMAGE=nvcr.io/nvidia/cuda-dl-base:25.02-cuda12.8-devel-ubuntu24.04
+ARG BASE_IMAGE=nvcr.io/nvidia/cuda-dl-base:25.03-cuda12.8-devel-ubuntu24.04
 ARG GIT_USER_NAME="JAX Toolbox"
 ARG GIT_USER_EMAIL=jax@nvidia.com
 ARG CLANG_VERSION=18

--- a/README.md
+++ b/README.md
@@ -278,6 +278,7 @@ For a list of previously used XLA flags that are no longer needed, please also r
 
 | First nightly with new base container | Base container |
 | ------------------------------------- | -------------- |
+| 2025-04-11 | nvcr.io/nvidia/cuda-dl-base:25.03-cuda12.8-devel-ubuntu24.04 |
 | 2025-03-04 | nvcr.io/nvidia/cuda-dl-base:25.02-cuda12.8-devel-ubuntu24.04 |
 | 2025-01-31 | nvcr.io/nvidia/cuda-dl-base:25.01-cuda12.8-devel-ubuntu24.04 |
 | 2025-01-28 | nvcr.io/nvidia/cuda-dl-base:24.11-cuda12.6-devel-ubuntu24.04 |


### PR DESCRIPTION
- [x] Move to `nvcr.io/nvidia/cuda-dl-base:25.03-cuda12.8-devel-ubuntu24.04`
- [x] Add a recipe patch for the build of `nsys` that this contains. 
- [x] Update https://github.com/NVIDIA/JAX-Toolbox?tab=readme-ov-file#versions with date of first nightly to include the new container