### PR TITLE
Add JetStream to /opt/jetstream

### DIFF
--- a/.github/container/Dockerfile.maxtext
+++ b/.github/container/Dockerfile.maxtext
@@ -16,17 +16,23 @@ ARG URLREF_JETSTREAM
 ARG SRC_PATH_MAXTEXT
 ARG SRC_PATH_JETSTREAM
 
-RUN <<"EOF" bash -ex
+RUN <<"EOF" bash -ex -o pipefail
 git-clone.sh ${URLREF_MAXTEXT} ${SRC_PATH_MAXTEXT}
 git-clone.sh ${URLREF_JETSTREAM} ${SRC_PATH_JETSTREAM}
+EOF
 
+RUN <<"EOF" bash -ex -o pipefail
 echo "-r ${SRC_PATH_MAXTEXT}/requirements.txt" >> /opt/pip-tools.d/requirements-maxtext.in
 echo "-e file://${SRC_PATH_JETSTREAM}" >> /opt/pip-tools.d/requirements-maxtext.in
+EOF
 
-# remove GitHub direct‑reference of JetStream in MaxText requirements
+# remove GitHub direct-reference of JetStream in MaxText requirements
+RUN <<"EOF" bash -ex -o pipefail
 sed -i '/^google-jetstream/d' ${SRC_PATH_MAXTEXT}/requirements.txt
+EOF
 
 # add version constraints to avoid eternal dependency resolution
+RUN <<"EOF" bash -ex -o pipefail
 for pattern in \
     "s|absl-py|absl-py>=2.1.0|g" \
     "s|protobuf==3.20.3|protobuf>=3.19.0|g" \
@@ -37,8 +43,10 @@ for pattern in \
     # tensorflow-cpu==2.19.0 is incompatible with tensorflow-text
     sed -i "${pattern}" ${SRC_PATH_MAXTEXT}/requirements.txt
 done
+EOF
 
 # add extra dependencies
+RUN <<"EOF" bash -ex -o pipefail
 echo >> ${SRC_PATH_MAXTEXT}/requirements.txt  # add new line
 for requirement in \
     "tensorflow-metadata>=1.15.0" \

--- a/.github/container/Dockerfile.maxtext
+++ b/.github/container/Dockerfile.maxtext
@@ -26,7 +26,7 @@ echo "-e file://${SRC_PATH_JETSTREAM}" >> /opt/pip-tools.d/requirements-maxtext.
 # remove GitHub direct‑reference of JetStream in MaxText requirements
 sed -i '/^google-jetstream/d' ${SRC_PATH_MAXTEXT}/requirements.txt
 
-# add version constraints to avoid eternal dependency resoltion
+# add version constraints to avoid eternal dependency resolution
 for pattern in \
     "s|absl-py|absl-py>=2.1.0|g" \
     "s|protobuf==3.20.3|protobuf>=3.19.0|g" \

--- a/.github/container/Dockerfile.maxtext
+++ b/.github/container/Dockerfile.maxtext
@@ -2,22 +2,31 @@
 
 ARG BASE_IMAGE=ghcr.io/nvidia/jax-mealkit:jax
 ARG URLREF_MAXTEXT=https://github.com/google/maxtext.git#main
+ARG URLREF_JETSTREAM=https://github.com/AI-Hypercomputer/JetStream.git#main
 ARG SRC_PATH_MAXTEXT=/opt/maxtext
+ARG SRC_PATH_JETSTREAM=/opt/jetstream
 
 ###############################################################################
 ## Download source and add auxiliary scripts
 ###############################################################################
 
-FROM ${BASE_IMAGE} as mealkit
+FROM ${BASE_IMAGE} AS mealkit
 ARG URLREF_MAXTEXT
+ARG URLREF_JETSTREAM
 ARG SRC_PATH_MAXTEXT
+ARG SRC_PATH_JETSTREAM
 
 RUN <<"EOF" bash -ex
 git-clone.sh ${URLREF_MAXTEXT} ${SRC_PATH_MAXTEXT}
-echo "-r ${SRC_PATH_MAXTEXT}/requirements.txt" >> /opt/pip-tools.d/requirements-maxtext.in
+git-clone.sh ${URLREF_JETSTREAM} ${SRC_PATH_JETSTREAM}
 
-# specify some restrictions to speed up the build and
-# avoid pip to download and check all available versions of packages
+echo "-r ${SRC_PATH_MAXTEXT}/requirements.txt" >> /opt/pip-tools.d/requirements-maxtext.in
+echo "-e file://${SRC_PATH_JETSTREAM}" >> /opt/pip-tools.d/requirements-maxtext.in
+
+# remove GitHub direct‑reference of JetStream in MaxText requirements
+sed -i '/^google-jetstream/d' ${SRC_PATH_MAXTEXT}/requirements.txt
+
+# add version constraints to avoid eternal dependency resoltion
 for pattern in \
     "s|absl-py|absl-py>=2.1.0|g" \
     "s|protobuf==3.20.3|protobuf>=3.19.0|g" \
