### PR TITLE
Skip the unversioned symlink in cuDNN >= 9.10

### DIFF
--- a/.github/container/symlnk-cudnn.sh
+++ b/.github/container/symlnk-cudnn.sh
@@ -21,8 +21,15 @@ if [[ -z "${libcudnn_pkgs}" ]]; then
 fi
 
 for cudnn_file in $(dpkg -L ${libcudnn_pkgs} | sort -u); do
-  # Real files and symlinks are linked into $prefix
+  # Skip unversioned symlinks since we'll create our own
   if [[ -f "${cudnn_file}" || -h "${cudnn_file}" ]]; then
+    # Skip if it's an unversioned symlink in the new package structure
+    if [[ -h "${cudnn_file}" ]] && \
+       [[ ! "${cudnn_file}" =~ _v${CUDNN_MAJOR_VERSION}\.h$ ]] && \
+       [[ ! "${cudnn_file}" =~ \.so\.${CUDNN_MAJOR_VERSION}(\.[0-9]+\.[0-9]+)?$ ]]; then
+      echo "Skipping unversioned symlink ${cudnn_file}"
+      continue
+    fi
     # Replace /usr with $prefix
     nosysprefix="${cudnn_file#"/usr/"}"
     # include/x86_64-linux-gpu -> include/


### PR DESCRIPTION
cuDNN < 9.10
```
root@7744493b82c5:/# dpkg -L libcudnn9-cuda-12 libcudnn9-dev-cuda-12 | sort -u

/.
/usr
/usr/include
/usr/include/x86_64-linux-gnu
/usr/include/x86_64-linux-gnu/cudnn_adv_v9.h
/usr/include/x86_64-linux-gnu/cudnn_backend_v9.h
...
/usr/lib
/usr/lib/x86_64-linux-gnu
/usr/lib/x86_64-linux-gnu/libcudnn.so.9
/usr/lib/x86_64-linux-gnu/libcudnn.so.9.9.0
...

```
cuDNN >= 9.10
```
/.
/usr
/usr/include
/usr/include/x86_64-linux-gnu
/usr/include/x86_64-linux-gnu/cudnn.h  <--- unversioned symlink
/usr/include/x86_64-linux-gnu/cudnn_adv.h  <--- unversioned symlink
/usr/include/x86_64-linux-gnu/cudnn_adv_v9.h
/usr/include/x86_64-linux-gnu/cudnn_backend.h  <--- unversioned symlink
/usr/include/x86_64-linux-gnu/cudnn_backend_v9.h
...
/usr/lib
/usr/lib/x86_64-linux-gnu
/usr/lib/x86_64-linux-gnu/libcudnn.so  <--- unversioned symlink
/usr/lib/x86_64-linux-gnu/libcudnn.so.9
/usr/lib/x86_64-linux-gnu/libcudnn.so.9.10.0
/usr/lib/x86_64-linux-gnu/libcudnn_adv.so  <--- unversioned symlink
/usr/lib/x86_64-linux-gnu/libcudnn_adv.so.9
...

```
Adjusting the script to work for both old and new package structure.