### PR TITLE
 build-jax.sh: build.py: pass --cuda_major_version

### DIFF
--- a/.github/container/build-jax.sh
+++ b/.github/container/build-jax.sh
@@ -218,6 +218,7 @@ fi
 ## Build the compiled parts of JAX
 pushd ${SRC_PATH_JAX}
 time python "${SRC_PATH_JAX}/build/build.py" build \
+    --cuda_major_version=${CUDA_MAJOR_VERSION} \
     --editable \
     --use_clang \
     --use_new_wheel_build_rule \
@@ -238,7 +239,7 @@ for component in jaxlib "jax-cuda${CUDA_MAJOR_VERSION}-pjrt" "jax-cuda${CUDA_MAJ
     # version, so nvidia-*-cu12 wheels disappear from the lock file
     sed -i "s|^${component}.*$|${component} @ file://${BUILD_PATH_JAXLIB}/${component//-/_}|" build/requirements.in
 done
-bazel run --verbose_failures=true //build:requirements.update --repo_env=HERMETIC_PYTHON_VERSION="${PYTHON_VERSION}"
+bazel run --config=cuda_libraries_from_stubs --verbose_failures=true //build:requirements.update --repo_env=HERMETIC_PYTHON_VERSION="${PYTHON_VERSION}"
 popd
 
 ## Install the built packages

--- a/.github/container/test-jax.sh
+++ b/.github/container/test-jax.sh
@@ -134,8 +134,8 @@ if [[ $BUILD_JAXLIB -eq 1 ]]; then
 else
     FLAGS+=("--//jax:build_jaxlib=false")
 fi
-
-# https://github.com/jax-ml/jax/pull/28870
+# Added in https://github.com/jax-ml/jax/pull/28870: do not fetch
+# nvidia-*-cu1X wheels from PyPI to run tests, use the local installations
 FLAGS+=("--//jaxlib/tools:add_pypi_cuda_wheel_deps=false")
 
 set_default JOBS_PER_GPU $(( GPU_MEMORIES_MIB[0] / 10000))


### PR DESCRIPTION
Also pass `--config=cuda_libraries_from_stubs` when updating the requirements to avoid invalidating the bazel analysis cache.