### PR TITLE
triage-tool: support triaging >2 packages

### DIFF
--- a/.github/triage/jax_toolbox_triage/args.py
+++ b/.github/triage/jax_toolbox_triage/args.py
@@ -42,7 +42,7 @@ def parse_args(args=None):
             re-testing inside the earliest container that demonstrates the failure. At each
             point, the oldest JAX commit that is newer than XLA is used.""",
     )
-    parser.add_argument(
+    container_search_args.add_argument(
         "--container",
         help="""
             Container to use. Example: jax, maxtext. Used to construct the URLs of

--- a/.github/triage/jax_toolbox_triage/docker.py
+++ b/.github/triage/jax_toolbox_triage/docker.py
@@ -3,6 +3,8 @@ import pathlib
 import subprocess
 import typing
 
+from .utils import run_and_log
+
 
 class DockerContainer:
     def __init__(
@@ -59,17 +61,17 @@ class DockerContainer:
         self,
         command: typing.List[str],
         policy: typing.Literal["once", "once_per_container", "default"] = "default",
+        stderr: typing.Literal["interleaved", "separate"] = "interleaved",
         workdir=None,
     ) -> subprocess.CompletedProcess:
         """
         Run a command inside a persistent container.
         """
         workdir = [] if workdir is None else ["--workdir", workdir]
