### PR TITLE
triage-tool: support multi-node triage

### DIFF
--- a/.github/triage/jax_toolbox_triage/args.py
+++ b/.github/triage/jax_toolbox_triage/args.py
@@ -175,19 +175,33 @@ def parse_args(args=None):
     )
     args = parser.parse_args(args=args)
     assert args.container_runtime in {"docker", "pyxis"}, args.container_runtime
-    passing_commits_known = (args.passing_container is not None) or (args.passing_commits is not None)
-    failing_commits_known = (args.failing_container is not None) or (args.failing_commits is not None)
+    passing_commits_known = (args.passing_container is not None) or (
+        args.passing_commits is not None
+    )
+    failing_commits_known = (args.failing_container is not None) or (
+        args.failing_commits is not None
+    )
     sets_of_known_commits = passing_commits_known + failing_commits_known
     if sets_of_known_commits == 2:
         # If the container-level search is being skipped, because a valid combination
         # of --{passing,failing}-{commits,container} is passed, then no container-level
         # search options should be passed.
-        assert args.container is None and args.start_date is None and args.end_date is None, "No container-level search options should be passed if the passing/failing containers/commits have been passed explicitly."
-        assert args.passing_container is not None or args.failing_container is not None, ""
+        assert (
+            args.container is None and args.start_date is None and args.end_date is None
+        ), (
+            "No container-level search options should be passed if the passing/failing containers/commits have been passed explicitly."
+        )
+        assert (
+            args.passing_container is not None or args.failing_container is not None
+        ), ""
     elif sets_of_known_commits == 1:
-        raise Exception("If --passing-{commits OR container} is passed then --failing-{commits OR container} should be too")
+        raise Exception(
+            "If --passing-{commits OR container} is passed then --failing-{commits OR container} should be too"
+        )
     else:
         # None of --{passing,failing}-{commits,container} were passed, make sure the
         # compulsory arguments for the container-level search were passed
-        assert args.container is not None, "--container must be passed for the container-level search"
+        assert args.container is not None, (
+            "--container must be passed for the container-level search"
+        )
     return args

