### PR TITLE
Ensure JAX installation is editable

### DIFF
--- a/.github/container/Dockerfile.jax
+++ b/.github/container/Dockerfile.jax
@@ -106,7 +106,7 @@ RUN <<"EOF" bash -ex
 for component in $(ls ${BUILD_PATH_JAXLIB}); do
     echo "-e file://${BUILD_PATH_JAXLIB}/${component}" >> /opt/pip-tools.d/requirements-jax.in;
 done
-echo "-e file://${BUILD_PATH_JAXLIB}/jax[k8s]" >> /opt/pip-tools.d/requirements-jax.in
+echo "-e file://${SRC_PATH_JAX}[k8s]" >> /opt/pip-tools.d/requirements-jax.in
 EOF
 
 ## Flax

--- a/.github/container/build-jax.sh
+++ b/.github/container/build-jax.sh
@@ -339,10 +339,10 @@ if [[ "${INSTALL}" == "1" ]]; then
     pip uninstall -y jax jaxlib jax-cuda${TF_CUDA_MAJOR_VERSION}-pjrt jax-cuda${TF_CUDA_MAJOR_VERSION}-plugin
 
     # install jax and jaxlib
-    pip --disable-pip-version-check install -e ${BUILD_PATH_JAXLIB}/jaxlib -e ${BUILD_PATH_JAXLIB}/jax_cuda${TF_CUDA_MAJOR_VERSION}_pjrt -e ${BUILD_PATH_JAXLIB}/jax_cuda${TF_CUDA_MAJOR_VERSION}_plugin -e ${BUILD_PATH_JAXLIB}/jax
+    pip --disable-pip-version-check install -e ${BUILD_PATH_JAXLIB}/jaxlib -e ${BUILD_PATH_JAXLIB}/jax_cuda${TF_CUDA_MAJOR_VERSION}_pjrt -e ${BUILD_PATH_JAXLIB}/jax_cuda${TF_CUDA_MAJOR_VERSION}_plugin -e ${SRC_PATH_JAX}/jax
 
     ## after installation (example)
-    # jax                     0.5.4.dev20250325    /opt/jaxlibs/jax
+    # jax                     0.5.4.dev20250325    /opt/jax
     # jax-cuda12-pjrt         0.5.4.dev20250325    /opt/jaxlibs/jax_cuda12_pjrt
     # jax-cuda12-plugin       0.5.4.dev20250325    /opt/jaxlibs/jax_cuda12_plugin
     # jaxlib                  0.5.4.dev20250325    /opt/jaxlibs/jaxlib

--- a/.github/container/build-jax.sh
+++ b/.github/container/build-jax.sh
@@ -310,7 +310,7 @@ time python "${SRC_PATH_JAX}/build/build.py" build \
     --editable \
     --use_clang \
     --use_new_wheel_build_rule \
-    --wheels=jax,jaxlib,jax-cuda-plugin,jax-cuda-pjrt \
+    --wheels=jaxlib,jax-cuda-plugin,jax-cuda-pjrt \
     --cuda_compute_capabilities=$TF_CUDA_COMPUTE_CAPABILITIES \
     --bazel_options=--linkopt=-fuse-ld=lld \
     --local_xla_path=$SRC_PATH_XLA \
@@ -320,10 +320,10 @@ popd
 
 # Make sure that JAX depends on the local jaxlib installation
 # https://jax.readthedocs.io/en/latest/developer.html#specifying-dependencies-on-local-wheels
-line="jax @ file://${BUILD_PATH_JAXLIB}/jax"
-if ! grep -xF "${line}" "${SRC_PATH_JAX}/build/requirements.in"; then
+local_jax_whl="jax @ file://${SRC_PATH_JAX}"
+if ! grep -xF "${local_jax_whl}" "${SRC_PATH_JAX}/build/requirements.in"; then
     pushd "${SRC_PATH_JAX}"
-    echo "${line}" >> build/requirements.in
+    echo "${local_jax_whl}" >> build/requirements.in
     echo "jaxlib @ file://${BUILD_PATH_JAXLIB}/jaxlib" >> build/requirements.in
     echo "jax-cuda${TF_CUDA_MAJOR_VERSION}-pjrt @ file://${BUILD_PATH_JAXLIB}/jax_cuda${TF_CUDA_MAJOR_VERSION}_pjrt" >> build/requirements.in
     echo "jax-cuda${TF_CUDA_MAJOR_VERSION}-plugin @ file://${BUILD_PATH_JAXLIB}/jax_cuda${TF_CUDA_MAJOR_VERSION}_plugin" >> build/requirements.in

--- a/.github/container/test-jax.sh
+++ b/.github/container/test-jax.sh
@@ -29,7 +29,7 @@ ENABLE_X64=-1
 
 query_tests() {
     cd ${SRC_PATH_JAX}
-    python build/build.py build --use_new_wheel_build_rule --wheels=jax,jaxlib,jax-cuda-plugin,jax-cuda-pjrt --configure_only
+    python build/build.py build --use_new_wheel_build_rule --wheels=jaxlib,jax-cuda-plugin,jax-cuda-pjrt --configure_only
     bazel query tests/... 2>&1 | grep -F '//tests:'
     exit
 }
@@ -196,5 +196,5 @@ pip install matplotlib
 ## Run tests
 
 cd ${SRC_PATH_JAX}
-python build/build.py build --use_new_wheel_build_rule --wheels=jax,jaxlib,jax-cuda-plugin,jax-cuda-pjrt --configure_only
+python build/build.py build --use_new_wheel_build_rule --wheels=jaxlib,jax-cuda-plugin,jax-cuda-pjrt --configure_only
 bazel test ${BAZEL_TARGET} ${TEST_TAG_FILTERS} ${COMMON_FLAGS} ${EXTRA_FLAGS}


### PR DESCRIPTION
Currently, the JAX Python source that we **installed** in the container is created by `build-jax.sh` (via _python build.py build --editable ... --wheels=**jax**,jaxlib,jax-cuda-plugin,jax-cuda-pjrt_)  and placed under `/opt/jaxlibs/jax`:

```
$ docker run --gpus all ghcr.io/nvidia/jax:jax python -c 'import jax; print(jax.__path__)'
['/opt/jaxlibs/jax/jax']
```

As a result, two copies of the JAX source exist in the container at `/opt/jax` and `/opt/jaxlibs/jax`, leading to potential confusions. Also, this defeats the 'editable' purpose of the build, as mounting a JAX working copy from outside the container to `/opt/jax` will not replace the installed JAX package.

Given that the editable wheel at `/opt/jaxlibs/jax` is practically identical to the original source (sans a number of build-related files), we should bypass creating this extra copy and directly specify `/opt/jax` as the installation target in the Dockerfile and build script. With this change, we will have
```
>>> import jax; print(jax.__path__)
['/opt/jax/jax']
```
which is the desired usage pattern.
