### PR TITLE
build-te.sh: add build script; cleanup .eggs/

### DIFF
--- a/.github/container/Dockerfile.base
+++ b/.github/container/Dockerfile.base
@@ -36,6 +36,7 @@ apt_packages=(
   git
   gnupg
   liblzma-dev
+  ninja-build
   python-is-python3
   python3-pip
   rsync
@@ -46,15 +47,7 @@ apt_packages=(
   # llvm.sh
   lsb-release 
   software-properties-common
-  # GCP autoconfig
-  pciutils hwloc bind9-host
 )
-if [[ $(dpkg --print-architecture) == arm64 ]]; then
-  # h5py: The newest release of of h5py (3.11.0) does not include ARM wheels and causes pip to build h5py.
-  #       These installs ensure that 3.11.0, or any future version missing ARM, can be built.
-  #       Related: https://github.com/h5py/h5py/issues/2408
-  apt_packages+=(pkg-config libhdf5-dev)
-fi
 apt-get install -y ${apt_packages[@]}
 
 # Install LLVM/Clang
@@ -135,6 +128,15 @@ ENV PIP_BREAK_SYSTEM_PACKAGES=1
 # and fails due to pip-24.0 has been installed with system tool `apt` but not `python`. So we keep 
 # both pip-24.0 and pip-23.3.1 in the system, but use 23.3.1 with equivalency patch (see above).
 RUN pip install --upgrade --ignore-installed --no-cache-dir -e /opt/pip pip-tools && rm -rf ~/.cache/*
+
+# The symlinks for CUDA/cuDNN/NCCL exist to make the container's installations
+# of those components conform to XLA's expectations for local installations.
+
+###############################################################################
+## Symlink for CUDA
+###############################################################################
+
+RUN ln -s /usr/local/cuda/lib64 /usr/local/cuda/lib
 
 ###############################################################################
 ## Symlink for cuDNN

--- a/.github/container/Dockerfile.jax
+++ b/.github/container/Dockerfile.jax
@@ -38,7 +38,7 @@ RUN --mount=type=ssh \
     git-clone.sh ${URLREF_XLA} ${SRC_PATH_XLA}
 EOF
 
-ADD build-jax.sh local_cuda_arch /usr/local/bin/
+ADD build-jax.sh build-te.sh local_cuda_arch /usr/local/bin/
 # Install bazelisk
 RUN ARCH="$(dpkg --print-architecture)" && \
     wget -O /usr/local/bin/bazel https://github.com/bazelbuild/bazelisk/releases/latest/download/bazelisk-linux-${ARCH} && \
@@ -55,27 +55,17 @@ RUN build-jax.sh \
     --clean
 
 ## Transformer engine: check out source and build wheel
-RUN <<"EOF" bash -ex -o pipefail
-pip install ninja && rm -rf ~/.cache/pip
-git-clone.sh ${URLREF_TRANSFORMER_ENGINE} ${SRC_PATH_TRANSFORMER_ENGINE}
-pushd ${SRC_PATH_TRANSFORMER_ENGINE}
-export NVTE_BUILD_THREADS_PER_JOB=8
-ARCH=$(dpkg --print-architecture)
-if [[ -n "${CUDA_ARCH_LIST}" ]]; then
-  # "1.2 3.4 5.6" -> "12-real;34-real;56", i.e. SASS plus PTX for the last one
-  NVTE_CUDA_ARCHS="${CUDA_ARCH_LIST// /-real;}"
-  export NVTE_CUDA_ARCHS="${NVTE_CUDA_ARCHS//./}"
-elif [[ "${ARCH}" == "amd64" ]]; then
-  export NVTE_CUDA_ARCHS="75-real;80-real;86-real;90-real;100-real;120"
-elif [[ "${ARCH}" == "arm64" ]]; then
-  export NVTE_CUDA_ARCHS="80-real;86-real;90-real;100-real;120"
-fi
-export NVTE_FRAMEWORK=jax
-# TransformerEngine needs FFI headers from XLA
-export XLA_HOME=${SRC_PATH_XLA}
-python setup.py bdist_wheel && rm -rf build
-ls "${SRC_PATH_TRANSFORMER_ENGINE}/dist"
-EOF
+RUN --mount=type=ssh \
+    --mount=type=secret,id=SSH_KNOWN_HOSTS,target=/root/.ssh/known_hosts \
+    git-clone.sh ${URLREF_TRANSFORMER_ENGINE} ${SRC_PATH_TRANSFORMER_ENGINE}
+# Populate ${SRC_PATH_TRANSFORMER_ENGINE}/dist with [a] .whl file(s); --no-install
+# because (a) this is the builder stage, and (b) pip-finalize.sh does the install
+RUN build-te.sh \
+    --clean \
+    --no-install \
+    --sm all \
+    --src-path-te ${SRC_PATH_TRANSFORMER_ENGINE} \
+    --src-path-xla ${SRC_PATH_XLA}
 
 ###############################################################################
 ## Pack jaxlib wheel and various source dirs into a pre-installation image
@@ -104,7 +94,7 @@ COPY --from=builder ${SRC_PATH_XLA} ${SRC_PATH_XLA}
 COPY --from=builder /usr/local/bin/bazel /usr/local/bin/bazel
 # Preserve the versions of jax and xla
 COPY --from=builder /opt/manifest.d/git-clone.yaml /opt/manifest.d/git-clone.yaml
-ADD build-jax.sh local_cuda_arch pytest-xdist.sh test-jax.sh /usr/local/bin/
+ADD build-jax.sh build-te.sh local_cuda_arch pytest-xdist.sh test-jax.sh /usr/local/bin/
 
 RUN mkdir -p /opt/pip-tools.d
 

--- a/.github/container/build-jax.sh
+++ b/.github/container/build-jax.sh
@@ -215,12 +215,6 @@ if [[ ${CLEANONLY} == 1 ]]; then
     exit
 fi
 
-# This is required for LOCAL_CUDA_PATH to matches XLA's expectations
-# TODO: move this to Dockerfile.base (?)
-if [[ ! -e "/usr/local/cuda/lib" ]]; then
-    ln -s /usr/local/cuda/lib64 /usr/local/cuda/lib
-fi
-
 ## Build the compiled parts of JAX
 pushd ${SRC_PATH_JAX}
 time python "${SRC_PATH_JAX}/build/build.py" build \

--- a/.github/container/build-te.sh
+++ b/.github/container/build-te.sh
@@ -1,0 +1,150 @@
+#!/bin/bash
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+set -eo pipefail
+
+## Parse command-line arguments
+usage() {
+    echo "Configure, build, and install TransformerEngine"
+    echo ""
+    echo "  Usage: $0 [OPTIONS]"
+    echo ""
+    echo "    OPTIONS                        DESCRIPTION"
+    echo "    --clean                        Clear build caches under --src-path-te."
+    echo "    -h, --help                     Print usage."
+    echo "    --no-install                   Only build a wheel; do not install."
+    echo "    --src-path-te                  Path to TransformerEngine source code."
+    echo "    --src-path-xla                 Path to XLA source code."
+    echo "    --sm SM1,SM2,...               Comma-separated list of CUDA SM versions"
+    echo "                                   to compile for, e.g. 7.5,8.0 -- PTX will"
+    echo "                                   only be emitted for the last one."
+    echo "    --sm local                     Compile for the local GPUs (default)."
+    echo "    --sm all                       Compile for a default set of SM versions."
+    exit $1
+}
+
+# Set defaults
+CLEAN=0
+INSTALL=1
+SM="local"
+SRC_PATH_TE="/opt/transformer-engine"
+SRC_PATH_XLA="/opt/xla"
+
+args=$(getopt -o h --long clean,help,no-install,src-path-te:,src-path-xla:,sm: -- "$@")
+if [[ $? -ne 0 ]]; then
+    exit 1
+fi
+
+eval set -- "$args"
+while [ : ]; do
+    case "$1" in
+        --clean)
+            CLEAN=1
+            shift 1
+            ;;
+        -h | --help)
+            usage 1
+            ;;
+        --no-install)
+            INSTALL=0
+            shift 1
+            ;;
+        --src-path-te)
+            SRC_PATH_TE=$(realpath $2)
+            shift 2
+            ;;
+        --src-path-xla)
+            SRC_PATH_XLA=$(realpath $2)
+            shift 2
+            ;;
+        --sm)
+            SM=$2
+            shift 2
+            ;;
+        --)
+            shift;
+            break
+            ;;
+        *)
+            echo "UNKNOWN OPTION $1"
+            usage 1
+    esac
+done
+
+# Return a default list of CUDA SM architectures to compile for, in 1.2,3.4,5.6 format.
+# If CUDA_ARCH_LIST is set, respect that, otherwise use hard-coded cpu-arch-specific lists.
+default_compute_capabilities() {
+    CPU_ARCH="$(dpkg --print-architecture)"
+    # Infer the compute capabilities from the CUDA_ARCH_LIST variable if it is set;
+    # this is in 1.2 3.4 5.6 format
+    if [[ -n "${CUDA_ARCH_LIST}" ]]; then
+        echo ${CUDA_ARCH_LIST// /,}
+    elif [[ "${CPU_ARCH}" == "amd64" ]]; then
+        echo "7.5,8.0,8.6,9.0,10.0,12.0"
+    elif [[ "${CPU_ARCH}" == "arm64" ]]; then
+        echo "8.0,8.6,9.0,10.0,12.0"
+    else
+        echo "Invalid arch '$CPU_ARCH' (expected 'amd64' or 'arm64')" 1>&2
+        return 1
+    fi
+}
+
+print_var() {
+    echo "$1: ${!1}"
+}
+
+clean() {
+    pushd "${SRC_PATH_TRANSFORMER_ENGINE}"
+    rm -rf build/ .eggs/
+    popd
+}
+
+# This should standardise on 1.2,3.4,5.6 format
+if [[ "$SM" == "all" ]]; then
+    SM_LIST=$(default_compute_capabilities)
+elif [[ "$SM" == "local" ]]; then
+    SM_LIST=$("${SCRIPT_DIR}/local_cuda_arch")
+else
+    SM_LIST=${SM}
+fi
+
+## Print info
+echo "=================================================="
+echo "                  Configuration                   "
+echo "--------------------------------------------------"
+print_var CLEAN
+print_var INSTALL
+print_var SM
+print_var SM_LIST
+print_var SRC_PATH_TE
+print_var SRC_PATH_XLA
+echo "=================================================="
+
+# Parse SM_LIST into the format accepted by TransformerEngine's build system
+# "1.2,3.4,5.6" -> "12-real;34-real;56", i.e. SASS plus PTX for the last one
+NVTE_CUDA_ARCHS="${SM_LIST//,/-real;}"
+set -x
+export NVTE_CUDA_ARCHS="${NVTE_CUDA_ARCHS//./}"
+# Parallelism within nvcc invocations.
+export NVTE_BUILD_THREADS_PER_JOB=8
+export NVTE_FRAMEWORK=jax
+# TransformerEngine needs FFI headers from XLA
+export XLA_HOME=${SRC_PATH_XLA}
+
+pushd ${SRC_PATH_TRANSFORMER_ENGINE}
+# The wheel filename includes the TE commit; if this has changed since the last
+# incremental build then we would end up with multiple wheels.
+rm -fv dist/*.whl
+python setup.py bdist_wheel
+ls dist/
+popd
+
+## Install the built packages
+if [[ "${INSTALL}" == "1" ]]; then
+    pip install ${SRC_PATH_TRANSFORMER_ENGINE}/dist/*.whl
+    pip list | grep ^transformer_engine
+fi
+
+## Cleanup
+if [[ "$CLEAN" == "1" ]]; then
+    clean
+fi


### PR DESCRIPTION
- Since https://github.com/NVIDIA/TransformerEngine/pull/1717 the `.eggs` subdirectory was left containing large files.
- Re-organising into `build-te.sh` will be useful for enabling TE in https://github.com/NVIDIA/JAX-Toolbox/pull/1449; further optimisation of incremental re-build time may be needed.