@@ -26,10 +35,11 @@ for pattern in \
     "s|tensorflow>=2.13.0|tensorflow==2.18.1|g" \
   ; do
     # tensorflow-cpu==2.19.0 is incompatible with tensorflow-text
-    sed -i "${pattern}" ${SRC_PATH_MAXTEXT}/requirements.txt;
+    sed -i "${pattern}" ${SRC_PATH_MAXTEXT}/requirements.txt
 done
-# add new line in case requirements.txt does not end with a new line
-echo >> ${SRC_PATH_MAXTEXT}/requirements.txt
+
+# add extra dependencies
+echo >> ${SRC_PATH_MAXTEXT}/requirements.txt  # add new line
 for requirement in \
     "tensorflow-metadata>=1.15.0" \
     "seqio@git+https://github.com/google/seqio.git" \
@@ -48,7 +58,7 @@ ADD test-maxtext.sh /usr/local/bin
 ## Install accumulated packages from the base image and the previous stage
 ###############################################################################
 
-FROM mealkit as final
+FROM mealkit AS final
 
 RUN pip-finalize.sh
 

--- a/.github/container/manifest.yaml
+++ b/.github/container/manifest.yaml
@@ -75,7 +75,7 @@ google-jetstream:
   url: https://github.com/AI-Hypercomputer/JetStream.git
   tracking_ref: main
   latest_verified_commit: b8b9cb2ea4668da2c5012fc4c7ba958424d82ac9
-  mode: pip-vcs
+  mode: git-clone
 maxtext:
   url: https://github.com/google/maxtext.git
   tracking_ref: main

--- a/.github/workflows/_ci.yaml
+++ b/.github/workflows/_ci.yaml
@@ -94,7 +94,7 @@ jobs:
       DOCKERFILE: .github/container/Dockerfile.maxtext
       EXTRA_BUILD_ARGS: |
         URLREF_MAXTEXT=${{ fromJson(inputs.SOURCE_URLREFS).MAXTEXT }}
-        URLREF_JETSTREAM=${{ fromJson(inputs.SOURCE_URLREFS).JETSTREAM }}
+        URLREF_JETSTREAM=${{ fromJson(inputs.SOURCE_URLREFS).GOOGLE-JETSTREAM }}
     secrets: inherit
 
   build-upstream-t5x:

--- a/.github/workflows/_ci.yaml
+++ b/.github/workflows/_ci.yaml
@@ -94,7 +94,7 @@ jobs:
       DOCKERFILE: .github/container/Dockerfile.maxtext
       EXTRA_BUILD_ARGS: |
         URLREF_MAXTEXT=${{ fromJson(inputs.SOURCE_URLREFS).MAXTEXT }}
-        URLREF_JETSTREAM=${{ fromJson(inputs.SOURCE_URLREFS).GOOGLE-JETSTREAM }}
+        URLREF_JETSTREAM=${{ fromJson(inputs.SOURCE_URLREFS).GOOGLE_JETSTREAM }}
     secrets: inherit
 
   build-upstream-t5x:

--- a/.github/workflows/_ci.yaml
+++ b/.github/workflows/_ci.yaml
@@ -94,6 +94,7 @@ jobs:
       DOCKERFILE: .github/container/Dockerfile.maxtext
       EXTRA_BUILD_ARGS: |
         URLREF_MAXTEXT=${{ fromJson(inputs.SOURCE_URLREFS).MAXTEXT }}
+        URLREF_JETSTREAM=${{ fromJson(inputs.SOURCE_URLREFS).JETSTREAM }}
     secrets: inherit
 
   build-upstream-t5x:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -37,7 +37,7 @@ on:
         type: string
         description: |
           A comma-separated PACKAGE=URL#REF list to override sources used by build.
-          PACKAGE∊{JAX,XLA,Flax,transformer-engine,airio,axlearn,equinox,T5X,maxtext} (case-insensitive)
+          PACKAGE∊{JAX,XLA,Flax,transformer-engine,airio,axlearn,equinox,T5X,maxtext,jetstream} (case-insensitive)
         default: ''
         required: false
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -37,7 +37,7 @@ on:
         type: string
         description: |
           A comma-separated PACKAGE=URL#REF list to override sources used by build.
-          PACKAGE∊{JAX,XLA,Flax,transformer-engine,airio,axlearn,equinox,T5X,maxtext,jetstream} (case-insensitive)
+          PACKAGE∊{JAX,XLA,Flax,transformer-engine,airio,axlearn,equinox,T5X,maxtext,google-jetstream} (case-insensitive)
         default: ''
         required: false
 


### PR DESCRIPTION
`jetstream/tools` contains checkpoint converters that are not shipped in the wheel. This is a stop-gap solution and the longer term solution is to have upstream ship a CLI for the converters.