### PR TITLE
Pin tf-text to 2.18.1 and remove default branch from internal repos

### DIFF
--- a/.github/container/Dockerfile.t5x
+++ b/.github/container/Dockerfile.t5x
@@ -24,6 +24,9 @@ echo "-e file://${SRC_PATH_T5X}[gpu]" >> /opt/pip-tools.d/requirements-t5x.in
 # so setting the lower-bound to something recent
 echo "seqio-nightly>=0.0.18.dev20240714" >> /opt/pip-tools.d/requirements-t5x.in
 
+# tensorflow-cpu==2.19.0 is incompatible with tensorflow-text
+echo "tensorflow==2.18.1" >> /opt/pip-tools.d/requirements-t5x.in
+
 # 2. Remove head-of-tree specs from select dependencies
 pushd ${SRC_PATH_T5X}
 sed -i "s| @ git+https://github.com/google/flax#egg=flax||g" setup.py

--- a/.github/container/git-clone.sh
+++ b/.github/container/git-clone.sh
@@ -82,6 +82,7 @@ if [[ "${GIT_REPO}" == *"gitlab"* ]]; then
   if grep -q -r gitlab-ci-token .git; then
     grep -r gitlab-ci-token .git | awk -F: '{print $1}' | xargs rm -f
   fi
+  git branch -D main
 fi
 popd
 


### PR DESCRIPTION
1. Similar to maxtext, we need to pin `tensorflow==2.18.1`
2. Remove default branch `main` for any internal repos