### PR TITLE
nsys-jax: handle application error codes

### DIFF
--- a/.github/container/nsys_jax/nsys_jax/scripts/nsys_jax.py
+++ b/.github/container/nsys_jax/nsys_jax/scripts/nsys_jax.py
@@ -339,16 +339,11 @@ def main() -> None:
     if capture_range_end == "stop-shutdown" or capture_range_end.startswith(
         "repeat-shutdown:"
     ):
-        # nsys will send this signal on shutdown
+        # nsys will send this signal on shutdown; takes none/sigkill/sigterm or an int
         kill_signal = nsys_arg_value("kill", "sigterm")
         if kill_signal != "none":
-            if kill_signal == "sigterm":
-                kill_signal = 15
-            elif kill_signal == "sigkill":
-                kill_signal = 9
-            else:
-                kill_signal = int(kill_signal)
-            expected_returncodes.add(128 + kill_signal)
+            ks_map = {"sigterm": 15, "sigkill": 9}
+            expected_returncodes.add(128 + int(ks_map.get(kill_signal, kill_signal)))
     if application_result.returncode in expected_returncodes:
         # Collapse any expected return code into success
         application_result.returncode = 0

--- a/.github/container/nsys_jax/nsys_jax/scripts/nsys_jax.py
+++ b/.github/container/nsys_jax/nsys_jax/scripts/nsys_jax.py
@@ -241,6 +241,28 @@ def main() -> None:
             return
         nsys_flags.append(f"--{arg}={value}")
 
+    def nsys_arg_value(arg, default_value):
+        """
+        Get the value of --arg in `nsys_flags`, or return `default_value`.
+        [..., --arg, VALUE, ...] and [--arg=VALUE] are both possible.
+        """
+        arg_indices = [
+            n
+            for n, flag in enumerate(nsys_flags)
+            if flag == f"--{arg}" or flag.startswith(f"--{arg}=")
+        ]
+        if len(arg_indices) == 0:
+            return default_value
+        arg_index = arg_indices[-1]  # last one wins
+        flag = nsys_flags[arg_index]
+        if flag == f"--{arg}":
+            assert arg_index < len(nsys_flags) - 1, (
+                "[..., --arg, VALUE, ...] requires --arg not be last"
+            )
+            return nsys_flags[arg_index + 1]
+        assert flag.startswith(f"--{arg}="), flag
+        return flag.removeprefix(f"--{arg}=")
+
     # Override some Nsight Systems defaults, but don't block setting them explicitly.
     override_nsys_default("cuda-graph-trace", "node")
     override_nsys_default("cpuctxsw", "none")
@@ -309,9 +331,29 @@ def main() -> None:
         "nsys",
         "profile",
     ] + nsys_flags
