### PR TITLE
MaxText: fix test script, workaround broken tf wheel

### DIFF
--- a/.github/container/Dockerfile.maxtext
+++ b/.github/container/Dockerfile.maxtext
@@ -23,7 +23,9 @@ for pattern in \
     "s|protobuf==3.20.3|protobuf>=3.19.0|g" \
     "s|tensorflow-datasets|tensorflow-datasets>=4.8.0|g" \
     "s|sentencepiece==0.1.97|sentencepiece>=0.2|g" \
+    "s|tensorflow>=2.13.0|tensorflow==2.18.1|g" \
   ; do
+    # tensorflow-cpu==2.19.0 is incompatible with tensorflow-text
     sed -i "${pattern}" ${SRC_PATH_MAXTEXT}/requirements.txt;
 done
 # add new line in case requirements.txt does not end with a new line

--- a/.github/container/test-maxtext.sh
+++ b/.github/container/test-maxtext.sh
@@ -253,8 +253,7 @@ RUN_NAME="logdir" ## the RUN_NAME cannot be changed
 if [ -z "$DECODER_BLOCK" ]; then
 
     # this part could be used to test different model ootb
-    RUN_SETTINGS="MaxText/train.py \
-        MaxText/configs/base.yml \
+    RUN_SETTINGS="MaxText/configs/base.yml \
         run_name=${RUN_NAME} \
         model_name=${MODEL} \
         steps=${STEPS} \
@@ -277,8 +276,7 @@ if [ -z "$DECODER_BLOCK" ]; then
         ${ADDITIONAL_ARGS}"
 else
     # this is essentially used for CI run
-    RUN_SETTINGS="MaxText/train.py \
-        MaxText/configs/base.yml \
+    RUN_SETTINGS="MaxText/configs/base.yml \
         run_name=${RUN_NAME} \
         decoder_block=${DECODER_BLOCK} \
         steps=$STEPS \
@@ -310,6 +308,6 @@ else
 fi
 
 echo "Command: python3 $RUN_SETTINGS"
-python3 $RUN_SETTINGS
+python3 -m MaxText.train $RUN_SETTINGS
 
 echo "Output at ${OUTPUT}"


### PR DESCRIPTION
- `tensorflow-cpu == 2.19.0` is, probably mistakenly, incompatible with `tensorflow-text==2.19.0`; pin `tensorflow-cpu==2.18.1` for now
- https://github.com/AI-Hypercomputer/maxtext/pull/1482 broke the old way of launching MaxText training tests