--- a/.github/triage/jax_toolbox_triage/docker.py
+++ b/.github/triage/jax_toolbox_triage/docker.py
@@ -56,7 +56,10 @@ class DockerContainer:
         return f"Docker({self._url})"
 
     def exec(
-        self, command: typing.List[str], workdir=None
+        self,
+        command: typing.List[str],
+        policy: typing.Literal["once", "once_per_container", "default"] = "default",
+        workdir=None,
     ) -> subprocess.CompletedProcess:
         """
         Run a command inside a persistent container.

--- a/.github/triage/jax_toolbox_triage/logic.py
+++ b/.github/triage/jax_toolbox_triage/logic.py
@@ -217,6 +217,7 @@ def commit_search(
         logger.info("Skipping check that 'bad' commits reproduce failure")
     else:
         # Verify we can build successfully and that the test fails as expected.
+        logger.info("Verifying test failure using 'bad' commits")
         range_end_result, stdout, stderr = build_and_test(
             jax_commit=end_jax_commit, xla_commit=end_xla_commit
         )
@@ -232,6 +233,7 @@ def commit_search(
         logger.info("Skipping check that 'good' commits reproduce success")
     else:
         # Verify that we can build successfully and that the test succeeds as expected.
+        logger.info("Verifying test success using 'good' commits")
         range_start_result, stdout, stderr = build_and_test(
             jax_commit=start_jax_commit, xla_commit=start_xla_commit
         )

--- a/.github/triage/jax_toolbox_triage/pyxis.py
+++ b/.github/triage/jax_toolbox_triage/pyxis.py
@@ -11,6 +11,7 @@ import typing
 # for .exists()
 _process_token = secrets.token_bytes()
 
+
 class PyxisContainer:
     def __init__(
         self,

--- a/.github/triage/jax_toolbox_triage/pyxis.py
+++ b/.github/triage/jax_toolbox_triage/pyxis.py
@@ -1,9 +1,15 @@
+import hashlib
 import logging
 import pathlib
 import secrets
 import subprocess
 import typing
 
+# Used to make sure the {url: name} mapping is consistent within a process, but that
+# names are not re-used by different invocations of the triage tool. Using a consistent
+# mapping is a simple way of avoiding re-creating the container multiple times, e.g.
+# for .exists()
+_process_token = secrets.token_bytes()
 
 class PyxisContainer:
     def __init__(
@@ -16,7 +22,7 @@ class PyxisContainer:
         self._logger = logger
         mount_str = ",".join(map(lambda t: f"{t[0]}:{t[1]}", mounts))
         self._mount_args = [f"--container-mounts={mount_str}"] if mount_str else []
-        self._name = secrets.token_urlsafe()
+        self._name = hashlib.sha256(url.encode() + _process_token).hexdigest()
         self._url = url
 
     def __enter__(self):

--- a/.github/triage/jax_toolbox_triage/pyxis.py
+++ b/.github/triage/jax_toolbox_triage/pyxis.py
@@ -39,12 +39,20 @@ class PyxisContainer:
         return f"Pyxis({self._url})"
 
     def exec(
-        self, command: typing.List[str], workdir=None
+        self,
+        command: typing.List[str],
+        policy: typing.Literal["once", "once_per_container", "default"] = "default",
+        workdir=None,
     ) -> subprocess.CompletedProcess:
         """
         Run a command inside a persistent container.
         """
         workdir = [] if workdir is None else [f"--container-workdir={workdir}"]
+        policy_args = {
+            "once": ["--ntasks=1"],
+            "once_per_container": ["--ntasks-per-node=1"],
+            "default": [],
+        }[policy]
         command = (
             [
                 "srun",
@@ -53,6 +61,7 @@ class PyxisContainer:
                 "--container-remap-root",
             ]
             + self._mount_args
+            + policy_args
             + workdir
             + command
         )

--- a/.github/triage/tests/test_arg_parsing.py
+++ b/.github/triage/tests/test_arg_parsing.py
@@ -9,8 +9,18 @@ valid_start_end_container = [
     "failing-url",
 ]
 valid_container_and_commits = [
-    ["--passing-container", "passing-url", "--failing-commits", "jax:0123456789,xla:fedcba9876543210"],
-    ["--failing-container", "failing-url", "--passing-commits", "xla:fedcba9876543210,jax:0123456789"],
+    [
+        "--passing-container",
+        "passing-url",
+        "--failing-commits",
+        "jax:0123456789,xla:fedcba9876543210",
+    ],
+    [
+        "--failing-container",
+        "failing-url",
+        "--passing-commits",
+        "xla:fedcba9876543210,jax:0123456789",
+    ],
 ]
 valid_start_end_date_args = [
     ["--container", "jax"],
@@ -21,7 +31,10 @@ valid_start_end_date_args = [
 
 
 @pytest.mark.parametrize(
-    "good_args", [valid_start_end_container] + valid_start_end_date_args + valid_container_and_commits
+    "good_args",
+    [valid_start_end_container]
+    + valid_start_end_date_args
+    + valid_container_and_commits,
 )
 def test_good_container_args(good_args):
     args = parse_args(good_args + test_command)
@@ -48,7 +61,12 @@ def test_bad_container_arg_combinations_across_groups(date_args):
         ["--passing-container", "passing-url"],
         ["--failing-container", "failing-url"],
         # Need at least one container
-        ["--passing-commits", "jax:0123456789,xla:fedcba9876543210", "--failing-commits", "xla:fedcba9876543210,jax:0123456789"],
+        [
+            "--passing-commits",
+            "jax:0123456789,xla:fedcba9876543210",
+            "--failing-commits",
+            "xla:fedcba9876543210,jax:0123456789",
+        ],
         # Cannot combine --passing-container with --passing-commits etc.
         ["--passing-container", "passing-url", "--passing-commits", "jax:123,xla:456"],
         ["--failing-container", "failing-url", "--failing-commits", "jax:123,xla:456"],
@@ -75,6 +93,7 @@ def test_bad_container_arg_combinations_within_groups(container_args):
 def test_unparsable_container_args(container_args):
     with pytest.raises(SystemExit):
         parse_args(container_args + test_command)
+
 
 def test_invalid_container_runtime():
     with pytest.raises(Exception):

--- a/.github/triage/tests/test_arg_parsing.py
+++ b/.github/triage/tests/test_arg_parsing.py
@@ -8,6 +8,10 @@ valid_start_end_container = [
     "--failing-container",
     "failing-url",
 ]
+valid_container_and_commits = [
+    ["--passing-container", "passing-url", "--failing-commits", "jax:0123456789,xla:fedcba9876543210"],
+    ["--failing-container", "failing-url", "--passing-commits", "xla:fedcba9876543210,jax:0123456789"],
+]
 valid_start_end_date_args = [
     ["--container", "jax"],
     ["--container", "jax", "--start-date", "2024-10-02"],
@@ -17,7 +21,7 @@ valid_start_end_date_args = [
 
 
 @pytest.mark.parametrize(
-    "good_args", [valid_start_end_container] + valid_start_end_date_args
+    "good_args", [valid_start_end_container] + valid_start_end_date_args + valid_container_and_commits
 )
 def test_good_container_args(good_args):
     args = parse_args(good_args + test_command)
@@ -39,9 +43,20 @@ def test_bad_container_arg_combinations_across_groups(date_args):
         ["--start-date", "2024-10-01"],
         ["--end-date", "2024-10-02"],
         ["--start-date", "2024-10-01", "--end-date", "2024-10-02"],
-        # Need both if either is passed
+        # If --passing-container (or --passing-commits) is passed then
+        # --failing-container (or --failing-commits) must be too
         ["--passing-container", "passing-url"],
         ["--failing-container", "failing-url"],
+        # Need at least one container
+        ["--passing-commits", "jax:0123456789,xla:fedcba9876543210", "--failing-commits", "xla:fedcba9876543210,jax:0123456789"],
+        # Cannot combine --passing-container with --passing-commits etc.
+        ["--passing-container", "passing-url", "--passing-commits", "jax:123,xla:456"],
+        ["--failing-container", "failing-url", "--failing-commits", "jax:123,xla:456"],
+        # --{passing,failing}-commits must be formatted correctly
+        ["--passing-container", "passing-url", "--failing-commits", "jax:123"],
+        ["--passing-container", "passing-url", "--failing-commits", "jax:123,jax:456"],
+        ["--passing-container", "passing-url", "--failing-commits", "xla:123"],
+        ["--passing-container", "passing-url", "--failing-commits", "bob:123"],
     ],
 )
 def test_bad_container_arg_combinations_within_groups(container_args):
@@ -60,3 +75,7 @@ def test_bad_container_arg_combinations_within_groups(container_args):
 def test_unparsable_container_args(container_args):
     with pytest.raises(SystemExit):
         parse_args(container_args + test_command)
+
+def test_invalid_container_runtime():
+    with pytest.raises(Exception):
+        parse_args(["--container-runtime=magic-beans"] + test_command)


### PR DESCRIPTION
- Add `--{passing,failing}-commits` option, which allows the commit-level search to be manually restricted in scope
  - This also allows single-container triage, as you can pass `--{passing,failing}-container` and `--{failing,passing}-commits`
- With the Pyxis backend, re-use the same container instance within a single triage tool process
  - This reduces the amount of time spent in container creation
- Support multi-node/multi-process triage with the Pyxis backend
  - This is implemented by annotating the various commands run inside the containers as `once` (run once, in one container instance), `once_per_container` (run once per container instance, i.e. once per node), and `default` (run without extra `srun` arguments -- the caller must make this do the right thing e.g. by passing `--ntasks-per-node` to `salloc`.
    -  `once` example: getting the JAX commit from a container
    - `once_per_container` example: building JAX
    - `default` example: running the test case