### PR TITLE
Set --//jaxlib/tools:add_pypi_cuda_wheel_deps=false by default

### DIFF
--- a/.github/container/test-jax.sh
+++ b/.github/container/test-jax.sh
@@ -135,6 +135,9 @@ else
     FLAGS+=("--//jax:build_jaxlib=false")
 fi
 
+# https://github.com/jax-ml/jax/pull/28870
+FLAGS+=("--//jaxlib/tools:add_pypi_cuda_wheel_deps=false")
+
 set_default JOBS_PER_GPU $(( GPU_MEMORIES_MIB[0] / 10000))
 FLAGS+=(
     "--cache_test_results=${CACHE_TEST_RESULTS}"


### PR DESCRIPTION
With the merge of https://github.com/jax-ml/jax/pull/28861, `--build_jaxlib=false` indicates that running the tests will depend on NVIDIA CUDA wheels hermetically. We don't want that, we want the local CUDA to be picked by the runtime as we normally do.

https://github.com/jax-ml/jax/pull/28870 provided an flag to turn off the default setting, we need to have this set for our test script.