-    subprocess.run(
-        (nsys if enable_profiling else []) + application, check=True, env=env
+    application_result = subprocess.run(
+        (nsys if enable_profiling else []) + application, env=env
     )
+    expected_returncodes = {0}
+    capture_range_end = nsys_arg_value("capture-range-end", "stop-shutdown")
+    if capture_range_end == "stop-shutdown" or capture_range_end.startswith(
+        "repeat-shutdown:"
+    ):
+        # nsys will send this signal on shutdown
+        kill_signal = nsys_arg_value("kill", "sigterm")
+        if kill_signal != "none":
+            if kill_signal == "sigterm":
+                kill_signal = 15
+            elif kill_signal == "sigkill":
+                kill_signal = 9
+            else:
+                kill_signal = int(kill_signal)
+            expected_returncodes.add(128 + kill_signal)
+    if application_result.returncode in expected_returncodes:
+        # Collapse any expected return code into success
+        application_result.returncode = 0
+    else:
+        print(f"Application returned unexpected code {application_result.returncode}")
 
     # If we skipped profiling the application, there is nothing more to be done.
     if not enable_profiling:
@@ -746,7 +788,7 @@ def main() -> None:
             # Make sure any errors from the output thread are surfaced
             future.result()
 
-    exit_code = 0
+    exit_code = application_result.returncode
     with ThreadPoolExecutor() as executor, output_thread(executor):
         # Track futures so we can wait on them and report errors.
         futures = []
@@ -817,7 +859,10 @@ def main() -> None:
             for future in results.done:
                 futures.remove(future)
                 if future.exception() is not None:
-                    exit_code = 1
+                    # Make sure we return an exit code, but don't overwrite which code
+                    # might have been returned by the application
+                    if exit_code == 0:
+                        exit_code = 1
                     traceback.print_exception(future.exception())
             pending = len(futures)
             if pending == 0:

--- a/.github/container/nsys_jax/tests/cuda_profiler_api.py
+++ b/.github/container/nsys_jax/tests/cuda_profiler_api.py
@@ -1,0 +1,29 @@
+from ctypes import cdll
+import jax
+import sys
+import time
+
+# what should this test program do after cudaProfilerStop?
+mode = sys.argv[1]
+assert mode in {"sleep", "exit42"}
+
+
+@jax.jit
+def distinctively_named_function(x):
+    return x @ x.T
+
+
+libcudart = cdll.LoadLibrary("libcudart.so")
+square = jax.random.normal(jax.random.key(1), (32, 32))
+square = distinctively_named_function(square)
+libcudart.cudaProfilerStart()
+square = distinctively_named_function(square)
+libcudart.cudaProfilerStop()
+if mode == "sleep":
+    # Sleep long enough that nsys always wins the race to termination
+    time.sleep(600)
+    sys.exit(24)
+elif mode == "exit42":
+    print("Exiting with status code 42")
+    sys.exit(42)
+raise Exception(f"Unknown exit mode {mode}")

--- a/.github/container/nsys_jax/tests/nsys_jax_test_helpers/__init__.py
+++ b/.github/container/nsys_jax/tests/nsys_jax_test_helpers/__init__.py
@@ -6,15 +6,26 @@ import tempfile
 import zipfile
 
 
+def nsys_jax_with_result(command):
+    """
+    Helper to run nsys-jax with a unique output file that will be automatically
+    cleaned up on destruction. Explicitly returns the `subprocess.CompletedProcess`
+    instance.
+    """
+    output = tempfile.NamedTemporaryFile(suffix=".zip")
+    result = subprocess.run(
+        ["nsys-jax", "--force-overwrite", "--output", output.name] + command,
+    )
+    return output, result
+
+
 def nsys_jax(command):
     """
     Helper to run nsys-jax with a unique output file that will be automatically
-    cleaned up on destruction.
+    cleaned up on destruction. Throws if running `nsys-jax` does not succeed.
     """
-    output = tempfile.NamedTemporaryFile(suffix=".zip")
-    subprocess.run(
-        ["nsys-jax", "--force-overwrite", "--output", output.name] + command, check=True
-    )
+    output, result = nsys_jax_with_result(command)
+    result.check_returncode()
     return output
 
 

--- a/.github/container/nsys_jax/tests/test_basics.py
+++ b/.github/container/nsys_jax/tests/test_basics.py
@@ -1,5 +1,4 @@
 import os
-import subprocess
 import sys
 import tempfile
 import zipfile
@@ -23,20 +22,17 @@ def test_stacktrace_entry_with_file():
     the source file is bundled into the nsys-jax output archive.
     """
     with tempfile.TemporaryDirectory() as tmpdir:
-        archive = f"{tmpdir}/out.zip"
         src_file = f"{tmpdir}/test.py"
         assert os.path.isabs(src_file), src_file
         src_code = "import jax\njax.jit(lambda x: x*2)(4)\n"
         with open(src_file, "w") as f:
             f.write(src_code)
-        subprocess.run(
-            ["nsys-jax", "--output", archive, sys.executable, src_file], check=True
-        )
-        with zipfile.ZipFile(archive) as ifile:
-            src_file_in_archive = f"sources{src_file}"
-            assert src_file_in_archive in ifile.namelist()
-            with ifile.open(src_file_in_archive, "r") as archived_file:
-                assert archived_file.read().decode() == src_code
+        archive = nsys_jax([sys.executable, src_file])
+    with zipfile.ZipFile(archive) as ifile:
+        src_file_in_archive = f"sources{src_file}"
+        assert src_file_in_archive in ifile.namelist()
+        with ifile.open(src_file_in_archive, "r") as archived_file:
+            assert archived_file.read().decode() == src_code
 
 
 def test_stacktrace_entry_without_file():

--- a/.github/container/nsys_jax/tests/test_exit_code_handling.py
+++ b/.github/container/nsys_jax/tests/test_exit_code_handling.py
@@ -1,0 +1,87 @@
+import os
+import pytest  # type: ignore
+import sys
+
+helper_dir = os.path.join(os.path.dirname(__file__), "nsys_jax_test_helpers")
+if helper_dir not in sys.path:
+    sys.path.insert(0, helper_dir)
+from nsys_jax_test_helpers import nsys_jax, nsys_jax_with_result  # noqa: E402
+
+# This example program does different things after calling cudaProfilerStop
+cuda_profiler_api = os.path.join(os.path.dirname(__file__), "cuda_profiler_api.py")
+
+kill_args = {
+    None: [],
+    "none": ["--kill=none"],
+    "sigterm": ["--kill", "sigterm"],
+    "sigkill": ["--kill=sigkill"],
+    "SIGINT": ["--kill", "2"],
+}
+
+
+@pytest.mark.parametrize("kill", kill_args.keys())
+def test_program_that_is_killed_by_nsys(kill):
+    """
+    The default --capture-range-end=stop-shutdown behaviour of nsys profile causes nsys
+    to kill the profiled process after cudaProfilerStop if
+    --capture-range=cudaProfilerApi is used. Test that in this case, nsys-jax returns
+    success (bug 5049736).
+    """
+    if kill == "none":
+        pytest.skip("Expected to hang")
+    output_zip = nsys_jax(
+        kill_args[kill]
+        + [
+            "--capture-range=cudaProfilerApi",
+            "--capture-range-end=stop-shutdown",
+            "--",
+            sys.executable,
+            cuda_profiler_api,
+            "sleep",
+        ]
+    )
+    assert os.path.isfile(output_zip.name)
+
+
+def test_program_that_fails_after_cuda_profiler_stop():
+    """
+    With --capture-range=stop then nsys-jax should still propagate a failure code from
+    the application.
+    """
+    output_zip, result = nsys_jax_with_result(
+        [
+            "--capture-range=cudaProfilerApi",
+            "--capture-range-end=stop",
+            "--",
+            sys.executable,
+            cuda_profiler_api,
+            "exit42",
+        ]
+    )
+    assert result.returncode == 42, result
+    assert os.path.isfile(output_zip.name)
+
+
+@pytest.mark.parametrize("kill", kill_args.keys())
+def test_program_that_fails_after_cuda_profiler_stop_as_nsys_tries_to_kill_it(kill):
+    """
+    The racy case, where either nsys sends SIGTERM or the application exits with 42.
+    Also cover the case where --capture-range-end is not passed explicitly.
+    """
+    output_zip, result = nsys_jax_with_result(
+        kill_args[kill]
+        + [
+            "--capture-range=cudaProfilerApi",
+            "--",
+            sys.executable,
+            cuda_profiler_api,
+            "exit42",
+        ]
+    )
+    # If nsys sends SIGTERM fast enough, the child process will exit due to that and
+    # nsys-jax will return 0 (because that is the expected result). The application
+    # might manage to return 42 before it is killed, which should be propagated by
+    # nsys-jax because it is not expected from the --capture-range-end setting.
+    print(f"nsys-jax returned code {result.returncode}")
+    assert result.returncode in {0, 42}, result
+    assert os.path.isfile(output_zip.name)


### PR DESCRIPTION
Previously then failing to pass `--capture-range-end=stop` would cause the application to exit with an error code and the `nsys-jax` wrapper to abort, even if profile data had been successfully recorded.