-        return subprocess.run(
+        return run_and_log(
             ["docker", "exec"] + workdir + [self._id] + command,
-            encoding="utf-8",
-            stderr=subprocess.PIPE,
-            stdout=subprocess.PIPE,
+            logger=self._logger,
+            stderr=stderr,
         )
 
     def check_exec(

--- a/.github/triage/tests/test_triage_logic.py
+++ b/.github/triage/tests/test_triage_logic.py
@@ -1,3 +1,4 @@
+import collections
 import datetime
 import itertools
 import logging
@@ -7,47 +8,63 @@ from jax_toolbox_triage.logic import commit_search, container_search, TestResult
 
 
 def wrap(b):
-    return b, "", ""
+    return TestResult(result=b, stdouterr="")
 
 
 @pytest.fixture
 def logger():
     logger = logging.getLogger("triage-tests")
     logger.setLevel(logging.DEBUG)
+    console = logging.StreamHandler()
+    console.setLevel(logging.INFO)
+    logger.addHandler(console)
     return logger
+
+
+def make_commits(jax, xla, flax=None):
+    # BEWARE: the order is meaningful for the triage algorithm
+    return collections.OrderedDict(
+        (("xla", xla), ("jax", jax)) + (() if flax is None else (("flax", flax),))
+    )
 
 
 @pytest.mark.parametrize(
     "dummy_test,expected",
     [
         (
-            lambda jax_commit, xla_commit: wrap(jax_commit == "oJ"),
-            {"xla_ref": "oX", "jax_bad": "mJ", "jax_good": "oJ"},
+            lambda commits: wrap(commits["jax"] == "oJ"),
+            {"flax_ref": "nF", "xla_ref": "oX", "jax_bad": "mJ", "jax_good": "oJ"},
         ),
         (
-            lambda jax_commit, xla_commit: wrap(jax_commit != "nJ"),
-            {"xla_ref": "oX", "jax_bad": "nJ", "jax_good": "mJ"},
+            lambda commits: wrap(commits["jax"] != "nJ"),
+            {"flax_ref": "nF", "xla_ref": "oX", "jax_bad": "nJ", "jax_good": "mJ"},
         ),
         (
-            lambda jax_commit, xla_commit: wrap(xla_commit == "oX"),
-            {"jax_ref": "nJ", "xla_bad": "nX", "xla_good": "oX"},
+            lambda commits: wrap(commits["xla"] == "oX"),
+            {"flax_ref": "nF", "jax_ref": "nJ", "xla_bad": "nX", "xla_good": "oX"},
+        ),
+        (
+            lambda commits: wrap(commits["flax"] == "oF"),
+            {"flax_bad": "nF", "flax_good": "oF", "xla_ref": "oX", "jax_ref": "oJ"},
         ),
     ],
 )
 def test_commit_search_explicit(logger, dummy_test, expected):
     """
-    Test the three possibilities in the hardcoded sequence below, where the container
-    level search yielded that (oJ, oX) passed and (nX, nJ) failed. mJ, nJ or nX could
-    be the culprit.
+    Test the four possibilities in the hardcoded sequence below, where the container
+    level search yielded that (oJ, oX, oF) passed and (nX, nJ, nF) failed. mJ, nJ, nX
+    or nF could be the culprit.
     """
-    jax_commits = [("oJ", 1), ("mJ", 2), ("nJ", 3)]
-    xla_commits = [("oX", 1), ("nX", 3)]
+    commits = make_commits(
+        jax=[("oJ", 1), ("mJ", 2), ("nJ", 3)],
+        xla=[("oX", 1), ("nX", 3)],
+        flax=[("oF", 1), ("nF", 3)],
+    )
     algorithm_result = commit_search(
         build_and_test=dummy_test,
-        jax_commits=jax_commits,
+        commits=commits,
         logger=logger,
         skip_precondition_checks=False,
-        xla_commits=xla_commits,
     )
     assert algorithm_result == expected
 
@@ -57,17 +74,18 @@ step_size = datetime.timedelta(days=1)
 
 
 @pytest.mark.parametrize("seed", range(10))
+@pytest.mark.parametrize("packages", [2, 3, 100])
 @pytest.mark.parametrize("extra_commits", [0, 2, 7, 100])
-def test_commit_search(logger, extra_commits, seed):
+def test_commit_search(logger, extra_commits, packages, seed):
     """
-    Generate random sequences of JAX/XLA commits and test that the commit-level search
-    algorithm yields the expected results.
+    Generate random sequences of commits for `packages` different packages and test
+    that the commit-level search algorithm yields the expected results.
 
-    The minimal set of commits generated is (good, bad) for one component and (ref) for
-    the other, where the test passes for (good, ref) and fails for (bad, ref).
+    The minimal set of commits generated is (good, bad) for the buggy package and
+    (ref_i) for each other package, where the test passes for (good, ref_1, ...) and
+    fails for (bad, ref_1, ...).
 
-    Around `extra_commits` extra commits will be added across the two components around
-    these.
+    Around `extra_commits` extra commits will be added across the 2+ packages.
     """
     rng = random.Random(seed)
 
@@ -77,11 +95,13 @@ def test_commit_search(logger, extra_commits, seed):
     def random_delay():
         return rng.randint(1, 10) * step_size
 
-    # Randomise whether JAX or XLA is newer at the start of the range
-    commits = {
-        "jax": [(random_hash(), start_date)],
-        "xla": [(random_hash(), start_date + rng.randint(-2, +2) * step_size)],
-    }
+    commits = collections.OrderedDict()
+    package_names = [f"pkg{i}" for i in range(packages)]
+    for package in package_names:
+        # Add the minimal good/start-of-range commit
+        commits[package] = [
+            (random_hash(), start_date + rng.randint(-2, +2) * step_size)
+        ]
 
     def append_random_commits(n):
         for _ in range(n):
@@ -92,7 +112,7 @@ def test_commit_search(logger, extra_commits, seed):
     append_random_commits(extra_commits // 2)
 
     # Inject the bad commit
-    culprit, innocent = rng.choice([("jax", "xla"), ("xla", "jax")])
+    culprit = rng.choice(package_names)
     good_commit, good_date = commits[culprit][-1]
     bad_commit, bad_date = random_hash(), good_date + random_delay()
     assert good_date < bad_date
@@ -101,49 +121,64 @@ def test_commit_search(logger, extra_commits, seed):
     # Noise
     append_random_commits(extra_commits // 2)
 
-    def dummy_test(*, jax_commit, xla_commit):
-        jax_date = {sha: dt for sha, dt in commits["jax"]}[jax_commit]
-        xla_date = {sha: dt for sha, dt in commits["xla"]}[xla_commit]
-        return wrap(xla_date < bad_date if culprit == "xla" else jax_date < bad_date)
+    culprit_dates = {sha: dt for sha, dt in commits[culprit]}
+    assert len(culprit_dates) == len(commits[culprit])
+
+    def dummy_test(*, commits):
+        return wrap(culprit_dates[commits[culprit]] < bad_date)
 
     algorithm_result = commit_search(
         build_and_test=dummy_test,
-        jax_commits=commits["jax"],
+        commits=commits,
         logger=logger,
         skip_precondition_checks=False,
-        xla_commits=commits["xla"],
     )
-    # Do not check the reference commit, it's a bit underspecified quite what it means,
-    # other than that the dummy_test assertions below should pass
-    innocent_ref = algorithm_result.pop(f"{innocent}_ref")
+    # Do not check the reference commits, it's a bit underspecified quite what they
+    # mean, other than that the dummy_test assertions below should pass
+    ref_commits = {
+        package: algorithm_result.pop(f"{package}_ref")
+        for package in package_names
+        if package != culprit
+    }
     assert {
         f"{culprit}_bad": bad_commit,
         f"{culprit}_good": good_commit,
     } == algorithm_result
-    if culprit == "jax":
-        assert not dummy_test(jax_commit=bad_commit, xla_commit=innocent_ref)[0]
-        assert dummy_test(jax_commit=good_commit, xla_commit=innocent_ref)[0]
-    else:
-        assert not dummy_test(jax_commit=innocent_ref, xla_commit=bad_commit)[0]
-        assert dummy_test(jax_commit=innocent_ref, xla_commit=good_commit)[0]
+    assert dummy_test(
+        commits={culprit: algorithm_result[f"{culprit}_good"]} | ref_commits
+    ).result
+    assert not dummy_test(
+        commits={culprit: algorithm_result[f"{culprit}_bad"]} | ref_commits
+    ).result
 
 
 def other(project):
     return "xla" if project == "jax" else "jax"
 
 
-def create_commits(num_commits):
+def create_commits(num_commits, num_projects):
     """
     Generate commits for test_commit_search_exhaustive.
     """
+    assert num_commits > num_projects, (
+        "Need at least a good commit for each project plus one bad commit for a culprit project"
+    )
 
     def fake_hash():
         fake_hash.n += 1
         return str(fake_hash.n)
 
     fake_hash.n = 0
-    for first_project in ["jax", "xla"]:
-        for commit_types in itertools.product(range(3), repeat=num_commits - 1):
+    for first_project in range(num_projects):
+        # commit_types is a list of instructions for how to create the next commit from
+        # the current one. There are 1 + 2 * (num_projects - 1) values:
+        # - same project, increment time (0)
+        # - different project, increment time (odd#, project offset = (code-1)//2)
+        # - different project, same time (even#, project offset = (code-1)//2)
+        # these are coded as integers
+        for commit_types in itertools.product(
+            range(1 + 2 * (num_projects - 1)), repeat=num_commits - 1
+        ):
             commits = [(first_project, fake_hash(), start_date)]
             # Cannot have all commits from the same project
             if sum(commit_types) == 0:
@@ -152,13 +187,16 @@ def create_commits(num_commits):
                 prev_project, _, prev_date = commits[-1]
                 if commit_type == 0:  # same
                     commits.append((prev_project, fake_hash(), prev_date + step_size))
-                elif commit_type == 1:  # diff
-                    commits.append(
-                        (other(prev_project), fake_hash(), prev_date + step_size)
-                    )
                 else:
-                    assert commit_type == 2  # diff-concurrent
-                    commits.append((other(prev_project), fake_hash(), prev_date))
+                    project_offset = (commit_type - 1) // 2
+                    new_project = (prev_project + project_offset) % num_projects
+                    if commit_type % 2 == 1:  # diff
+                        commits.append(
+                            (new_project, fake_hash(), prev_date + step_size)
+                        )
+                    else:
+                        assert commit_type % 2 == 0  # diff-concurrent
+                        commits.append((new_project, fake_hash(), prev_date))
             assert len(commits) == num_commits
 
             # The commits for a each project must have increasing timestamps
@@ -168,7 +206,7 @@ def create_commits(num_commits):
                 )
                 return all(x < y for x, y in zip(project_dates, project_dates[1:]))
 
-            if not increasing("jax") or not increasing("xla"):
+            if not all(map(increasing, range(num_projects))):
                 continue
 
             for bad_commit_index in range(
@@ -185,18 +223,29 @@ def create_commits(num_commits):
                 yield bad_commit_index, commits
 
 
-@pytest.mark.parametrize("commits", create_commits(5))
+@pytest.mark.parametrize(
+    "commits",
+    itertools.chain(
+        create_commits(num_commits=5, num_projects=2),
+        create_commits(num_commits=5, num_projects=3),
+    ),
+)
 def test_commit_search_exhaustive(logger, commits):
     """
     Exhaustive search over combinations of a small number of commits
     """
+    # Note that the "project" here is just an integer. That should be OK.
     bad_index, merged_commits = commits
     bad_project, bad_commit, bad_date = merged_commits[bad_index]
-    good_project = other(bad_project)
-    split_commits = {
-        p: [(commit, date) for proj, commit, date in merged_commits if proj == p]
-        for p in ("jax", "xla")
-    }
+    # create_commits internally generates all the different combinations of which of
+    # the `num_projects` is "first", so by making sure the "algorithm order" is sorted
+    # we should cover all the possibilities
+    all_projects = sorted({proj for proj, _, _ in merged_commits})
+    split_commits = collections.OrderedDict()
+    for p in all_projects:
+        split_commits[p] = [
+            (commit, date) for proj, commit, date in merged_commits if proj == p
+        ]
     good_commit, _ = list(
         filter(lambda t: t[1] < bad_date, split_commits[bad_project])
     )[-1]
@@ -205,52 +254,49 @@ def test_commit_search_exhaustive(logger, commits):
     assert all(len(v) for v in split_commits.values())
     assert len(split_commits[bad_project]) >= 2
 
-    def dummy_test(*, jax_commit, xla_commit):
-        return wrap(
-            dates[jax_commit if bad_project == "jax" else xla_commit] < bad_date
-        )
+    def dummy_test(*, commits):
+        return wrap(dates[commits[bad_project]] < bad_date)
 
     algorithm_result = commit_search(
         build_and_test=dummy_test,
-        jax_commits=split_commits["jax"],
+        commits=split_commits,
         logger=logger,
         skip_precondition_checks=False,
-        xla_commits=split_commits["xla"],
     )
     # Do not check the reference commit, it's a bit underspecified quite what it means.
     assert algorithm_result[f"{bad_project}_bad"] == bad_commit
     assert algorithm_result[f"{bad_project}_good"] == good_commit
     # Do check that the reference commit gives the expected results
-    assert not dummy_test(
-        **{
-            f"{bad_project}_commit": bad_commit,
-            f"{good_project}_commit": algorithm_result[f"{good_project}_ref"],
-        }
-    )[0]
-    assert dummy_test(
-        **{
-            f"{bad_project}_commit": good_commit,
-            f"{good_project}_commit": algorithm_result[f"{good_project}_ref"],
-        }
-    )[0]
+    ref_commits = {
+        proj: algorithm_result[f"{proj}_ref"]
+        for proj in all_projects
+        if proj != bad_project
+    }
+    assert not dummy_test(commits={bad_project: bad_commit} | ref_commits).result
+    assert dummy_test(commits={bad_project: good_commit} | ref_commits).result
 
 
 @pytest.mark.parametrize(
-    "jax_commits,xla_commits",
+    "commits",
     [
-        ([], [("", start_date)]),
-        ([("", start_date)], []),
-        ([("", start_date)], [("", start_date)]),
+        make_commits(jax=[("", start_date)], xla=[]),
+        make_commits(jax=[("", start_date)], flax=[], xla=[]),
+        make_commits(xla=[("", start_date)], jax=[]),
+        make_commits(xla=[("", start_date)], flax=[], jax=[]),
+        make_commits(jax=[("", start_date)], xla=[("", start_date)]),
+        make_commits(jax=[("", start_date)], xla=[("", start_date)], flax=[]),
+        make_commits(
+            jax=[("", start_date)], xla=[("", start_date)], flax=[("", start_date)]
+        ),
     ],
 )
-def test_commit_search_no_commits(logger, jax_commits, xla_commits):
+def test_commit_search_no_commits(logger, commits):
     with pytest.raises(Exception, match="Not enough commits"):
         commit_search(
-            build_and_test=lambda jax_commit, xla_commit: None,
-            jax_commits=jax_commits,
+            build_and_test=lambda commits: None,
+            commits=commits,
             logger=logger,
             skip_precondition_checks=False,
-            xla_commits=xla_commits,
         )
 
 
@@ -258,9 +304,11 @@ def test_commit_search_no_commits(logger, jax_commits, xla_commits):
 def test_commit_search_static_test_function(logger, value):
     with pytest.raises(Exception, match="Could not reproduce"):
         commit_search(
-            build_and_test=lambda jax_commit, xla_commit: wrap(value),
-            jax_commits=[("", start_date), ("", start_date + step_size)],
-            xla_commits=[("", start_date), ("", start_date + step_size)],
+            build_and_test=lambda commits: wrap(value),
+            commits=make_commits(
+                jax=[("", start_date), ("", start_date + step_size)],
+                xla=[("", start_date), ("", start_date + step_size)],
+            ),
             logger=logger,
             skip_precondition_checks=False,
         )
@@ -306,7 +354,7 @@ def test_container_search_limits(
     with pytest.raises(Exception, match=match_string):
         container_search(
             container_exists=lambda dt: dt in dates_that_exist,
-            container_passes=lambda dt: TestResult(result=False),
+            container_passes=lambda dt: wrap(False),
             start_date=start_date,
             end_date=end_date,
             logger=logger,
@@ -353,7 +401,7 @@ def test_container_search_checks(
     with pytest.raises(Exception, match=match_string):
         container_search(
             container_exists=lambda dt: True,
-            container_passes=lambda dt: TestResult(result=dt in dates_that_pass),
+            container_passes=lambda dt: wrap(dt in dates_that_pass),
             start_date=start_date,
             end_date=end_date,
             logger=logger,
@@ -374,7 +422,7 @@ def test_container_search(logger, start_date, days_of_failure, threshold_days):
     assert start_date is None or threshold_date >= start_date
     good_date, bad_date = container_search(
         container_exists=lambda dt: True,
-        container_passes=lambda dt: TestResult(result=dt < threshold_date),
+        container_passes=lambda dt: wrap(dt < threshold_date),
         start_date=start_date,
         end_date=end_date,
         logger=logger,


### PR DESCRIPTION
Also:
- stream merged stdout/stderr directly to logs
- pyxis backend: explicitly do not mount $HOME
- expand tests to cover >2 package cases
- swap to check the positive precondition before the negative one at the start of the commit-level search; experience says this will likely fail faster as it's common to accidentally provide a test that always fails
- when checking the negative precondition at the start of the commit-level search, print the debug-level logs to the console