### PR TITLE
Fix redundant install of JAX wheels

### DIFF
--- a/.github/container/Dockerfile.jax
+++ b/.github/container/Dockerfile.jax
@@ -49,6 +49,7 @@ ADD xla-arm64-neon.patch /opt
 RUN build-jax.sh \
     --bazel-cache ${BAZEL_CACHE} \
     --build-path-jaxlib ${BUILD_PATH_JAXLIB} \
+    --no-install \
     --src-path-jax ${SRC_PATH_JAX} \
     --src-path-xla ${SRC_PATH_XLA} \
     --sm all \

--- a/.github/container/build-jax.sh
+++ b/.github/container/build-jax.sh
@@ -134,11 +134,11 @@ while [ : ]; do
             usage 1
             ;;
         --install)
-            install=1
+            INSTALL=1
             shift 1
             ;;
         --no-install)
-            install=0
+            INSTALL=0
             shift 1
             ;;
         --src-path-jax)


### PR DESCRIPTION
There is a `pip install` in build-jax.sh that installs the JAX wheels in the 'builder' stage. Since the stage is later discarded, this installation is useless and unnecessary during container build (but still useful for code development).