### PR TITLE
Add GKE example

### DIFF
--- a/.github/actions/gke-xpk/action.yml
+++ b/.github/actions/gke-xpk/action.yml
@@ -62,6 +62,7 @@ runs:
   using: 'composite'
   steps:
   - name: Show environment
+    shell: bash -x -e -u {0}
     run: |
       set -x
   
@@ -72,6 +73,7 @@ runs:
       xpk version
   
   - name: Apply XPK workload create patch
+    shell: bash -x -e -u {0}
     run: |
       cd ${HOME}/xpk && git checkout src/xpk && cd -
       git apply --unsafe-paths .github/gke-workflow/xpk/tcpxo_decorator.patch --directory ${HOME}/xpk
@@ -79,6 +81,7 @@ runs:
       git apply --unsafe-paths .github/gke-workflow/xpk/workload.patch --directory ${HOME}/xpk
   
   - name: Set workload name
+    shell: bash -x -e -u {0}
     run: |
       WORKLOAD_NAME="${{ inputs.WORKLOAD_NAME_PREFIX }}-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
       DATE=$(date +'%Y-%m-%d')
@@ -86,9 +89,10 @@ runs:
 
       echo "WORKLOAD_NAME=${WORKLOAD_NAME}" >> ${GITHUB_ENV}
       echo "DATE=${DATE}" >> ${GITHUB_ENV}
-i     echo "GCS_ARTIFACT_PATH=${GCS_ARTIFACT_PATH}" >> ${GITHUB_ENV}
+      echo "GCS_ARTIFACT_PATH=${GCS_ARTIFACT_PATH}" >> ${GITHUB_ENV}
 
   - name: Set workload commands
+    shell: bash -x -e -u {0}
     run: |
       PRELUDE="
           curl -LO https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-cli-linux-x86_64.tar.gz;
@@ -117,6 +121,7 @@ i     echo "GCS_ARTIFACT_PATH=${GCS_ARTIFACT_PATH}" >> ${GITHUB_ENV}
       echo "POSTLUDE=${POSTLUDE}" >> ${GITHUB_ENV}
   
   - name: Create workload on cluster with XPK
+    shell: bash -x -e -u {0}
     run: |
       cd ${HOME}/xpk
       source ${HOME}/.venv/bin/activate
@@ -133,6 +138,7 @@ i     echo "GCS_ARTIFACT_PATH=${GCS_ARTIFACT_PATH}" >> ${GITHUB_ENV}
                     --command "${PRELUDE} ${CMD} ${POSTLUDE}"
   
   - name: Wait for JobSet to unsuspend on cluster
+    shell: bash -u {0}
     env:
       POLL_TIMEOUT: 3600
     run: |
@@ -153,6 +159,7 @@ i     echo "GCS_ARTIFACT_PATH=${GCS_ARTIFACT_PATH}" >> ${GITHUB_ENV}
       echo "JobSet ${WORKLOAD_NAME} has just become active in cluster ${GKE_CLUSTER}"
   
   - name: Set JobSet Pod name
+    shell: bash -u {0}
     run: |
       echo "POD=$(kubectl get pods -o json | jq -r '.items[] | select(.metadata.labels."'jobset.sigs.k8s.io/jobset-name'" == "'${WORKLOAD_NAME}'") | .metadata.name ' | sort | head -n1 )" >> ${GITHUB_ENV}
   
@@ -173,6 +180,7 @@ i     echo "GCS_ARTIFACT_PATH=${GCS_ARTIFACT_PATH}" >> ${GITHUB_ENV}
       done;
   
   - name: Stream logs from JobSet Pods
+    shell: bash -u {0}
     run: |
       jobset_pods=($(kubectl get pods -o json | jq -r '.items[].metadata | select(.labels."jobset.sigs.k8s.io/jobset-name" == "'${WORKLOAD_NAME}'") | .name' | tr '\n' ' '))
   
@@ -182,6 +190,7 @@ i     echo "GCS_ARTIFACT_PATH=${GCS_ARTIFACT_PATH}" >> ${GITHUB_ENV}
       wait < <(jobs -p)
   
   - name: Set exit code from JobSet logs
+    shell: bash -u {0}
     run: |
       MAYBE_XPK_EXIT_CODE="$(tail -n 1 ${WORKLOAD_NAME}-${POD}-jobset.log | awk '{ print $3 }' )"
       echo ${MAYBE_XPK_EXIT_CODE} | grep -E 'EXIT\_CODE=[0-9]+$'
@@ -195,11 +204,13 @@ i     echo "GCS_ARTIFACT_PATH=${GCS_ARTIFACT_PATH}" >> ${GITHUB_ENV}
       exit ${EXIT_CODE}
   
   - name: Clean up JobSet from cluster
+    shell: bash -x -u {0}
     if: ${{ always() }}
     run: |
       kubectl delete jobset --wait ${WORKLOAD_NAME} || echo "JobSet ${WORKLOAD_NAME} does not exist in ${{ inputs.GKE_CLUSTER }}"
   
   - name: Download artifacts from GCS to runner
+    shell: bash -x -u {0}
     run: |
       mkdir -p output/${WORKLOAD_NAME}
       gsutil cp -r ${GCS_ARTIFACT_PATH} output/${WORKLOAD_NAME}
@@ -212,6 +223,7 @@ i     echo "GCS_ARTIFACT_PATH=${GCS_ARTIFACT_PATH}" >> ${GITHUB_ENV}
       path: output/${{ env.WORKLOAD_NAME }}/*
   
   - name: Clean up GCS artifacts from runner
+    shell: bash -x -u {0}
     if: ${{ always() }}
     run: |
       rm -rf output/${WORKLOAD_NAME}

--- a/.github/actions/gke-xpk/action.yml
+++ b/.github/actions/gke-xpk/action.yml
@@ -126,9 +126,10 @@ runs:
       cd ${HOME}/xpk
       source ${HOME}/.venv/bin/activate
       python xpk.py workload create \
+                    --project ${{ inputs.GCP_PROJECT }} \
                     --cluster ${{ inputs.GKE_CLUSTER }} \
                     --zone ${{ inputs.GCP_ZONE }} \
-                    --workload ${{ inputs.WORKLOAD_NAME }} \
+                    --workload ${WORKLOAD_NAME} \
                     --docker-image ${{ inputs.IMAGE }} \
                     --device-type ${{ inputs.CLUSTER_DEVICE }} \
                     --num-nodes ${{ inputs.NUM_NODES }} \

--- a/.github/actions/gke-xpk/action.yml
+++ b/.github/actions/gke-xpk/action.yml
@@ -150,14 +150,14 @@ runs:
         NOW=$(date +%s)
         ELAPSED=$(( NOW - START ))
         if (( ELAPSED > POLL_TIMEOUT )) ; then
-          echo "Timeout after waiting for JobSet ${WORKLOAD_NAME} to become active in cluster ${GKE_CLUSTER}"
+          echo "Timeout after waiting for JobSet ${WORKLOAD_NAME} to become active in cluster ${{ inputs.GKE_CLUSTER }}"
           exit 1
         fi
-        echo "Waiting for JobSet ${WORKLOAD_NAME} to become active in cluster ${GKE_CLUSTER}"
+        echo "Waiting for JobSet ${WORKLOAD_NAME} to become active in cluster ${{ inputs.GKE_CLUSTER }}"
         sleep 5
       done
   
-      echo "JobSet ${WORKLOAD_NAME} has just become active in cluster ${GKE_CLUSTER}"
+      echo "JobSet ${WORKLOAD_NAME} has just become active in cluster ${{ inputs.GKE_CLUSTER }}"
   
   - name: Set JobSet Pod name
     shell: bash -u {0}
@@ -174,7 +174,7 @@ runs:
   
         POD_ERROR=$(kubectl get pod ${POD} -o json | jq -r '.status.containerStatuses[]? | select(.name == "'${{ inputs.MAIN_CONTAINER_NAME }}'") | .state | ( has("terminated") and (.terminated.reason == "Error" ))')
         if ${POD_ERROR} ; then
-          echo "There was an issue starting the JobSet ${WORKLOAD_NAME} on ${GKE_CLUSTER}"
+          echo "There was an issue starting the JobSet ${WORKLOAD_NAME} on ${{ inputs.GKE_CLUSTER }}"
           break
         fi
   

--- a/.github/actions/gke-xpk/action.yml
+++ b/.github/actions/gke-xpk/action.yml
@@ -62,27 +62,21 @@ inputs:
     required: false
     default: 'xpk'
     type: string
+  XPK_VERSION:
+    description: 'XPK release tag'
+    required: false
+    default: 'v0.8.0'
+    type: string
+  XPK_PYTHON:
+    description: 'Python version for XPK'
+    required: false
+    default: '3.12.10'
+    type: string
 
 runs:
   using: 'composite'
   steps:
-  - name: Show environment
-    shell: bash -x -e -u {0}
-    run: |
-      gcloud version
-  
-      source $HOME/.venv/bin/activate
-      python --version
-      xpk version
-  
-  - name: Apply XPK workload create patch
-    shell: bash -x -e -u {0}
-    run: |
-      cd ${HOME}/xpk && git checkout src/xpk && cd -
-      git apply --unsafe-paths .github/gke-workflow/xpk/tcpxo_decorator.patch --directory ${HOME}/xpk
-      git apply --unsafe-paths .github/gke-workflow/xpk/docker_resources.patch --directory ${HOME}/xpk
-      git apply --unsafe-paths .github/gke-workflow/xpk/workload.patch --directory ${HOME}/xpk
-  
+
   - name: Set workload name
     shell: bash -x -e -u {0}
     run: |
@@ -94,6 +88,35 @@ runs:
       echo "DATE=${DATE}" >> ${GITHUB_ENV}
       echo "GCS_ARTIFACT_PATH=${GCS_ARTIFACT_PATH}" >> ${GITHUB_ENV}
 
+  - name: Setup environment
+    shell: bash -x -e -u {0}
+    run: |
+      mkdir -p ${WORKLOAD_NAME}
+      uv venv --verbose --python=${{ inputs.XPK_PYTHON }} --directory=${WORKLOAD_NAME}
+      source ${WORKLOAD_NAME}/.venv/bin/activate
+
+      # install xpk
+      git clone --depth=1 --branch=${{ inputs.XPK_VERSION }} https://github.com/AI-Hypercomputer/xpk.git ${WORKLOAD_NAME}/xpk
+
+      sed 's@pip install \.@'$(which uv)' pip install \.@g' -i ${WORKLOAD_NAME}/xpk/Makefile
+      cd ${WORKLOAD_NAME}/xpk && make install && cd -
+
+  - name: Show environment
+    shell: bash -x -e -u {0}
+    run: |
+      gcloud version
+  
+      source ${WORKLOAD_NAME}/.venv/bin/activate
+      python --version
+      xpk version
+  
+  - name: Apply XPK workload create patch
+    shell: bash -x -e -u {0}
+    run: |
+      git apply --unsafe-paths .github/gke-workflow/xpk/tcpxo_decorator.patch --directory ${WORKLOAD_NAME}/xpk
+      git apply --unsafe-paths .github/gke-workflow/xpk/docker_resources.patch --directory ${WORKLOAD_NAME}/xpk
+      git apply --unsafe-paths .github/gke-workflow/xpk/workload.patch --directory ${WORKLOAD_NAME}/xpk
+  
   - name: Set workload commands
     shell: bash -x -e -u {0}
     run: |
@@ -127,8 +150,8 @@ runs:
   - name: Create workload on cluster with XPK
     shell: bash -x -e -u {0}
     run: |
-      cd ${HOME}/xpk
-      source ${HOME}/.venv/bin/activate
+      cd ${WORKLOAD_NAME}/xpk
+      source ${WORKLOAD_NAME}/.venv/bin/activate
       python xpk.py workload create \
                     --project ${{ inputs.GCP_PROJECT }} \
                     --cluster ${{ inputs.GKE_CLUSTER }} \
@@ -233,3 +256,9 @@ runs:
     if: ${{ always() }}
     run: |
       rm -rf output/${WORKLOAD_NAME}
+
+  - name: Clean up xpk environment from runner
+    shell: bash -x -u {0}
+    if: ${{ always() }}
+    run: |
+        rm -rf ${WORKLOAD_NAME}

--- a/.github/actions/gke-xpk/action.yml
+++ b/.github/actions/gke-xpk/action.yml
@@ -105,8 +105,9 @@ runs:
       "
   
       POSTLUDE="
+          EXIT_CODE=\$PIPESTATUS
           ./google-cloud-sdk/bin/gsutil cp -r ${{ inputs.CONTAINER_OUTPUT_PATH }}/ ${GCS_ARTIFACT_PATH}/node0\$NODE_RANK;
-          exit \$PIPESTATUS
+          exit \$EXIT_CODE
       "
   
       CMD="${{ inputs.COMMAND }}"

--- a/.github/actions/gke-xpk/action.yml
+++ b/.github/actions/gke-xpk/action.yml
@@ -99,7 +99,7 @@ runs:
       git clone --depth=1 --branch=${{ inputs.XPK_VERSION }} https://github.com/AI-Hypercomputer/xpk.git ${WORKLOAD_NAME}/xpk
 
       sed 's@pip install \.@'$(which uv)' pip install \.@g' -i ${WORKLOAD_NAME}/xpk/Makefile
-      cd ${WORKLOAD_NAME}/xpk && make install && cd -
+      cd ${WORKLOAD_NAME}/xpk && sudo make install && cd -
 
   - name: Show environment
     shell: bash -x -e -u {0}
@@ -150,8 +150,8 @@ runs:
   - name: Create workload on cluster with XPK
     shell: bash -x -e -u {0}
     run: |
-      cd ${WORKLOAD_NAME}/xpk
       source ${WORKLOAD_NAME}/.venv/bin/activate
+      cd ${WORKLOAD_NAME}/xpk
       python xpk.py workload create \
                     --project ${{ inputs.GCP_PROJECT }} \
                     --cluster ${{ inputs.GKE_CLUSTER }} \

--- a/.github/actions/gke-xpk/action.yml
+++ b/.github/actions/gke-xpk/action.yml
@@ -261,4 +261,4 @@ runs:
     shell: bash -x -u {0}
     if: ${{ always() }}
     run: |
-        rm -rf ${WORKLOAD_NAME}
+      sudo rm -rf ${WORKLOAD_NAME}

--- a/.github/actions/gke-xpk/action.yml
+++ b/.github/actions/gke-xpk/action.yml
@@ -1,0 +1,217 @@
+name: Launch workload on GKE with XPK
+
+description: "Launch a JobSet workload on GKE with XPK. Upload artifacts from container to GCS and GitHub Actions."
+
+inputs:
+  GCP_PROJECT:
+    description: 'GCP project ID'
+    default: nv-jaxtoolboxgcp-20240925
+    type: string
+  GKE_CLUSTER:
+    description: 'GKE cluster name'
+    default: jtb-2025-06-12
+    required: false
+    type: string
+  GCP_ZONE:
+    description: 'GCP zone of the cluster'
+    default: us-central1-a
+    required: false
+    type: string
+  CLUSTER_DEVICE: 
+    description: 'GPU device type in the cluster'
+    default: h100-mega-80gb-8
+    required: false
+    type: string
+  NUM_NODES:
+    description: 'Number of nodes to use in JobSet (n.b each a3-megagpu-8g node has 8xGPU)'
+    default: 2
+    required: false
+    type: string
+  MAIN_CONTAINER_NAME: 
+    description: 'Name of the main contianer in an XPK JobSet (fixed)'
+    default: gpu-image
+    required: false
+    type: string
+  CONTAINER_OUTPUT_PATH:
+    description: 'Output directory for artifacts'
+    default: /opt/output
+    required: false
+    type: string
+  GCS_BUCKET:
+    description: 'GCS bucket to which CI output artifacts will be uploaded'
+    default: jaxtoolbox-ci
+    required: false
+    type: string
+  IMAGE:
+    description: 'URI of image to use in JobSet'
+    required: false
+    default: ghcr.io/nvidia/jax:latest
+    type: string
+  COMMAND:
+    description: 'Command to run in main container on JobSet start up'
+    required: false
+    default: 'nvidia-smi; free -h;'
+    type: string
+  WORKLOAD_NAME_PREFIX:
+    description: 'Workload name prefix for XPK, also used to name uploaded artifact'
+    required: false
+    default: 'xpk'
+    type: string
+
+runs:
+  using: 'composite'
+  steps:
+  - name: Show environment
+    run: |
+      set -x
+  
+      gcloud version
+  
+      source $HOME/.venv/bin/activate
+      python --version
+      xpk version
+  
+  - name: Apply XPK workload create patch
+    run: |
+      cd ${HOME}/xpk && git checkout src/xpk && cd -
+      git apply --unsafe-paths .github/gke-workflow/xpk/tcpxo_decorator.patch --directory ${HOME}/xpk
+      git apply --unsafe-paths .github/gke-workflow/xpk/docker_resources.patch --directory ${HOME}/xpk
+      git apply --unsafe-paths .github/gke-workflow/xpk/workload.patch --directory ${HOME}/xpk
+  
+  - name: Set workload name
+    run: |
+      WORKLOAD_NAME="${{ inputs.WORKLOAD_NAME_PREFIX }}-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+      DATE=$(date +'%Y-%m-%d')
+      GCS_ARTIFACT_PATH="gs://${{ inputs.GCS_BUCKET }}/${{ inputs.WORKLOAD_NAME_PREFIX }}/${DATE}/${WORKLOAD_NAME}"
+
+      echo "WORKLOAD_NAME=${WORKLOAD_NAME}" >> ${GITHUB_ENV}
+      echo "DATE=${DATE}" >> ${GITHUB_ENV}
+i     echo "GCS_ARTIFACT_PATH=${GCS_ARTIFACT_PATH}" >> ${GITHUB_ENV}
+
+  - name: Set workload commands
+    run: |
+      PRELUDE="
+          curl -LO https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-cli-linux-x86_64.tar.gz;
+          tar xf google-cloud-cli-linux-x86_64.tar.gz;
+          ./google-cloud-sdk/install.sh --quiet;
+          ./google-cloud-sdk/bin/gcloud init;
+  
+          mkdir -p /usr/share/workload;
+          mkdir -p ${{ inputs.CONTAINER_OUTPUT_PATH }};
+      "
+  
+      POSTLUDE="
+          ./google-cloud-sdk/bin/gsutil cp -r ${{ inputs.CONTAINER_OUTPUT_PATH }}/ ${GCS_ARTIFACT_PATH}/node0\$NODE_RANK;
+          exit \$PIPESTATUS
+      "
+  
+      CMD="${{ inputs.COMMAND }}"
+  
+      # set container commands in-line
+      PRELUDE=$(echo ${PRELUDE} | sed 's/\n/\ /g')
+      POSTLUDE=$(echo ${POSTLUDE} | sed 's/\n/\ /g')
+      CMD=$(echo ${CMD} | sed 's/\n/\ /g')
+
+      echo "PRELUDE=${PRELUDE}" >> ${GITHUB_ENV}
+      echo "CMD=${CMD}" >> ${GITHUB_ENV}
+      echo "POSTLUDE=${POSTLUDE}" >> ${GITHUB_ENV}
+  
+  - name: Create workload on cluster with XPK
+    run: |
+      cd ${HOME}/xpk
+      source ${HOME}/.venv/bin/activate
+      python xpk.py workload create \
+                    --cluster ${{ inputs.GKE_CLUSTER }} \
+                    --zone ${{ inputs.GCP_ZONE }} \
+                    --workload ${{ inputs.WORKLOAD_NAME }} \
+                    --docker-image ${{ inputs.IMAGE }} \
+                    --device-type ${{ inputs.CLUSTER_DEVICE }} \
+                    --num-nodes ${{ inputs.NUM_NODES }} \
+                    --num-slices ${{ inputs.NUM_NODES }} \
+                    --priority=high \
+                    --scheduler=gke.io/topology-aware-auto \
+                    --command "${PRELUDE} ${CMD} ${POSTLUDE}"
+  
+  - name: Wait for JobSet to unsuspend on cluster
+    env:
+      POLL_TIMEOUT: 3600
+    run: |
+      START=$(date +%s)
+      JOBSET_ACTIVE=false
+      while ! ${JOBSET_ACTIVE}  || [ -z ${JOBSET_ACTIVE} ]; do
+        JOBSET_ACTIVE=$(kubectl get jobset -o json | jq -r '.items[] | select(.metadata.name == "'${WORKLOAD_NAME}'").status.replicatedJobsStatus[0] | .active == 1')
+        NOW=$(date +%s)
+        ELAPSED=$(( NOW - START ))
+        if (( ELAPSED > POLL_TIMEOUT )) ; then
+          echo "Timeout after waiting for JobSet ${WORKLOAD_NAME} to become active in cluster ${GKE_CLUSTER}"
+          exit 1
+        fi
+        echo "Waiting for JobSet ${WORKLOAD_NAME} to become active in cluster ${GKE_CLUSTER}"
+        sleep 5
+      done
+  
+      echo "JobSet ${WORKLOAD_NAME} has just become active in cluster ${GKE_CLUSTER}"
+  
+  - name: Set JobSet Pod name
+    run: |
+      echo "POD=$(kubectl get pods -o json | jq -r '.items[] | select(.metadata.labels."'jobset.sigs.k8s.io/jobset-name'" == "'${WORKLOAD_NAME}'") | .metadata.name ' | sort | head -n1 )" >> ${GITHUB_ENV}
+  
+  - name: Wait for JobSet Pod readiness
+    run: |
+      POD_READY=false
+      while ! ${POD_READY}  || [ -z ${POD_READY} ]; do
+        echo "Waiting for pod ${POD} in JobSet ${WORKLOAD_NAME} to become ready"
+        sleep 10
+  
+        POD_ERROR=$(kubectl get pod ${POD} -o json | jq -r '.status.containerStatuses[]? | select(.name == "'${{ inputs.MAIN_CONTAINER_NAME }}'") | .state | ( has("terminated") and (.terminated.reason == "Error" ))')
+        if ${POD_ERROR} ; then
+          echo "There was an issue starting the JobSet ${WORKLOAD_NAME} on ${GKE_CLUSTER}"
+          break
+        fi
+  
+        POD_READY=$(kubectl get pod ${POD} -o json | jq -r '.status.containerStatuses[]? | select(.name == "'${{ inputs.MAIN_CONTAINER_NAME }}'").ready')
+      done;
+  
+  - name: Stream logs from JobSet Pods
+    run: |
+      jobset_pods=($(kubectl get pods -o json | jq -r '.items[].metadata | select(.labels."jobset.sigs.k8s.io/jobset-name" == "'${WORKLOAD_NAME}'") | .name' | tr '\n' ' '))
+  
+      for jobset_pod in ${jobset_pods[@]}; do
+          kubectl logs --pod-running-timeout=1m -f --prefix=true --timestamps=true -c gpu-image ${jobset_pod} 2>&1 | tee -a ${WORKLOAD_NAME}-${jobset_pod}-jobset.log &
+      done
+      wait < <(jobs -p)
+  
+  - name: Set exit code from JobSet logs
+    run: |
+      MAYBE_XPK_EXIT_CODE="$(tail -n 1 ${WORKLOAD_NAME}-${POD}-jobset.log | awk '{ print $3 }' )"
+      echo ${MAYBE_XPK_EXIT_CODE} | grep -E 'EXIT\_CODE=[0-9]+$'
+  
+      if [ $? -ne 0 ]; then
+        echo "The JobSet ${WORKLOAD_NAME} on ${{ inputs.GKE_CLUSTER }} did not complete as expected "
+        exit 1
+      fi
+  
+      eval "export ${MAYBE_XPK_EXIT_CODE}"
+      exit ${EXIT_CODE}
+  
+  - name: Clean up JobSet from cluster
+    if: ${{ always() }}
+    run: |
+      kubectl delete jobset --wait ${WORKLOAD_NAME} || echo "JobSet ${WORKLOAD_NAME} does not exist in ${{ inputs.GKE_CLUSTER }}"
+  
+  - name: Download artifacts from GCS to runner
+    run: |
+      mkdir -p output/${WORKLOAD_NAME}
+      gsutil cp -r ${GCS_ARTIFACT_PATH} output/${WORKLOAD_NAME}
+      mv ${WORKLOAD_NAME}-*.log output/${WORKLOAD_NAME}
+  
+  - name: Upload artifacts to GitHub Actions from runner
+    uses: actions/upload-artifact@v4
+    with:
+      name: ${{ inputs.WORKLOAD_NAME_PREFIX }}
+      path: output/${{ env.WORKLOAD_NAME }}/*
+  
+  - name: Clean up GCS artifacts from runner
+    if: ${{ always() }}
+    run: |
+      rm -rf output/${WORKLOAD_NAME}

--- a/.github/actions/gke-xpk/action.yml
+++ b/.github/actions/gke-xpk/action.yml
@@ -52,6 +52,11 @@ inputs:
     required: false
     default: 'nvidia-smi; free -h;'
     type: string
+  EXIT_COMMAND:
+    description: 'Command to set exit code'
+    required: false
+    default: 'exit \$EXIT_CODE'
+    type: string
   WORKLOAD_NAME_PREFIX:
     description: 'Workload name prefix for XPK, also used to name uploaded artifact'
     required: false
@@ -106,7 +111,7 @@ runs:
   
       POSTLUDE="
           ./google-cloud-sdk/bin/gsutil cp -r ${{ inputs.CONTAINER_OUTPUT_PATH }}/ ${GCS_ARTIFACT_PATH}/node0\$NODE_RANK;
-          exit \$EXIT_CODE
+          ${{ inputs.EXIT_COMMAND }}
       "
   
       CMD="${{ inputs.COMMAND }}"

--- a/.github/actions/gke-xpk/action.yml
+++ b/.github/actions/gke-xpk/action.yml
@@ -98,9 +98,10 @@ runs:
     shell: bash -x -e -u {0}
     run: |
       PRELUDE="
+          apt install -y ripgrep > /dev/null;
           curl -LO https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-cli-linux-x86_64.tar.gz;
           tar xf google-cloud-cli-linux-x86_64.tar.gz;
-          ./google-cloud-sdk/install.sh --quiet;
+          ./google-cloud-sdk/install.sh --quiet > /dev/null;
           ./google-cloud-sdk/bin/gcloud init;
   
           mkdir -p /usr/share/workload;

--- a/.github/actions/gke-xpk/action.yml
+++ b/.github/actions/gke-xpk/action.yml
@@ -164,6 +164,7 @@ runs:
       echo "POD=$(kubectl get pods -o json | jq -r '.items[] | select(.metadata.labels."'jobset.sigs.k8s.io/jobset-name'" == "'${WORKLOAD_NAME}'") | .metadata.name ' | sort | head -n1 )" >> ${GITHUB_ENV}
   
   - name: Wait for JobSet Pod readiness
+    shell: bash -u {0}
     run: |
       POD_READY=false
       while ! ${POD_READY}  || [ -z ${POD_READY} ]; do

--- a/.github/actions/gke-xpk/action.yml
+++ b/.github/actions/gke-xpk/action.yml
@@ -99,7 +99,7 @@ runs:
       git clone --depth=1 --branch=${{ inputs.XPK_VERSION }} https://github.com/AI-Hypercomputer/xpk.git ${WORKLOAD_NAME}/xpk
 
       sed 's@pip install \.@'$(which uv)' pip install \.@g' -i ${WORKLOAD_NAME}/xpk/Makefile
-      cd ${WORKLOAD_NAME}/xpk && sudo make install && cd -
+      cd ${WORKLOAD_NAME}/xpk && sudo make install; cd -
 
   - name: Show environment
     shell: bash -x -e -u {0}

--- a/.github/actions/gke-xpk/action.yml
+++ b/.github/actions/gke-xpk/action.yml
@@ -69,8 +69,6 @@ runs:
   - name: Show environment
     shell: bash -x -e -u {0}
     run: |
-      set -x
-  
       gcloud version
   
       source $HOME/.venv/bin/activate
@@ -110,7 +108,7 @@ runs:
       "
   
       POSTLUDE="
-          ./google-cloud-sdk/bin/gsutil cp -r ${{ inputs.CONTAINER_OUTPUT_PATH }}/ ${GCS_ARTIFACT_PATH}/node0\$NODE_RANK;
+          ./google-cloud-sdk/bin/gsutil cp -r ${{ inputs.CONTAINER_OUTPUT_PATH }}/ ${GCS_ARTIFACT_PATH}/node-0\$NODE_RANK;
           ${{ inputs.EXIT_COMMAND }}
       "
   
@@ -220,8 +218,8 @@ runs:
     shell: bash -x -u {0}
     run: |
       mkdir -p output/${WORKLOAD_NAME}
-      gsutil cp -r ${GCS_ARTIFACT_PATH} output/${WORKLOAD_NAME}
       mv ${WORKLOAD_NAME}-*.log output/${WORKLOAD_NAME}
+      gsutil cp -r ${GCS_ARTIFACT_PATH} output/${WORKLOAD_NAME}
   
   - name: Upload artifacts to GitHub Actions from runner
     uses: actions/upload-artifact@v4

--- a/.github/actions/gke-xpk/action.yml
+++ b/.github/actions/gke-xpk/action.yml
@@ -105,7 +105,6 @@ runs:
       "
   
       POSTLUDE="
-          EXIT_CODE=\$PIPESTATUS
           ./google-cloud-sdk/bin/gsutil cp -r ${{ inputs.CONTAINER_OUTPUT_PATH }}/ ${GCS_ARTIFACT_PATH}/node0\$NODE_RANK;
           exit \$EXIT_CODE
       "

--- a/.github/container/Dockerfile.jax
+++ b/.github/container/Dockerfile.jax
@@ -132,6 +132,4 @@ EOF
 ###############################################################################
 
 FROM mealkit AS final
-ENV PIP_PRE=1
-RUN sed -i '10,/pip-compile/{s/pip-compile/pip-compile --pre/}' pip-finalize.sh
 RUN pip-finalize.sh

--- a/.github/container/Dockerfile.jax
+++ b/.github/container/Dockerfile.jax
@@ -125,4 +125,6 @@ EOF
 ###############################################################################
 
 FROM mealkit AS final
+ENV PIP_PRE=1
+RUN sed -i '10,/pip-compile/{s/pip-compile/pip-compile --pre/}' pip-finalize.sh
 RUN pip-finalize.sh

--- a/.github/gke-workflow/nccl/scripts/nccl-test-launch.sh
+++ b/.github/gke-workflow/nccl/scripts/nccl-test-launch.sh
@@ -8,7 +8,7 @@ pushd /scripts;
 /scripts/generate_hostfiles.sh ${@};
 popd;
 
-COMPLETION_FLAG=/opt/output/$BENCHMARK_done
+COMPLETION_FLAG=/opt/output/${BENCHMARK}_done
 
 service ssh restart
 
@@ -28,7 +28,11 @@ if [ $NODE_RANK = 0 ] ; then
   done
 
   BENCHMARK=$BENCHMARK NHOSTS=$NHOSTS /scripts/test.sh
-  touch $COMPLETION_FLAG
+
+  for host in ${@}; do
+    ssh ${host} touch ${COMPLETION_FLAG}
+  done
+
 else
   while [ ! -f $COMPLETION_FLAG ]; do sleep 10; done
 fi

--- a/.github/gke-workflow/nccl/scripts/nccl-test-launch.sh
+++ b/.github/gke-workflow/nccl/scripts/nccl-test-launch.sh
@@ -27,7 +27,7 @@ if [ $NODE_RANK = 0 ] ; then
     echo "$host ready"
   done
 
-  BENCHMARK=$BENCHMARK NHOSTS=$NHOSTS /scripts/test.sh
+  NCCL_BENCHMARK=$BENCHMARK NHOSTS=$NHOSTS /scripts/test.sh
 
   for host in ${@}; do
     ssh ${host} touch ${COMPLETION_FLAG}

--- a/.github/gke-workflow/nccl/scripts/test.sh
+++ b/.github/gke-workflow/nccl/scripts/test.sh
@@ -48,8 +48,6 @@ run_nccl() {
          -x NCCL_SHIMNET_GUEST_CONFIG_CHECKER_CONFIG_FILE=/usr/local/nvidia/lib64/a3plus_guest_config.textproto \
          -x NCCL_FASTRAK_PLUGIN_ACCEPT_TIMEOUT_MS=${NCCL_FASTRAK_PLUGIN_ACCEPT_TIMEOUT_MS} \
          -x NCCL_NVLS_ENABLE=${NCCL_NVLS_ENABLE} \
-         taskset \
-         -c 32-63 \
          ${NCCL_BENCHMARK} --minbytes ${NCCL_MINBYTES} \
                            --maxbytes ${NCCL_MAXBYTES} \
                            --stepfactor ${NCCL_STEPFACTOR} \

--- a/.github/gke-workflow/nccl/scripts/test.sh
+++ b/.github/gke-workflow/nccl/scripts/test.sh
@@ -1,92 +1,63 @@
 set -x
 
-: "${BENCHMARK:?Must set BENCHMARK}"
-: "${NHOSTS:?Must set NHOSTS}"
+export SCRIPT_DIR=/scripts
 
 ulimit -n 1048576
 
-DATA_MIN="${DATA_MIN:-8G}"
-DATA_MAX="${DATA_MAX:-8G}"
-GPU_PER_NODE="${GPU_PER_NODE:-8}"
-RUN_ITERS="${RUN_ITERS:-20}"
-WARMUP_ITERS="${WARMUP_ITERS:-5}"
+NCCL_LIB_DIR=${NCCL_LIB_DIR} . /usr/local/nvidia/lib64/nccl-env-profile.sh
 
-SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
-
-host_nic="eth0"
-gpu_nics="eth1,eth2,eth3,eth4,eth5,eth6,eth7,eth8"
-find_nics() {
-    local nics_discovered=0
-    local host_nic_discovered=""
-    local gpu_nics_discovered=""
-    for netdev in $(ls /sys/class/net | awk '{print $1}'); do
-        pci_bdf=$(cat "/sys/class/net/${netdev}/device/uevent" 2>/dev/null | grep "PCI_SLOT_NAME" | awk -F '=' '{print $2}' || echo "")
-        if [[ -z "${pci_bdf}" ]]; then
-            continue
-        fi
-        if [[ "${pci_bdf}" =~ 00\:[0-9a-f]{2}\.0 ]]; then
-            host_nic_discovered="${netdev}"
-        elif [[ "" =~ [0|8][6-7d-e]\:00\.0 ]]; then
-            if [[ -z "${gpu_nics_discovered}" ]]; then
-                gpu_nics_discovered="${netdev}"
-            else
-                gpu_nics_discovered="${gpu_nics_discovered},${netdev}"
-            fi
-        fi
-    done
-    if [[ -n "" ]]; then
-        host_nic="${host_nic_discovered}"
-    fi
-    if [[ -n "" ]]; then
-        gpu_nics="${gpu_nics_discovered}"
-    fi
-}
-
-find_nics
+: "${NCCL_BENCHMARK:?Must set NCCL_BENCHMARK}"
+NCCL_MINBYTES="${NCCL_MINBYTES:-8G}"
+NCCL_MAXBYTES="${NCCL_MAXBYTES:-16G}"
+NCCL_STEPFACTOR="${NCCL_STEPFACTOR:-2}"
+NCCL_ITERS="${NCCL_ITERS:-100}"
+NCCL_WARMUP_ITERS="${NCCL_WARMUP_ITERS:-0}"
 
 run_nccl() {
   mpirun --mca btl tcp,self \
          --mca btl_tcp_if_include eth0 \
          --allow-run-as-root \
-         -np $(( GPU_PER_NODE * "${NHOSTS}" )) \
-         --hostfile "${SCRIPT_DIR}/hostfiles${NHOSTS}/hostfile${GPU_PER_NODE}"     \
-         -x NCCL_DEBUG_FILE="/tmp/${BENCHMARK}"-%h-%p.log     \
-         -x NCCL_TOPO_DUMP_FILE="/tmp/${BENCHMARK}"_topo.txt     \
-         -x NCCL_GRAPH_DUMP_FILE="/tmp/${BENCHMARK}"_graph.txt     \
+         -np $(( GPUS_PER_NODE * "${NHOSTS}" )) \
+         --hostfile "${SCRIPT_DIR}/hostfiles${NHOSTS}/hostfile${GPUS_PER_NODE}"     \
          -x LD_LIBRARY_PATH \
          -x PATH     \
          -x NCCL_DEBUG=VERSION \
-         -x NCCL_DEBUG_SUBSYS=INIT,NET,ENV,COLL,GRAPH \
          -x NCCL_TESTS_SPLIT_MASK="${NCCL_TESTS_SPLIT_MASK:-0x0}"     \
          -x NCCL_FASTRAK_LLCM_DEVICE_DIRECTORY="${NCCL_FASTRAK_LLCM_DEVICE_DIRECTORY}"     \
          -x NCCL_LIB_DIR \
-         -x NCCL_FASTRAK_IFNAME="${gpu_nics}" \
-         -x NCCL_FASTRAK_CTRL_DEV="${host_nic}" \
-         -x NCCL_SOCKET_IFNAME="${host_nic}" \
-         -x NCCL_CROSS_NIC=0 \
-         -x NCCL_ALGO=Ring,Tree \
-         -x NCCL_PROTO=Simple \
-         -x NCCL_MIN_NCHANNELS=4 \
-         -x NCCL_P2P_NET_CHUNKSIZE=524288 \
-         -x NCCL_P2P_PCI_CHUNKSIZE=524288 \
-         -x NCCL_P2P_NVL_CHUNKSIZE=1048576 \
-         -x NCCL_FASTRAK_NUM_FLOWS=2 \
-         -x NCCL_FASTRAK_ENABLE_CONTROL_CHANNEL=0 \
-         -x NCCL_BUFFSIZE=8388608 \
-         -x NCCL_FASTRAK_USE_SNAP=1 \
-         -x NCCL_FASTRAK_USE_LLCM=1 \
-         -x CUDA_VISIBLE_DEVICES=0,1,2,3,4,5,6,7 \
-         -x NCCL_NET_GDR_LEVEL=PIX \
-         -x NCCL_FASTRAK_ENABLE_HOTPATH_LOGGING=0 \
-         -x NCCL_TUNER_PLUGIN=libnccl-tuner.so \
+         -x NCCL_FASTRAK_IFNAME=${NCCL_FASTRAK_IFNAME} \
+         -x NCCL_FASTRAK_CTRL_DEV="${NCCL_SOCKET_IFNAME}" \
+         -x NCCL_SOCKET_IFNAME="${NCCL_SOCKET_IFNAME}" \
+         -x NCCL_CROSS_NIC=${NCCL_CROSS_NIC} \
+         -x NCCL_ALGO=${NCCL_ALGO} \
+         -x NCCL_PROTO=${NCCL_PROTO} \
+         -x NCCL_MIN_NCHANNELS=${NCCL_MIN_NCHANNELS} \
+         -x NCCL_P2P_NET_CHUNKSIZE=${NCCL_P2P_NET_CHUNKSIZE} \
+         -x NCCL_P2P_PCI_CHUNKSIZE=${NCCL_P2P_PCI_CHUNKSIZE} \
+         -x NCCL_P2P_NVL_CHUNKSIZE=${NCCL_P2P_NVL_CHUNKSIZE} \
+         -x NCCL_FASTRAK_NUM_FLOWS=${NCCL_FASTRAK_NUM_FLOWS} \
+         -x NCCL_FASTRAK_ENABLE_CONTROL_CHANNEL=${NCCL_FASTRAK_ENABLE_CONTROL_CHANNEL} \
+         -x NCCL_BUFFSIZE=${NCCL_BUFFSIZE} \
+         -x NCCL_FASTRAK_USE_SNAP=${NCCL_FASTRAK_USE_SNAP} \
+         -x NCCL_FASTRAK_USE_LLCM=${NCCL_FASTRAK_USE_LLCM} \
+         -x CUDA_VISIBLE_DEVICES=${CUDA_VISIBLE_DEVICES} \
+         -x NCCL_NET_GDR_LEVEL=${NCCL_NET_GDR_LEVEL} \
+         -x NCCL_FASTRAK_ENABLE_HOTPATH_LOGGING=${NCCL_FASTRAK_ENABLE_HOTPATH_LOGGING} \
+         -x NCCL_TUNER_PLUGIN=${NCCL_TUNER_PLUGIN} \
          -x NCCL_TUNER_CONFIG_PATH=/usr/local/nvidia/lib64/a3plus_tuner_config.textproto \
          -x NCCL_SHIMNET_GUEST_CONFIG_CHECKER_CONFIG_FILE=/usr/local/nvidia/lib64/a3plus_guest_config.textproto \
-         -x NCCL_FASTRAK_PLUGIN_ACCEPT_TIMEOUT_MS=600000 \
-         -x NCCL_NVLS_ENABLE=0 \
+         -x NCCL_FASTRAK_PLUGIN_ACCEPT_TIMEOUT_MS=${NCCL_FASTRAK_PLUGIN_ACCEPT_TIMEOUT_MS} \
+         -x NCCL_NVLS_ENABLE=${NCCL_NVLS_ENABLE} \
          taskset \
          -c 32-63 \
-         "${BENCHMARK}" -b "${DATA_MIN}" -e "${DATA_MAX}" -f 2 -g 1 -w "${WARMUP_ITERS}" --iters "${RUN_ITERS}" 2>&1 | \
-         tee "/tmp/${BENCHMARK}_nh${NHOSTS}_ng${GPU_PER_NODE}_i${RUN_ITERS}.txt"
+         ${NCCL_BENCHMARK} --minbytes ${NCCL_MINBYTES} \
+                           --maxbytes ${NCCL_MAXBYTES} \
+                           --stepfactor ${NCCL_STEPFACTOR} \
+                           --ngpus 1 \
+                           --check 1 \
+                           --warmup_iters ${NCCL_WARMUP_ITERS} \
+                           --iters ${NCCL_ITERS} 2>&1 | \
+         tee "/opt/output/${NCCL_BENCHMARK}_nh${NHOSTS}_ng${GPUS_PER_NODE}_i${NCCL_ITERS}.txt"
 }
 
 run_nccl "$@"

--- a/.github/gke-workflow/nccl/service.yml
+++ b/.github/gke-workflow/nccl/service.yml
@@ -5,7 +5,6 @@ metadata:
 spec:
   selector:
     batch.kubernetes.io/job-completion-index: "0"
-    jobset.sigs.k8s.io/jobset-name: {JOBSET_NAME}
   clusterIP: None
   ports:
   - port: 22
@@ -19,7 +18,6 @@ metadata:
 spec:
   selector:
     batch.kubernetes.io/job-completion-index: "1"
-    jobset.sigs.k8s.io/jobset-name: {JOBSET_NAME}
   clusterIP: None
   ports:
   - port: 22

--- a/.github/gke-workflow/xpk/blueprint.patch
+++ b/.github/gke-workflow/xpk/blueprint.patch
@@ -19,7 +19,7 @@ index ccbca90..22a880a 100644
          settings={
              "name": f"{cluster_name}-a3-megagpu-pool-0",
              "machine_type": system.gce_machine_type,
-+            "guest_accelerator": [{"type":"nvidia-h100-mega-80gb", "count": 8, "gpu_driver_installation_config": {"gpu_driver_version": "LATEST"}}],
++            "guest_accelerator": [{"type":"nvidia-h100-mega-80gb", "count": 8, "gpu_driver_installation_config": {"gpu_driver_version": "DEFAULT"}}],
              "static_node_count": num_nodes,
              "zones": [zone],
 -            "host_maintenance_interval": "PERIODIC",

--- a/.github/gke-workflow/xpk/docker_resources.patch
+++ b/.github/gke-workflow/xpk/docker_resources.patch
@@ -1,5 +1,5 @@
 diff --git a/src/xpk/core/docker_resources.py b/src/xpk/core/docker_resources.py
-index a95c557..754ac03 100644
+index a95c557..11e8e43 100644
 --- a/src/xpk/core/docker_resources.py
 +++ b/src/xpk/core/docker_resources.py
 @@ -20,6 +20,8 @@ from .storage import GCS_FUSE_TYPE, GCP_FILESTORE_TYPE, Storage, get_storages_to
@@ -20,7 +20,7 @@ index a95c557..754ac03 100644
                    - name: REPLICATED_JOB_NAME
                      valueFrom:
                        fieldRef:
-@@ -74,30 +76,32 @@ def get_env_container(args, system: SystemCharacteristics) -> str:
+@@ -74,22 +76,22 @@ def get_env_container(args, system: SystemCharacteristics) -> str:
                        fieldRef:
                          fieldPath: metadata.annotations['jobset.sigs.k8s.io/jobset-name']
                    - name: JAX_COORDINATOR_ADDRESS
@@ -50,18 +50,7 @@ index a95c557..754ac03 100644
  
    if system.accelerator_type == AcceleratorType['GPU']:
      gpu_direct_name = 'fastrak'
-     if args.device_type == H100_DEVICE_TYPE:
-       gpu_direct_name = 'tcpx'
-       gpu_env_yaml += """
-+                  - name: NCCL_LIB_DIR
-+                    value: /opt/nvidia/nccl/lib
-                   - name: LD_LIBRARY_PATH
--                    value: /usr/local/nvidia/lib64
-+                    value: /opt/nvidia/nccl/lib:/usr/local/cuda-12.8/targets/x86_64-linux/lib:/usr/local/nvidia/lib64
- """
-     elif args.device_type == H100_MEGA_DEVICE_TYPE:
-       gpu_direct_name = 'tcpxo'
-@@ -123,7 +127,7 @@ def get_cpu_env(num_slices, env_vars, system) -> str:
+@@ -123,7 +125,7 @@ def get_cpu_env(num_slices, env_vars, system) -> str:
    Returns:
      str: yaml containing env variables
    """
@@ -70,7 +59,7 @@ index a95c557..754ac03 100644
                  - name: REPLICATED_JOB_NAME
                    valueFrom:
                      fieldRef:
-@@ -137,12 +141,12 @@ def get_cpu_env(num_slices, env_vars, system) -> str:
+@@ -137,12 +139,12 @@ def get_cpu_env(num_slices, env_vars, system) -> str:
                      fieldRef:
                        fieldPath: metadata.annotations['batch.kubernetes.io/job-completion-index']
                  - name: PROCESSES_IN_JOB
@@ -87,7 +76,7 @@ index a95c557..754ac03 100644
    """
    return yaml.format(
        processes_in_job=system.vms_per_slice,
-@@ -251,7 +255,9 @@ def get_volume_mounts(args, system: SystemCharacteristics) -> str:
+@@ -251,7 +253,9 @@ def get_volume_mounts(args, system: SystemCharacteristics) -> str:
          or system.device_type == H200_DEVICE_TYPE
          or system.device_type == B200_DEVICE_TYPE
      ):
@@ -98,7 +87,7 @@ index a95c557..754ac03 100644
  
    storages: list[Storage] = get_storages_to_mount(
        setup_k8s_env(args), args.storage
-@@ -300,7 +306,7 @@ def add_container_ports(args, system: SystemCharacteristics) -> str:
+@@ -300,7 +304,7 @@ def add_container_ports(args, system: SystemCharacteristics) -> str:
    if args.use_pathways:
      return ''
  

--- a/.github/gke-workflow/xpk/tcpxo_decorator.patch
+++ b/.github/gke-workflow/xpk/tcpxo_decorator.patch
@@ -1,42 +1,13 @@
 diff --git a/src/xpk/core/workload_decorators/tcpxo_decorator.py b/src/xpk/core/workload_decorators/tcpxo_decorator.py
-index 322e574..0a71db8 100644
+index 322e574..5a0cc42 100644
 --- a/src/xpk/core/workload_decorators/tcpxo_decorator.py
 +++ b/src/xpk/core/workload_decorators/tcpxo_decorator.py
-@@ -163,7 +163,12 @@ def add_tcpxo_daemon_container(job_manifest):
-           {'name': 'sys', 'mountPath': '/hostsysfs'},
-           {'name': 'proc-sys', 'mountPath': '/hostprocsysfs'},
-       ],
--      'env': [{'name': 'LD_LIBRARY_PATH', 'value': '/usr/local/nvidia/lib64'}],
-+      'env': [
-+          {'name': 'LD_LIBRARY_PATH', 'value': '/opt/nvidia/nccl/lib:/usr/local/cuda-12.8/targets/x86_64-local/lib:/usr/local/nvidia/lib64'},
-+          {'name': 'NCCL_LIB_DIR', 'value': '/opt/nvidia/nccl/lib'},
-+          {'name': 'NCCL_TUNER_PLUGIN', 'value': 'none'},
-+          {'name': 'NCCL_NET_PLUGIN', 'value': '/opt/hpcx/nccl_rdma_sharp_plugin/lib/libnccl-net.so'}
-+      ],
-   }
-   job_manifest['spec']['template']['spec']['containers'].append(
-       tcpxo_daemon_container
-@@ -175,12 +180,22 @@ def update_gpu_containers(job_manifest):
+@@ -175,7 +175,7 @@ def update_gpu_containers(job_manifest):
      if 'nvidia.com/gpu' in container.get('resources', {}).get('limits', {}):
        container.setdefault('env', [])
        container['env'].append(
 -          {'name': 'LD_LIBRARY_PATH', 'value': '/usr/local/nvidia/lib64'}
-+          {'name': 'LD_LIBRARY_PATH', 'value': '/opt/nvidia/nccl/lib:/usr/local/cuda-12.8/targets/x86_64-local/lib:/usr/local/nvidia/lib64'}
-+      )
-+      container['env'].append(
-+          {'name': 'NCCL_LIB_DIR', 'value': '/opt/nvidia/nccl/lib'}
-+      )
-+      container['env'].append(
-+          {'name': 'NCCL_NET_PLUGIN', 'value': '/opt/hpcx/nccl_rdma_sharp_plugin/lib/libnccl-net.so'}
++              {'name': 'LD_LIBRARY_PATH', 'value': '/opt/nvidia/nccl/lib:/usr/local/cuda-12.8/targets/x86_64-local/lib:/usr/local/nvidia/lib64'}
        )
        container['env'].append({
            'name': 'NCCL_FASTRAK_LLCM_DEVICE_DIRECTORY',
-           'value': '/dev/aperture_devices',
-       })
-+      container['env'].append({
-+          'name': 'NCCL_TUNER_PLUGIN',
-+          'value': 'none',
-+      })
-       container.setdefault('volumeMounts', [])
-       container['volumeMounts'].append(
-           {'name': 'aperture-devices', 'mountPath': '/dev/aperture_devices'}

--- a/.github/gke-workflow/xpk/xpk-sa-rbac.yml
+++ b/.github/gke-workflow/xpk/xpk-sa-rbac.yml
@@ -3,6 +3,8 @@ kind: ServiceAccount
 metadata:
   name: xpk-sa
   namespace: default
+  annotations:
+    iam.gke.io/gcp-service-account: jobset-xpk-user@nv-jaxtoolboxgcp-20240925.iam.gserviceaccount.com
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role

--- a/.github/workflows/_test_maxtext_gke_xpk.yaml
+++ b/.github/workflows/_test_maxtext_gke_xpk.yaml
@@ -1,6 +1,12 @@
 name: ~Test MaxText (GKE, XPK)
 
 on:
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - ready_for_review
+      - synchronize
   workflow_call:
     inputs:
       MAXTEXT_IMAGE:
@@ -14,179 +20,42 @@ jobs:
     runs-on: gke-a3mega
 
     env:
-      CLUSTER_NAME: jtb-2025-06-12
-      DEVICE_TYPE: h100-mega-80gb-8
-      NUM_NODES: 2
-      ZONE: us-central1-a
       WORKLOAD_NAME_PREFIX: gke-maxtext-train
-      MAIN_CONTAINER_NAME: gpu-image
-      GCS_BUCKET: jaxtoolbox-ci
+      MAXTEXT_MODEL: llama2-7b
+      MAXTEXT_ATTENTION_TYPE: cudnn_flash_te
+      MAXTEXT_REMAT_POLICY: minimal_flash
+      MAXTEXT_TRAIN_STEPS: 20
+      MAXTEXT_FSDP: 16
+      MAXTEXT_IMAGE: ghcr.io/nvidia/jax-toolbox-internal:15729281707-maxtext-amd64
+      NUM_NODES: 2
 
     steps:
-      - uses: actions/checkout@v4
-
-      - name: Show environment
-        run: |
-          set -x 
+    - name: Launch XPK workload on cluster
+      uses: ./.github/actions/gke-xpk
+      with:
+        IMAGE: ${{ env.MAXTEXT_IMAGE }}
+        WORKLOAD_NAME_PREFIX: ${{ env.WORKLOAD_NAME_PREFIX }}
+        COMMAND: |
+          console=/dev/stdout;
           
-          gcloud version
-
-          source $HOME/.venv/bin/activate
-          python --version
-          xpk version
-
-      - name: Set workload name
-        run: |
-          echo "WORKLOAD_NAME=${WORKLOAD_NAME_PREFIX}-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}" >> ${GITHUB_ENV}
-          echo "DATE=$(date +'%Y-%m-%d')" >> ${GITHUB_ENV}
-
-      - name: Create maxtext workload
-        env:
-          MAXTEXT_MODEL: llama2-7b 
-          MAXTEXT_ATTENTION_TYPE: cudnn_flash_te
-          MAXTEXT_REMAT_POLICY: minimal_flash
-          MAXTEXT_TRAIN_STEPS: 20
-          MAXTEXT_FSDP: 16
-        run: |
-          PRELUDE="
-              curl -LO https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-cli-linux-x86_64.tar.gz;
-              tar xf google-cloud-cli-linux-x86_64.tar.gz;
-              ./google-cloud-sdk/install.sh --quiet;
-              ./google-cloud-sdk/bin/gcloud init;
-
-              mkdir -p /usr/share/workload;
-              mkdir -p /opt/output;
-          "
-
-          POSTLUDE="
-              ./google-cloud-sdk/bin/gsutil cp -r /opt/output/ gs://${GCS_BUCKET}/${WORKLOAD_NAME_PREFIX}/${DATE}/${WORKLOAD_NAME}/node0\$NODE_RANK;
-              exit \$PIPESTATUS;
-          "
-
-          CMD="
-              console=/dev/stdout;
-              
-              nsys-jax --capture-range=cudaProfilerApi 
-                       --capture-range-end=stop 
-                       -o /opt/output/profile.zip 
-                       -- 
-                       test-maxtext.sh -n ${NUM_NODES} 
-                                       -b ${NUM_NODES}
-                                       --model-name=${MAXTEXT_MODEL}
-                                       --attn-type=${MAXTEXT_ATTENTION_TYPE}
-                                       --remat-policy=${MAXTEXT_REMAT_POLICY}
-                                       --steps=${MAXTEXT_TRAIN_STEPS}
-                                       --fsdp=${MAXTEXT_FSDP}
-                                       --multiprocess 
-                                       -a 'scan_layers=false
-                                           max_target_length=4096 
-                                           use_iota_embed=true 
-                                           logits_dot_in_fp32=false 
-                                           profiler=nsys 
-                                           skip_first_n_steps_for_profiler=3 
-                                           profiler_steps=8' |&
-              tee /opt/output/output.log &> \${console};
-          "
-
-          # set container command in-line
-          PRELUDE=$(echo ${PRELUDE} | sed 's/\n/\ /g')
-          POSTLUDE=$(echo ${POSTLUDE} | sed 's/\n/\ /g')
-          CMD=$(echo ${CMD} | sed 's/\n/\ /g')
-
-          cd ${HOME}/xpk
-          source ${HOME}/.venv/bin/activate
-          python xpk.py workload create \
-                        --cluster ${CLUSTER_NAME} \
-                        --zone ${ZONE} \
-                        --workload ${WORKLOAD_NAME} \
-                        --docker-image ${{ inputs.MAXTEXT_IMAGE }} \
-                        --device-type ${DEVICE_TYPE} \
-                        --num-nodes ${NUM_NODES} \
-                        --num-slices ${NUM_NODES} \
-                        --priority=high \
-                        --scheduler=gke.io/topology-aware-auto \
-                        --command "${PRELUDE} ${CMD} ${POSTLUDE}"
-
-      - name: Wait for JobSet to unsuspend
-        env:
-          POLL_TIMEOUT: 3600
-        run: |
-          # wait for jobset to start
-          START=$(date +%s)
-          JOBSET_ACTIVE=false
-          while ! ${JOBSET_ACTIVE}  || [ -z ${JOBSET_ACTIVE} ]; do
-            JOBSET_ACTIVE=$(kubectl get jobset -o json | jq -r '.items[] | select(.metadata.name == "'${WORKLOAD_NAME}'").status.replicatedJobsStatus[0] | .active == 1')
-            NOW=$(date +%s)
-            ELAPSED=$(( NOW - START ))
-            if (( ELAPSED > POLL_TIMEOUT )) ; then
-              echo "Timeout after waiting for JobSet ${WORKLOAD_NAME} to become active in cluster ${CLUSTER_NAME}"
-              exit 1
-            fi
-            echo "Waiting for JobSet ${WORKLOAD_NAME} to become active in cluster ${CLUSTER_NAME}"
-            sleep 5
-          done
-
-          echo "JobSet ${WORKLOAD_NAME} has just become active in cluster ${CLUSTER_NAME}"
-
-      - name: Set Pod name
-        run: |
-          echo "POD=$(kubectl get pods -o json | jq -r '.items[] | select(.metadata.labels."'jobset.sigs.k8s.io/jobset-name'" == "'${WORKLOAD_NAME}'") | .metadata.name ' | sort | head -n1 )" >> ${GITHUB_ENV}
-
-      - name: Wait for Pod readiness
-        run: |
-          POD_READY=false
-          while ! ${POD_READY}  || [ -z ${POD_READY} ]; do
-            echo "Waiting for pod ${POD} in JobSet ${WORKLOAD_NAME} to become ready"
-            sleep 10
-
-            POD_ERROR=$(kubectl get pod ${POD} -o json | jq -r '.status.containerStatuses[]? | select(.name == "'${MAIN_CONTAINER_NAME}'") | .state | ( has("terminated") and (.terminated.reason == "Error" ))')
-            if ${POD_ERROR} ; then
-              echo "There was an issue starting the JobSet ${WORKLOAD_NAME} on ${CLUSTER_NAME}"
-              break
-            fi
-
-            POD_READY=$(kubectl get pod ${POD} -o json | jq -r '.status.containerStatuses[]? | select(.name == "'${MAIN_CONTAINER_NAME}'").ready')
-          done;
-
-      - name: Stream logs from JobSet Pods
-        run: |
-          jobset_pods=($(kubectl get pods -o json | jq -r '.items[].metadata | select(.labels."jobset.sigs.k8s.io/jobset-name" == "'${WORKLOAD_NAME}'") | .name' | tr '\n' ' '))
-
-          for jobset_pod in ${jobset_pods[@]}; do
-              kubectl logs  --pod-running-timeout=1m -f --prefix=true --timestamps=true -c gpu-image ${jobset_pod} 2>&1 | tee -a ${WORKLOAD_NAME}-${jobset_pod}-jobset.log &
-          done
-          wait < <(jobs -p)
-
-      - name: Set exit code from JobSet
-        run: |
-          MAYBE_XPK_EXIT_CODE="$(tail -n 1 ${WORKLOAD_NAME}-${POD}-jobset.log | awk '{ print $3 }' )"
-          echo ${MAYBE_XPK_EXIT_CODE} | grep -E 'EXIT\_CODE=[0-9]+$'
-
-          if [ $? -ne 0 ]; then
-            echo "The JobSet ${WORKLOAD_NAME} on ${CLUSTER_NAME} did not complete as expected "
-            exit 1
-          fi
-
-          eval "export ${MAYBE_XPK_EXIT_CODE}"
-          exit ${EXIT_CODE}
-
-      - name: Clean up JobSet
-        if: ${{ always() }}
-        run: |
-          kubectl delete jobset --wait ${WORKLOAD_NAME} || echo "JobSet ${WORKLOAD_NAME} does not exist in ${CLUSTER_NAME}"
-
-      - name: Download artifacts from GCS
-        run: |
-          mkdir -p output/${WORKLOAD_NAME}
-          gsutil cp -r gs://${GCS_BUCKET}/${WORKLOAD_NAME_PREFIX}/${DATE}/${WORKLOAD_NAME} output/${WORKLOAD_NAME}
-
-      - name: Upload artifacts to GitHub Acions
-        uses: actions/upload-artifact@v4
-        with:
-          name: ${{ env.WORKLOAD_NAME_PREFIX }}
-          path: output/${{ env.WORKLOAD_NAME }}/*
-
-      - name: Clean up GCS artifacts
-        if: ${{ always() }}
-        run: |
-          rm -rf output/${WORKLOAD_NAME}
+          nsys-jax --capture-range=cudaProfilerApi
+                   --capture-range-end=stop
+                   -o /opt/output/profile.zip
+                   --
+                   test-maxtext.sh -n ${{ env.NUM_NODES }}
+                                   -b ${{ env.NUM_NODES }}
+                                   --model-name=${{ env.MAXTEXT_MODEL }}
+                                   --attn-type=${[ env.MAXTEXT_ATTENTION_TYPE }}
+                                   --remat-policy=${{ env.MAXTEXT_REMAT_POLICY }}
+                                   --steps=${{ env.MAXTEXT_TRAIN_STEPS }}
+                                   --fsdp=${{ env.MAXTEXT_FSDP }}
+                                   --multiprocess
+                                   -a 'scan_layers=false
+                                       max_target_length=4096
+                                       use_iota_embed=true
+                                       logits_dot_in_fp32=false
+                                       profiler=nsys
+                                       skip_first_n_steps_for_profiler=3
+                                       profiler_steps=8' |&
+          tee /opt/output/output.log &> \${console};
+          EXIT_CODE=\$PIPESTATUS;

--- a/.github/workflows/_test_maxtext_gke_xpk.yaml
+++ b/.github/workflows/_test_maxtext_gke_xpk.yaml
@@ -143,15 +143,15 @@ jobs:
 
       - name: Stream logs from JobSet Pods
         run: |
-          jobset_pods=($(kubectl get pods -o json | jq -r '.items[].metadata | select(.labels."jobset.sigs.k8s.io/jobset-name" == "'${workload_name}'") | .name' | tr '\n' ' '))
+          jobset_pods=($(kubectl get pods -o json | jq -r '.items[].metadata | select(.labels."jobset.sigs.k8s.io/jobset-name" == "'${WORKLOAD_NAME}'") | .name' | tr '\n' ' '))
           for jobset_pod in $jobset_pods; do
-            kubectl logs -f --prefix=true --timestamps=true -c ${main_container_name} ${jobset_pod} |& tee ${workload_name}-${jobset_pod}-jobset.log &
+            kubectl logs -f --prefix=true --timestamps=true -c ${main_container_name} ${jobset_pod} |& tee ${WORKLOAD_NAME}-${jobset_pod}-jobset.log &
           done
           wait < <(jobs -p)
 
       - name: Set exit code from JobSet
         run: |
-          MAYBE_XPK_EXIT_CODE="$(tail -n 1 ${WORKLOAD_NAME}-jobset.log)"
+          MAYBE_XPK_EXIT_CODE="$(tail -n 1 ${WORKLOAD_NAME}-${POD}-jobset.log)"
           echo ${MAYBE_XPK_EXIT_CODE} |  grep -E '^EXIT\_CODE=*'
 
           if [ $? -ne 0 ]; then

--- a/.github/workflows/_test_maxtext_gke_xpk.yaml
+++ b/.github/workflows/_test_maxtext_gke_xpk.yaml
@@ -25,7 +25,7 @@ jobs:
       DEVICE_TYPE: h100-mega-80gb-8
       NUM_NODES: 2
       ZONE: us-central1-a
-      WORKLOAD_NAME_PREFIX: maxtext
+      WORKLOAD_NAME_PREFIX: maxtext-train
       MAIN_CONTAINER_NAME: gpu-image
       MAXTEXT_IMAGE: ghcr.io/nvidia/jax-toolbox-internal:15606961831-maxtext-amd64
 
@@ -45,6 +45,7 @@ jobs:
       - name: Set workload name
         run: |
           echo "WORKLOAD_NAME=${WORKLOAD_NAME_PREFIX}-${GITHUB_RUN_ID}-${GITHUB_RUN_NUMBER}-${GITHUB_RUN_ATTEMPT}" >> ${GITHUB_ENV}
+          echo "DATE=$(date +'%Y-%m-%d')" >> ${GITHUB_ENV}
 
       - name: Create maxtext workload
         env:
@@ -54,10 +55,23 @@ jobs:
           MAXTEXT_TRAIN_STEPS: 20
           MAXTEXT_FSDP: 16
         run: |
-          CMD="
+          PRELUDE="
+              curl -LO https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-cli-linux-x86_64.tar.gz;
+              tar xvf google-cloud-cli-linux-x86_64.tar.gz;
+              ./google-cloud-sdk/install.sh --quiet;
+              ./google-cloud-sdk/bin/gcloud init;
+              source \$HOME/.bashrc;
+
               mkdir -p /usr/share/workload;
               mkdir -p /opt/output;
+          "
 
+          POSTLUDE="
+              \$HOME/google-cloud-sdk/bin/gsutil cp -r /opt/output/ ${{ env.WORKLOAD_NAME_PREFIX}}/${{ env.DATE }}/${{ env.WORKLOAD_NAME }}-node0\${NODE_RANK};
+              exit \$PIPESTATUS
+          "
+
+          CMD="
               console=/dev/stdout;
               
               nsys-jax --capture-range=cudaProfilerApi 
@@ -80,7 +94,6 @@ jobs:
                                            skip_first_n_steps_for_profiler=3 
                                            profiler_steps=8' |&
               tee /opt/output/output.log &> \${console};
-              exit \$PIPESTATUS
           "
 
           # set container command in-line

--- a/.github/workflows/_test_maxtext_gke_xpk.yaml
+++ b/.github/workflows/_test_maxtext_gke_xpk.yaml
@@ -30,7 +30,7 @@ jobs:
       NUM_NODES: 2
 
     steps:
-    - name: Launch XPK workload on cluster
+    - name: Run XPK workload on cluster
       uses: ./.github/actions/gke-xpk
       with:
         IMAGE: ${{ env.MAXTEXT_IMAGE }}
@@ -45,7 +45,7 @@ jobs:
                    test-maxtext.sh -n ${{ env.NUM_NODES }}
                                    -b ${{ env.NUM_NODES }}
                                    --model-name=${{ env.MAXTEXT_MODEL }}
-                                   --attn-type=${[ env.MAXTEXT_ATTENTION_TYPE }}
+                                   --attn-type=${{ env.MAXTEXT_ATTENTION_TYPE }}
                                    --remat-policy=${{ env.MAXTEXT_REMAT_POLICY }}
                                    --steps=${{ env.MAXTEXT_TRAIN_STEPS }}
                                    --fsdp=${{ env.MAXTEXT_FSDP }}

--- a/.github/workflows/_test_maxtext_gke_xpk.yaml
+++ b/.github/workflows/_test_maxtext_gke_xpk.yaml
@@ -45,7 +45,7 @@ jobs:
 
       - name: Set workload name
         run: |
-          echo "WORKLOAD_NAME=${WORKLOAD_NAME_PREFIX}-${GITHUB_RUN_ID}-${GITHUB_RUN_NUMBER}-${GITHUB_RUN_ATTEMPT}" >> ${GITHUB_ENV}
+          echo "WORKLOAD_NAME=${WORKLOAD_NAME_PREFIX}-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}" >> ${GITHUB_ENV}
           echo "DATE=$(date +'%Y-%m-%d')" >> ${GITHUB_ENV}
 
       - name: Create maxtext workload

--- a/.github/workflows/_test_maxtext_gke_xpk.yaml
+++ b/.github/workflows/_test_maxtext_gke_xpk.yaml
@@ -30,6 +30,8 @@ jobs:
         IMAGE: ${{ env.MAXTEXT_IMAGE }}
         WORKLOAD_NAME_PREFIX: ${{ env.WORKLOAD_NAME_PREFIX }}
         COMMAND: |
+          export NCCL_NET_PLUGIN=/opt/hpcx/nccl_rdma_sharp_plugin/lib/libnccl-net.so;
+          export NCCL_TUNER_PLUGIN=none;
           console=/dev/stdout;
           
           nsys-jax --capture-range=cudaProfilerApi

--- a/.github/workflows/_test_maxtext_gke_xpk.yaml
+++ b/.github/workflows/_test_maxtext_gke_xpk.yaml
@@ -113,7 +113,7 @@ jobs:
                         --num-slices ${NUM_NODES} \
                         --priority=high \
                         --scheduler=gke.io/topology-aware-auto \
-                        --command "${PREDLUDE} ${CMD} ${POSTLUDE}"
+                        --command "${PRELUDE} ${CMD} ${POSTLUDE}"
 
       - name: Wait for JobSet to unsuspend
         env:
@@ -161,7 +161,7 @@ jobs:
           jobset_pods=($(kubectl get pods -o json | jq -r '.items[].metadata | select(.labels."jobset.sigs.k8s.io/jobset-name" == "'${WORKLOAD_NAME}'") | .name' | tr '\n' ' '))
 
           for jobset_pod in ${jobset_pods[@]}; do
-              kubectl logs -f --prefix=true --timestamps=true -c gpu-image ${jobset_pod} 2>&1 | tee -a ${WORKLOAD_NAME}-${jobset_pod}-jobset.log &
+              kubectl logs  --pod-running-timeout=1m -f --prefix=true --timestamps=true -c gpu-image ${jobset_pod} 2>&1 | tee -a ${WORKLOAD_NAME}-${jobset_pod}-jobset.log &
           done
           wait < <(jobs -p)
 

--- a/.github/workflows/_test_maxtext_gke_xpk.yaml
+++ b/.github/workflows/_test_maxtext_gke_xpk.yaml
@@ -67,7 +67,7 @@ jobs:
           "
 
           POSTLUDE="
-              ./google-cloud-sdk/bin/gsutil cp -r /opt/output/ gs://${ env.GCS_BUCKET }}/${{ env.WORKLOAD_NAME_PREFIX}}/${{ env.DATE }}/${{ env.WORKLOAD_NAME }}/node0\${NODE_RANK};
+              ./google-cloud-sdk/bin/gsutil cp -r /opt/output/ gs://${ env.GCS_BUCKET }}/${{ env.WORKLOAD_NAME_PREFIX}}/${{ env.DATE }}/${{ env.WORKLOAD_NAME }}/node0\$NODE_RANK;
               exit \$PIPESTATUS;
           "
 

--- a/.github/workflows/_test_maxtext_gke_xpk.yaml
+++ b/.github/workflows/_test_maxtext_gke_xpk.yaml
@@ -18,7 +18,7 @@ jobs:
       DEVICE_TYPE: h100-mega-80gb-8
       NUM_NODES: 2
       ZONE: us-central1-a
-      WORKLOAD_NAME_PREFIX: maxtext-train
+      WORKLOAD_NAME_PREFIX: gke-maxtext-train
       MAIN_CONTAINER_NAME: gpu-image
       GCS_BUCKET: jaxtoolbox-ci
 

--- a/.github/workflows/_test_maxtext_gke_xpk.yaml
+++ b/.github/workflows/_test_maxtext_gke_xpk.yaml
@@ -67,6 +67,7 @@ jobs:
           "
 
           POSTLUDE="
+              ./google-cloud-sdk/bin/gsutil cp -r /opt/output/ gs://${GCS_BUCKET}/${WORKLOAD_NAME_PREFIX}/${DATE}/${WORKLOAD_NAME}/node0\$NODE_RANK;
               exit \$PIPESTATUS;
           "
 
@@ -96,6 +97,8 @@ jobs:
           "
 
           # set container command in-line
+          PRELUDE=$(echo ${PRELUDE} | sed 's/\n/\ /g')
+          POSTLUDE=$(echo ${POSTLUDE} | sed 's/\n/\ /g')
           CMD=$(echo ${CMD} | sed 's/\n/\ /g')
 
           cd ${HOME}/xpk

--- a/.github/workflows/_test_maxtext_gke_xpk.yaml
+++ b/.github/workflows/_test_maxtext_gke_xpk.yaml
@@ -67,7 +67,7 @@ jobs:
           "
 
           POSTLUDE="
-              ./google-cloud-sdk/bin/gsutil cp -r /opt/output/ gs://${ env.GCS_BUCKET }}/${{ env.WORKLOAD_NAME_PREFIX}}/${{ env.DATE }}/${{ env.WORKLOAD_NAME }}/node0\$NODE_RANK;
+              ./google-cloud-sdk/bin/gsutil cp -r /opt/output/ gs://${GCS_BUCKET}/${WORKLOAD_NAME_PREFIX}/${DATE}/${WORKLOAD_NAME}/node0\$NODE_RANK;
               exit \$PIPESTATUS;
           "
 

--- a/.github/workflows/_test_maxtext_gke_xpk.yaml
+++ b/.github/workflows/_test_maxtext_gke_xpk.yaml
@@ -58,7 +58,7 @@ jobs:
         run: |
           PRELUDE="
               curl -LO https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-cli-linux-x86_64.tar.gz;
-              tar xvf google-cloud-cli-linux-x86_64.tar.gz;
+              tar xf google-cloud-cli-linux-x86_64.tar.gz;
               ./google-cloud-sdk/install.sh --quiet;
               ./google-cloud-sdk/bin/gcloud init;
 
@@ -185,13 +185,14 @@ jobs:
 
       - name: Download artifacts from GCS
         run: |
+          mkdir -p output/${WORKLOAD_NAME}
           gsutil cp -r gs://${GCS_BUCKET}/${WORKLOAD_NAME_PREFIX}/${DATE}/${WORKLOAD_NAME} output/${WORKLOAD_NAME}
 
       - name: Upload artifacts to GitHub Acions
         uses: actions/upload-artifact@v4
         with:
-          name: ${WORKLOAD_NAME_PREFIX}-${TEST}
-          path: output/${WORKLOAD_NAME}/*
+          name: ${{ env.WORKLOAD_NAME_PREFIX }}-${{ env.TEST }}
+          path: output/${{ env.WORKLOAD_NAME }}/*
 
       - name: Clean up GCS artifacts
         if: ${{ always() }}

--- a/.github/workflows/_test_maxtext_gke_xpk.yaml
+++ b/.github/workflows/_test_maxtext_gke_xpk.yaml
@@ -111,7 +111,7 @@ jobs:
                         --num-slices ${NUM_NODES} \
                         --priority=high \
                         --scheduler=gke.io/topology-aware-auto \
-                        --command "${CMD}"
+                        --command "${PREDLUDE} ${CMD} ${POSTLUDE}"
 
       - name: Wait for JobSet to unsuspend
         env:

--- a/.github/workflows/_test_maxtext_gke_xpk.yaml
+++ b/.github/workflows/_test_maxtext_gke_xpk.yaml
@@ -152,7 +152,7 @@ jobs:
 
       - name: Set exit code from JobSet
         run: |
-          MAYBE_XPK_EXIT_CODE="$(tail -n 1 ${WORKLOAD_NAME}-${POD}jobset.log | awk '{ print $3 }' )"
+          MAYBE_XPK_EXIT_CODE="$(tail -n 1 ${WORKLOAD_NAME}-${POD}-jobset.log | awk '{ print $3 }' )"
           echo ${MAYBE_XPK_EXIT_CODE} | grep -E 'EXIT\_CODE=[0-9]+$'
 
           if [ $? -ne 0 ]; then

--- a/.github/workflows/_test_maxtext_gke_xpk.yaml
+++ b/.github/workflows/_test_maxtext_gke_xpk.yaml
@@ -1,13 +1,6 @@
 name: ~Test MaxText (GKE, XPK)
 
 on:
-  pull_request:
-    types:
-      - opened
-      - reopened
-      - ready_for_review
-      - synchronize
-
   workflow_call:
     inputs:
       MAXTEXT_IMAGE:
@@ -27,7 +20,6 @@ jobs:
       ZONE: us-central1-a
       WORKLOAD_NAME_PREFIX: maxtext-train
       MAIN_CONTAINER_NAME: gpu-image
-      MAXTEXT_IMAGE: ghcr.io/nvidia/jax-toolbox-internal:15606961831-maxtext-amd64
       GCS_BUCKET: jaxtoolbox-ci
 
     steps:
@@ -107,7 +99,7 @@ jobs:
                         --cluster ${CLUSTER_NAME} \
                         --zone ${ZONE} \
                         --workload ${WORKLOAD_NAME} \
-                        --docker-image ${MAXTEXT_IMAGE} \
+                        --docker-image ${{ inputs.MAXTEXT_IMAGE }} \
                         --device-type ${DEVICE_TYPE} \
                         --num-nodes ${NUM_NODES} \
                         --num-slices ${NUM_NODES} \

--- a/.github/workflows/_test_maxtext_gke_xpk.yaml
+++ b/.github/workflows/_test_maxtext_gke_xpk.yaml
@@ -191,7 +191,7 @@ jobs:
       - name: Upload artifacts to GitHub Acions
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ env.WORKLOAD_NAME_PREFIX }}-${{ env.TEST }}
+          name: ${{ env.WORKLOAD_NAME_PREFIX }}
           path: output/${{ env.WORKLOAD_NAME }}/*
 
       - name: Clean up GCS artifacts

--- a/.github/workflows/_test_maxtext_gke_xpk.yaml
+++ b/.github/workflows/_test_maxtext_gke_xpk.yaml
@@ -67,7 +67,6 @@ jobs:
           "
 
           POSTLUDE="
-              ./google-cloud-sdk/bin/gsutil cp -r /opt/output/ gs://${GCS_BUCKET}/${WORKLOAD_NAME_PREFIX}/${DATE}/${WORKLOAD_NAME}/node0\$NODE_RANK;
               exit \$PIPESTATUS;
           "
 

--- a/.github/workflows/_test_maxtext_gke_xpk.yaml
+++ b/.github/workflows/_test_maxtext_gke_xpk.yaml
@@ -28,6 +28,7 @@ jobs:
       WORKLOAD_NAME_PREFIX: maxtext-train
       MAIN_CONTAINER_NAME: gpu-image
       MAXTEXT_IMAGE: ghcr.io/nvidia/jax-toolbox-internal:15606961831-maxtext-amd64
+      GCS_BUCKET: jaxtoolbox-ci
 
     steps:
       - uses: actions/checkout@v4
@@ -67,7 +68,7 @@ jobs:
           "
 
           POSTLUDE="
-              \$HOME/google-cloud-sdk/bin/gsutil cp -r /opt/output/ ${{ env.WORKLOAD_NAME_PREFIX}}/${{ env.DATE }}/${{ env.WORKLOAD_NAME }}-node0\${NODE_RANK};
+              \$HOME/google-cloud-sdk/bin/gsutil cp -r /opt/output/ gs://${ env.GCS_BUCKET }}/${{ env.WORKLOAD_NAME_PREFIX}}/${{ env.DATE }}/${{ env.WORKLOAD_NAME }}/node0\${NODE_RANK};
               exit \$PIPESTATUS
           "
 
@@ -176,8 +177,22 @@ jobs:
           eval "export ${MAYBE_XPK_EXIT_CODE}"
           exit ${EXIT_CODE}
 
-
       - name: Clean up JobSet
         if: ${{ always() }}
         run: |
           kubectl delete jobset --wait ${WORKLOAD_NAME} || echo "JobSet ${WORKLOAD_NAME} does not exist in ${CLUSTER_NAME}"
+
+      - name: Download artifacts from GCS
+        run: |
+          gsutil cp -r gs://${GCS_BUCKET}/${WORKLOAD_NAME_PREFIX}/${DATE}/${WORKLOAD_NAME} output/${WORKLOAD_NAME}
+
+      - name: Upload artifacts to GitHub Acions
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${WORKLOAD_NAME_PREFIX}-${TEST}
+          path: output/${WORKLOAD_NAME}/*
+
+      - name: Clean up GCS artifacts
+        if: ${{ always() }}
+        run: |
+          rm -rf output/${WORKLOAD_NAME}

--- a/.github/workflows/_test_maxtext_gke_xpk.yaml
+++ b/.github/workflows/_test_maxtext_gke_xpk.yaml
@@ -144,15 +144,16 @@ jobs:
       - name: Stream logs from JobSet Pods
         run: |
           jobset_pods=($(kubectl get pods -o json | jq -r '.items[].metadata | select(.labels."jobset.sigs.k8s.io/jobset-name" == "'${WORKLOAD_NAME}'") | .name' | tr '\n' ' '))
-          for jobset_pod in $jobset_pods; do
-            kubectl logs -f --prefix=true --timestamps=true -c ${MAIN_CONTAINER_NAME} ${jobset_pod} |& tee ${WORKLOAD_NAME}-${jobset_pod}-jobset.log &
+
+          for jobset_pod in ${jobset_pods[@]}; do
+              kubectl logs -f --prefix=true --timestamps=true -c gpu-image ${jobset_pod} 2>&1 | tee -a ${WORKLOAD_NAME}-${jobset_pod}-jobset.log &
           done
           wait < <(jobs -p)
 
       - name: Set exit code from JobSet
         run: |
-          MAYBE_XPK_EXIT_CODE="$(tail -n 1 ${WORKLOAD_NAME}-${POD}-jobset.log)"
-          echo ${MAYBE_XPK_EXIT_CODE} |  grep -E '^EXIT\_CODE=*'
+          MAYBE_XPK_EXIT_CODE="$(tail -n 1 ${WORKLOAD_NAME}-${POD}jobset.log | awk '{ print $3 }' )"
+          echo ${MAYBE_XPK_EXIT_CODE} | grep -E 'EXIT\_CODE=[0-9]+$'
 
           if [ $? -ne 0 ]; then
             echo "The JobSet ${WORKLOAD_NAME} on ${CLUSTER_NAME} did not complete as expected "
@@ -161,6 +162,7 @@ jobs:
 
           eval "export ${MAYBE_XPK_EXIT_CODE}"
           exit ${EXIT_CODE}
+
 
       - name: Clean up JobSet
         if: ${{ always() }}

--- a/.github/workflows/_test_maxtext_gke_xpk.yaml
+++ b/.github/workflows/_test_maxtext_gke_xpk.yaml
@@ -146,6 +146,7 @@ jobs:
           jobset_pods=($(kubectl get pods -o json | jq -r '.items[].metadata | select(.labels."jobset.sigs.k8s.io/jobset-name" == "'${workload_name}'") | .name' | tr '\n' ' '))
           for jobset_pod in $jobset_pods; do
             kubectl logs -f --prefix=true --timestamps=true -c ${main_container_name} ${jobset_pod} |& tee ${workload_name}-${jobset_pod}-jobset.log &
+          done
           wait < <(jobs -p)
 
       - name: Set exit code from JobSet

--- a/.github/workflows/_test_maxtext_gke_xpk.yaml
+++ b/.github/workflows/_test_maxtext_gke_xpk.yaml
@@ -141,11 +141,12 @@ jobs:
             POD_READY=$(kubectl get pod ${POD} -o json | jq -r '.status.containerStatuses[]? | select(.name == "'${MAIN_CONTAINER_NAME}'").ready')
           done;
 
-      - name: Stream logs from JobSet
+      - name: Stream logs from JobSet Pods
         run: |
-          # stream gpu-image container logs from first (coordinator) pod in jobset
-          echo "Pod ${POD} in JobSet ${WORKLOAD_NAME} has become ready. Streaming logs..."
-          kubectl logs -f -c ${MAIN_CONTAINER_NAME} ${POD} |& tee ${WORKLOAD_NAME}-jobset.log
+          jobset_pods=($(kubectl get pods -o json | jq -r '.items[].metadata | select(.labels."jobset.sigs.k8s.io/jobset-name" == "'${workload_name}'") | .name' | tr '\n' ' '))
+          for jobset_pod in $jobset_pods; do
+            kubectl logs -f --prefix=true --timestamps=true -c ${main_container_name} ${jobset_pod} |& tee ${workload_name}-${jobset_pod}-jobset.log &
+          wait < <(jobs -p)
 
       - name: Set exit code from JobSet
         run: |

--- a/.github/workflows/_test_maxtext_gke_xpk.yaml
+++ b/.github/workflows/_test_maxtext_gke_xpk.yaml
@@ -61,15 +61,14 @@ jobs:
               tar xvf google-cloud-cli-linux-x86_64.tar.gz;
               ./google-cloud-sdk/install.sh --quiet;
               ./google-cloud-sdk/bin/gcloud init;
-              source \$HOME/.bashrc;
 
               mkdir -p /usr/share/workload;
               mkdir -p /opt/output;
           "
 
           POSTLUDE="
-              \$HOME/google-cloud-sdk/bin/gsutil cp -r /opt/output/ gs://${ env.GCS_BUCKET }}/${{ env.WORKLOAD_NAME_PREFIX}}/${{ env.DATE }}/${{ env.WORKLOAD_NAME }}/node0\${NODE_RANK};
-              exit \$PIPESTATUS
+              ./google-cloud-sdk/bin/gsutil cp -r /opt/output/ gs://${ env.GCS_BUCKET }}/${{ env.WORKLOAD_NAME_PREFIX}}/${{ env.DATE }}/${{ env.WORKLOAD_NAME }}/node0\${NODE_RANK};
+              exit \$PIPESTATUS;
           "
 
           CMD="

--- a/.github/workflows/_test_maxtext_gke_xpk.yaml
+++ b/.github/workflows/_test_maxtext_gke_xpk.yaml
@@ -1,12 +1,6 @@
 name: ~Test MaxText (GKE, XPK)
 
 on:
-  pull_request:
-    types:
-      - opened
-      - reopened
-      - ready_for_review
-      - synchronize
   workflow_call:
     inputs:
       MAXTEXT_IMAGE:
@@ -26,7 +20,7 @@ jobs:
       MAXTEXT_REMAT_POLICY: minimal_flash
       MAXTEXT_TRAIN_STEPS: 20
       MAXTEXT_FSDP: 16
-      MAXTEXT_IMAGE: ghcr.io/nvidia/jax-toolbox-internal:15729281707-maxtext-amd64
+      MAXTEXT_IMAGE: ${{ inputs.MAXTEXT_IMAGE }}
       NUM_NODES: 2
 
     steps:

--- a/.github/workflows/_test_maxtext_gke_xpk.yaml
+++ b/.github/workflows/_test_maxtext_gke_xpk.yaml
@@ -145,7 +145,7 @@ jobs:
         run: |
           jobset_pods=($(kubectl get pods -o json | jq -r '.items[].metadata | select(.labels."jobset.sigs.k8s.io/jobset-name" == "'${WORKLOAD_NAME}'") | .name' | tr '\n' ' '))
           for jobset_pod in $jobset_pods; do
-            kubectl logs -f --prefix=true --timestamps=true -c ${main_container_name} ${jobset_pod} |& tee ${WORKLOAD_NAME}-${jobset_pod}-jobset.log &
+            kubectl logs -f --prefix=true --timestamps=true -c ${MAIN_CONTAINER_NAME} ${jobset_pod} |& tee ${WORKLOAD_NAME}-${jobset_pod}-jobset.log &
           done
           wait < <(jobs -p)
 

--- a/.github/workflows/_test_nccl.yaml
+++ b/.github/workflows/_test_nccl.yaml
@@ -15,12 +15,9 @@ permissions:
 
 jobs:
   nccl-test-gke:
-    runs-on: gke-a3mega
-    steps:
-      - name: NCCL Test on GKE
-        uses: ./.github/workflows/_test_nccl_gke.yaml
-        with:
-          JAX_IMAGE: ${{ inputs.CONTAINER }}
+    uses: ./.github/workflows/_test_nccl_gke.yaml
+    with:
+      JAX_IMAGE: ${{ inputs.CONTAINER }}
 
   build-mpi-operator-compatible-base:
     runs-on: [self-hosted, "amd64", "large"]

--- a/.github/workflows/_test_nccl.yaml
+++ b/.github/workflows/_test_nccl.yaml
@@ -16,11 +16,11 @@ permissions:
 jobs:
   nccl-test-gke:
     runs-on: gke-a3mega
-  steps:
-    - name: NCCL Test on GKE
-      uses: ./.github/workflows/_test_nccl_gke.yaml
-      with:
-        JAX_IMAGE: ${{ inputs.CONTAINER }}
+    steps:
+      - name: NCCL Test on GKE
+        uses: ./.github/workflows/_test_nccl_gke.yaml
+        with:
+          JAX_IMAGE: ${{ inputs.CONTAINER }}
 
   build-mpi-operator-compatible-base:
     runs-on: [self-hosted, "amd64", "large"]

--- a/.github/workflows/_test_nccl.yaml
+++ b/.github/workflows/_test_nccl.yaml
@@ -14,6 +14,12 @@ permissions:
   packages: write # to upload container
 
 jobs:
+  nccl-test-gke:
+    runs-on: gke-a3mega
+    uses: ./.github/workflows/_test_nccl_gke.yaml
+    with:
+      JAX_IMAGE: ${{ inputs.CONTAINER }}
+
   build-mpi-operator-compatible-base:
     runs-on: [self-hosted, "amd64", "large"]
     steps:
@@ -38,7 +44,6 @@ jobs:
     outputs:
       DOCKER_TAG_MEALKIT: ${{ steps.build.outputs.DOCKER_TAG_MEALKIT }}
       DOCKER_TAG_FINAL:   ${{ steps.build.outputs.DOCKER_TAG_FINAL }}
-
 
   nccl-test:
     needs: build-mpi-operator-compatible-base

--- a/.github/workflows/_test_nccl.yaml
+++ b/.github/workflows/_test_nccl.yaml
@@ -16,9 +16,11 @@ permissions:
 jobs:
   nccl-test-gke:
     runs-on: gke-a3mega
-    uses: ./.github/workflows/_test_nccl_gke.yaml
-    with:
-      JAX_IMAGE: ${{ inputs.CONTAINER }}
+  steps:
+    - name: NCCL Test on GKE
+      uses: ./.github/workflows/_test_nccl_gke.yaml
+      with:
+        JAX_IMAGE: ${{ inputs.CONTAINER }}
 
   build-mpi-operator-compatible-base:
     runs-on: [self-hosted, "amd64", "large"]

--- a/.github/workflows/_test_nccl.yaml
+++ b/.github/workflows/_test_nccl.yaml
@@ -18,6 +18,7 @@ jobs:
     uses: ./.github/workflows/_test_nccl_gke.yaml
     with:
       JAX_IMAGE: ${{ inputs.CONTAINER }}
+    secrets: inherit
 
   build-mpi-operator-compatible-base:
     runs-on: [self-hosted, "amd64", "large"]

--- a/.github/workflows/_test_nccl_gke.yaml
+++ b/.github/workflows/_test_nccl_gke.yaml
@@ -220,7 +220,7 @@ jobs:
       - name: Upload artifacts to GitHub Acions
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ env.WORKLOAD_NAME_PREFIX }}-${{ env.TEST }}
+          name: ${{ env.WORKLOAD_NAME_PREFIX }}-${{ matrix.test }}
           path: output/${{ env.WORKLOAD_NAME }}/*
 
       - name: Clean up GCS artifacts

--- a/.github/workflows/_test_nccl_gke.yaml
+++ b/.github/workflows/_test_nccl_gke.yaml
@@ -106,7 +106,7 @@ jobs:
           "
 
           POSTLUDE="
-              ./google-cloud-sdk/bin/gsutil cp -r /opt/output/ gs://${{ env.GCS_BUCKET }}/${{ env.WORKLOAD_NAME_PREFIX}}/${{ env.DATE }}/${{ env.WORKLOAD_NAME }}/node0\${NODE_RANK};
+              ./google-cloud-sdk/bin/gsutil cp -r /opt/output/ gs://${{ env.GCS_BUCKET }}/${{ env.WORKLOAD_NAME_PREFIX}}/${{ env.DATE }}/${{ env.WORKLOAD_NAME }}/node0\$NODE_RANK;
               exit \$PIPESTATUS
           "
 

--- a/.github/workflows/_test_nccl_gke.yaml
+++ b/.github/workflows/_test_nccl_gke.yaml
@@ -17,42 +17,41 @@ on:
 
 
 jobs:
-#  build-nccl-gke:
-#    runs-on: [self-hosted, "amd64", "large"]
-#    steps:
-#      - uses: actions/checkout@v4
-#      - name: Build NCCL image
-#        id: build
-#        uses: ./.github/actions/build-container
-#        with:
-#          ARCHITECTURE: amd64
-#          ARTIFACT_NAME: artifact-nccl-gke-build
-#          BADGE_FILENAME: badge-nccl-gke-build
-#          BUILD_DATE: 0000-00-00 # not important; this image is never published
-#          BASE_IMAGE: ghcr.io/nvidia/jax-toolbox-internal:15729070690-base-amd64
-#          CONTAINER_NAME: nccl-gke
-#          DOCKERFILE: .github/container/Dockerfile.nccl-gke
-#          RUNNER_SIZE: small
-#          DOCKER_CONTEXT: .
-#          ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
-#          ssh-known-hosts: ${{ vars.SSH_KNOWN_HOSTS }}
-#          github-token: ${{ secrets.GITHUB_TOKEN }}
-#          bazel-remote-cache-url: ${{ vars.BAZEL_REMOTE_CACHE_URL }}
-#    outputs:
-#      DOCKER_TAG_FINAL:   ${{ steps.build.outputs.DOCKER_TAG_FINAL }}
+  build-nccl-gke:
+    runs-on: [self-hosted, "amd64", "large"]
+    steps:
+      - uses: actions/checkout@v4
+      - name: Build NCCL image
+        id: build
+        uses: ./.github/actions/build-container
+        with:
+          ARCHITECTURE: amd64
+          ARTIFACT_NAME: artifact-nccl-gke-build
+          BADGE_FILENAME: badge-nccl-gke-build
+          BUILD_DATE: 0000-00-00 # not important; this image is never published
+          BASE_IMAGE: ${{ inputs.JAX_IMAGE }}
+          CONTAINER_NAME: nccl-gke
+          DOCKERFILE: .github/container/Dockerfile.nccl-gke
+          RUNNER_SIZE: small
+          DOCKER_CONTEXT: .
+          ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
+          ssh-known-hosts: ${{ vars.SSH_KNOWN_HOSTS }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          bazel-remote-cache-url: ${{ vars.BAZEL_REMOTE_CACHE_URL }}
+    outputs:
+      DOCKER_TAG_FINAL:   ${{ steps.build.outputs.DOCKER_TAG_FINAL }}
 
   nccl-gke:
     runs-on: gke-a3mega
 
-#    needs: build-nccl-gke 
+    needs: build-nccl-gke 
 
     strategy:
       matrix:
         test: [all_gather_perf_mpi, all_reduce_perf_mpi, broadcast_perf_mpi, reduce_scatter_perf_mpi]
 
     env:
-#      BASE_IMAGE: ${{ needs.build-nccl-gke.outputs.DOCKER_TAG_FINAL }}
-      BASE_IMAGE: ghcr.io/nvidia/jax-toolbox-internal:15737233011-nccl-gke-amd64
+      BASE_IMAGE: ${{ needs.build-nccl-gke.outputs.DOCKER_TAG_FINAL }}
       TEST_NAME: ${{ matrix.test }}
       WORKLOAD_NAME_PREFIX: nccl-gke
 
@@ -76,7 +75,7 @@ jobs:
           cat .github/gke-workflow/nccl/service.yml | yq '.spec.selector."jobset.sigs.k8s.io/jobset-name" = "'${WORKLOAD_NAME}'"' --yaml-output | tee ${SERVICE_MANIFEST}
           kubectl apply -f ${SERVICE_MANIFEST}
 
-      - name: Launch XPK workload on cluster
+      - name: Run XPK workload on cluster
         uses: ./.github/actions/gke-xpk
         with:
           IMAGE: ${{ env.BASE_IMAGE }}

--- a/.github/workflows/_test_nccl_gke.yaml
+++ b/.github/workflows/_test_nccl_gke.yaml
@@ -185,7 +185,7 @@ jobs:
           jobset_pods=($(kubectl get pods -o json | jq -r '.items[].metadata | select(.labels."jobset.sigs.k8s.io/jobset-name" == "'${WORKLOAD_NAME}'") | .name' | tr '\n' ' '))
 
           for jobset_pod in ${jobset_pods[@]}; do
-              kubectl logs -f --prefix=true --timestamps=true -c gpu-image ${jobset_pod} 2>&1 | tee -a ${WORKLOAD_NAME}-${jobset_pod}-jobset.log &
+              kubectl logs  --pod-running-timeout=1m -f --prefix=true --timestamps=true -c gpu-image ${jobset_pod} 2>&1 | tee -a ${WORKLOAD_NAME}-${jobset_pod}-jobset.log &
           done
           wait < <(jobs -p)
 

--- a/.github/workflows/_test_nccl_gke.yaml
+++ b/.github/workflows/_test_nccl_gke.yaml
@@ -169,6 +169,7 @@ jobs:
           jobset_pods=($(kubectl get pods -o json | jq -r '.items[].metadata | select(.labels."jobset.sigs.k8s.io/jobset-name" == "'${workload_name}'") | .name' | tr '\n' ' '))
           for jobset_pod in $jobset_pods; do
             kubectl logs -f --prefix=true --timestamps=true -c ${main_container_name} ${jobset_pod} |& tee ${workload_name}-${jobset_pod}-jobset.log &
+          done
           wait < <(jobs -p)
 
       - name: Set exit code from JobSet

--- a/.github/workflows/_test_nccl_gke.yaml
+++ b/.github/workflows/_test_nccl_gke.yaml
@@ -167,15 +167,16 @@ jobs:
       - name: Stream logs from JobSet Pods
         run: |
           jobset_pods=($(kubectl get pods -o json | jq -r '.items[].metadata | select(.labels."jobset.sigs.k8s.io/jobset-name" == "'${WORKLOAD_NAME}'") | .name' | tr '\n' ' '))
-          for jobset_pod in $jobset_pods; do
-            kubectl logs -f --prefix=true --timestamps=true -c ${MAIN_CONTAINER_NAME} ${jobset_pod} |& tee ${WORKLOAD_NAME}-${jobset_pod}-jobset.log &
+
+          for jobset_pod in ${jobset_pods[@]}; do
+              kubectl logs -f --prefix=true --timestamps=true -c gpu-image ${jobset_pod} 2>&1 | tee -a ${WORKLOAD_NAME}-${jobset_pod}-jobset.log &
           done
           wait < <(jobs -p)
 
       - name: Set exit code from JobSet
         run: |
-          MAYBE_XPK_EXIT_CODE="$(tail -n 1 ${WORKLOAD_NAME}-${POD}-jobset.log)"
-          echo ${MAYBE_XPK_EXIT_CODE} |  grep -E '^EXIT\_CODE=*'
+          MAYBE_XPK_EXIT_CODE="$(tail -n 1 ${WORKLOAD_NAME}-${POD}jobset.log | awk '{ print $3 }' )"
+          echo ${MAYBE_XPK_EXIT_CODE} | grep -E 'EXIT\_CODE=[0-9]+$'
 
           if [ $? -ne 0 ]; then
             echo "The JobSet ${WORKLOAD_NAME} on ${CLUSTER_NAME} did not complete as expected "

--- a/.github/workflows/_test_nccl_gke.yaml
+++ b/.github/workflows/_test_nccl_gke.yaml
@@ -59,13 +59,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Create NCCL test service
-        run: |
-          SERVICE_MANIFEST=".github/gke-workflow/nccl/service-${WORKLOAD_NAME}-${{ matrix.test }}.yaml"
-          echo "SERVICE_MANIFEST=${SERVICE_MANIFEST}" >> ${GITHUB_ENV}
-          cat .github/gke-workflow/nccl/service.yml | yq '.spec.selector."jobset.sigs.k8s.io/jobset-name" = "'${WORKLOAD_NAME}'"' --yaml-output | tee ${SERVICE_MANIFEST}
-          kubectl apply -f ${SERVICE_MANIFEST}
-
       - name: Set workload name prefix # due to 40 char limit
         id: workload-name
         run: |
@@ -74,7 +67,16 @@ jobs:
 
           echo "WORKLOAD_PREFIX=${WORKLOAD_PREFIX}" >> ${GITHUB_OUTPUT}
 
-      - name: Launch XPK workload 
+      - name: Create NCCL test Services on cluster
+        run: |
+          SERVICE_MANIFEST=".github/gke-workflow/nccl/service-${WORKLOAD_NAME}-${{ matrix.test }}.yaml"
+          WORKLOAD_NAME="${{ steps.workload-name.outputs.WORKLOAD_PREFIX }}-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+          echo "SERVICE_MANIFEST=${SERVICE_MANIFEST}" >> ${GITHUB_ENV}
+
+          cat .github/gke-workflow/nccl/service.yml | yq '.spec.selector."jobset.sigs.k8s.io/jobset-name" = "'${WORKLOAD_NAME}'"' --yaml-output | tee ${SERVICE_MANIFEST}
+          kubectl apply -f ${SERVICE_MANIFEST}
+
+      - name: Launch XPK workload  on cluster
         uses: ./.github/actions/gke-xpk
         with:
           IMAGE: ${{ env.BASE_IMAGE }}
@@ -86,7 +88,7 @@ jobs:
             /scripts/nccl-test-launch.sh ${{ matrix.test }} \${hosts[@]} |&
             tee /opt/output/output.log &> \${console};
 
-      - name: Clean up NCCL test service
+      - name: Clean up NCCL test Services from cluster
         if: ${{ always() }}
         run: |
           kubectl delete -f ${SERVICE_MANIFEST}

--- a/.github/workflows/_test_nccl_gke.yaml
+++ b/.github/workflows/_test_nccl_gke.yaml
@@ -44,7 +44,7 @@ jobs:
   nccl-gke:
     runs-on: gke-a3mega
 
-#    needs: build-nccl-gke
+#    needs: build-nccl-gke 
 
     strategy:
       matrix:
@@ -82,6 +82,7 @@ jobs:
           IMAGE: ${{ env.BASE_IMAGE }}
           WORKLOAD_NAME_PREFIX: ${{ steps.workload-name.outputs.WORKLOAD_PREFIX }}
           COMMAND: |
+            service ssh restart;
             console=/dev/stdout;
             declare -a hosts=('nccl-test-host-1' 'nccl-test-host-2');
 

--- a/.github/workflows/_test_nccl_gke.yaml
+++ b/.github/workflows/_test_nccl_gke.yaml
@@ -90,7 +90,7 @@ jobs:
             tee /opt/output/output.log &> \${console};
 
             apt install ripgrep;
-            MAYBE_MPI_EXIT_CODE=\$(tail /opt/output/output.log | rg 'Exit code:\\\s+([0-9]+)' -or '\$1');
+            MAYBE_MPI_EXIT_CODE=\$(tail /opt/output/output.log | rg 'Exit code:    ([0-9]+)' -or '\$1');
             if [ -z \${MAYBE_MPI_EXIT_CODE} ]; then
               EXIT_CODE=0;
             else

--- a/.github/workflows/_test_nccl_gke.yaml
+++ b/.github/workflows/_test_nccl_gke.yaml
@@ -97,7 +97,7 @@ jobs:
         run: |
           PRELUDE="
               curl -LO https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-cli-linux-x86_64.tar.gz;
-              tar xvf google-cloud-cli-linux-x86_64.tar.gz;
+              tar xf google-cloud-cli-linux-x86_64.tar.gz;
               ./google-cloud-sdk/install.sh --quiet;
               ./google-cloud-sdk/bin/gcloud init;
 
@@ -214,13 +214,14 @@ jobs:
 
       - name: Download artifacts from GCS
         run: |
+          mkdir -p output/${WORKLOAD_NAME}
           gsutil cp -r gs://${GCS_BUCKET}/${WORKLOAD_NAME_PREFIX}/${DATE}/${WORKLOAD_NAME} output/${WORKLOAD_NAME}
 
       - name: Upload artifacts to GitHub Acions
         uses: actions/upload-artifact@v4
         with:
-          name: ${WORKLOAD_NAME_PREFIX}-${TEST}
-          path: output/${WORKLOAD_NAME}/*
+          name: ${{ env.WORKLOAD_NAME_PREFIX }}-${{ env.TEST }}
+          path: output/${{ env.WORKLOAD_NAME }}/*
 
       - name: Clean up GCS artifacts
         if: ${{ always() }}

--- a/.github/workflows/_test_nccl_gke.yaml
+++ b/.github/workflows/_test_nccl_gke.yaml
@@ -81,7 +81,8 @@ jobs:
 
       - name: Set workload name
         run: |
-          echo "WORKLOAD_NAME=${WORKLOAD_NAME_PREFIX}-${{ matrix.test }}-${GITHUB_RUN_ID}-${GITHUB_RUN_NUMBER}-${GITHUB_RUN_ATTEMPT}" >> ${GITHUB_ENV}
+          TEST=$(echo "${{ matrix.test }}" | sed 's/perf_mpi//g')
+          echo "WORKLOAD_NAME=${WORKLOAD_NAME_PREFIX}-${TEST}-${GITHUB_RUN_ID}-${GITHUB_RUN_NUMBER}-${GITHUB_RUN_ATTEMPT}" >> ${GITHUB_ENV}
 
       - name: Create NCCL test service
         run: |

--- a/.github/workflows/_test_nccl_gke.yaml
+++ b/.github/workflows/_test_nccl_gke.yaml
@@ -74,7 +74,6 @@ jobs:
           IMAGE: ${{ env.BASE_IMAGE }}
           WORKLOAD_NAME_PREFIX: ${{ steps.workload-name.outputs.WORKLOAD_PREFIX }}
           COMMAND: |
-            unset NCCL_NET_PLUGIN;
             service ssh restart;
             console=/dev/stdout;
             declare -a hosts=('nccl-test-host-1' 'nccl-test-host-2');
@@ -82,7 +81,6 @@ jobs:
             /scripts/nccl-test-launch.sh ${{ matrix.test }} \${hosts[@]} |&
             tee /opt/output/output.log &> \${console};
 
-            apt install ripgrep;
             MAYBE_MPI_EXIT_CODE=\$(tail /opt/output/output.log | rg 'Exit code:[ ]+([0-9]+)' -or '\$1');
             if [ -z \${MAYBE_MPI_EXIT_CODE} ]; then
               EXIT_CODE=0;

--- a/.github/workflows/_test_nccl_gke.yaml
+++ b/.github/workflows/_test_nccl_gke.yaml
@@ -95,7 +95,7 @@ jobs:
               EXIT_CODE=0;
             else
               EXIT_CODE=\${MAYBE_MPI_EXIT_CODE};
-            fi
+            fi;
 
       - name: Clean up NCCL test Services from cluster
         if: ${{ always() }}

--- a/.github/workflows/_test_nccl_gke.yaml
+++ b/.github/workflows/_test_nccl_gke.yaml
@@ -1,12 +1,6 @@
 name: ~Test NCCL Kubernetes (GKE)
 
 on:
-  pull_request:
-    types:
-      - opened
-      - reopened
-      - ready_for_review
-      - synchronize
   workflow_call:
     inputs:
       JAX_IMAGE:
@@ -14,7 +8,6 @@ on:
         description: JAX image from ghcr.io/nvidia
         default: ghcr.io/nvidia/jax-toolbox-internal:15729070690-base-amd64
         required: false
-
 
 jobs:
   build-nccl-gke:

--- a/.github/workflows/_test_nccl_gke.yaml
+++ b/.github/workflows/_test_nccl_gke.yaml
@@ -168,7 +168,7 @@ jobs:
         run: |
           jobset_pods=($(kubectl get pods -o json | jq -r '.items[].metadata | select(.labels."jobset.sigs.k8s.io/jobset-name" == "'${WORKLOAD_NAME}'") | .name' | tr '\n' ' '))
           for jobset_pod in $jobset_pods; do
-            kubectl logs -f --prefix=true --timestamps=true -c ${main_container_name} ${jobset_pod} |& tee ${WORKLOAD_NAME}-${jobset_pod}-jobset.log &
+            kubectl logs -f --prefix=true --timestamps=true -c ${MAIN_CONTAINER_NAME} ${jobset_pod} |& tee ${WORKLOAD_NAME}-${jobset_pod}-jobset.log &
           done
           wait < <(jobs -p)
 

--- a/.github/workflows/_test_nccl_gke.yaml
+++ b/.github/workflows/_test_nccl_gke.yaml
@@ -90,7 +90,7 @@ jobs:
             tee /opt/output/output.log &> \${console};
 
             apt install ripgrep;
-            MAYBE_MPI_EXIT_CODE=\$(tail /opt/output/output.log | rg 'Exit code:\\W+([0-9]+)' -or '\$1');
+            MAYBE_MPI_EXIT_CODE=\$(tail /opt/output/output.log | rg 'Exit code:\\s+([0-9]+)' -or '\$1');
             if [ -z \${MAYBE_MPI_EXIT_CODE} ]; then
               EXIT_CODE=0;
             else

--- a/.github/workflows/_test_nccl_gke.yaml
+++ b/.github/workflows/_test_nccl_gke.yaml
@@ -90,7 +90,7 @@ jobs:
             tee /opt/output/output.log &> \${console};
 
             apt install ripgrep;
-            MAYBE_MPI_EXIT_CODE=\$(tail /opt/output/output.log | rg 'Exit code:\W+([0-9]+)' -or '\$1');
+            MAYBE_MPI_EXIT_CODE=\$(tail /opt/output/output.log | rg 'Exit code:\\W+([0-9]+)' -or '\$1');
             if [ -z \${MAYBE_MPI_EXIT_CODE} ]; then
               EXIT_CODE=0;
             else

--- a/.github/workflows/_test_nccl_gke.yaml
+++ b/.github/workflows/_test_nccl_gke.yaml
@@ -29,7 +29,7 @@ jobs:
           ARTIFACT_NAME: artifact-nccl-gke-build
           BADGE_FILENAME: badge-nccl-gke-build
           BUILD_DATE: 0000-00-00 # not important; this image is never published
-          BASE_IMAGE: ${{ inputs.JAX_IMAGE }}
+          BASE_IMAGE: ghcr.io/nvidia/jax-toolbox-internal:15729070690-base-amd64
           CONTAINER_NAME: nccl-gke
           DOCKERFILE: .github/container/Dockerfile.nccl-gke
           RUNNER_SIZE: small

--- a/.github/workflows/_test_nccl_gke.yaml
+++ b/.github/workflows/_test_nccl_gke.yaml
@@ -83,6 +83,7 @@ jobs:
         run: |
           TEST=$(echo "${{ matrix.test }}" | sed 's/perf_mpi//g')
           echo "WORKLOAD_NAME=${WORKLOAD_NAME_PREFIX}-${TEST}-${GITHUB_RUN_ID}-${GITHUB_RUN_NUMBER}-${GITHUB_RUN_ATTEMPT}" >> ${GITHUB_ENV}
+          echo "DATE=$(date +'%Y-%m-%d')" >> ${GITHUB_ENV}
 
       - name: Create NCCL test service
         run: |
@@ -93,11 +94,24 @@ jobs:
 
       - name: Create NCCL test workload
         run: |
-          CMD="
+          PRELUDE="
+              curl -LO https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-cli-linux-x86_64.tar.gz;
+              tar xvf google-cloud-cli-linux-x86_64.tar.gz;
+              ./google-cloud-sdk/install.sh --quiet;
+              ./google-cloud-sdk/bin/gcloud init;
+              source \$HOME/.bashrc;
+
               mkdir -p /usr/share/workload;
               mkdir -p /opt/output;
+          "
 
-              service ssh start;
+          POSTLUDE="
+              \$HOME/google-cloud-sdk/bin/gsutil cp -r /opt/output/ ${{ env.WORKLOAD_NAME_PREFIX}}/${{ env.DATE }}/${{ env.WORKLOAD_NAME }}-node0\${NODE_RANK};
+              exit \$PIPESTATUS
+          "
+
+          CMD="
+              service ssh restart;
               unset NCCL_NET_PLUGIN;
 
               console=/dev/stdout;
@@ -105,10 +119,11 @@ jobs:
 
               /scripts/nccl-test-launch.sh ${{ matrix.test }} \${hosts[@]} |&
               tee /opt/output/output.log &> \${console};
-              exit \$PIPESTATUS
           "
 
-          # set container command in-line
+          # set container commands in-line
+          PRELUDE=$(echo ${PRELUDE} | sed 's/\n/\ /g')
+          POSTLUDE=$(echo ${POSTLUDE} | sed 's/\n/\ /g')
           CMD=$(echo ${CMD} | sed 's/\n/\ /g')
 
           cd ${HOME}/xpk
@@ -123,7 +138,7 @@ jobs:
                         --num-slices ${NUM_NODES} \
                         --priority=high \
                         --scheduler=gke.io/topology-aware-auto \
-                        --command "${CMD}"
+                        --command "${PRELUDE} ${CMD} ${POSTLUDE}"
 
       - name: Wait for JobSet to unsuspend
         env:
@@ -196,3 +211,4 @@ jobs:
         if: ${{ always() }}
         run: |
           kubectl delete -f ${SERVICE_MANIFEST}
+

--- a/.github/workflows/_test_nccl_gke.yaml
+++ b/.github/workflows/_test_nccl_gke.yaml
@@ -51,6 +51,7 @@ jobs:
       DEVICE_TYPE: h100-mega-80gb-8
       NUM_NODES: 2
       MAIN_CONTAINER_NAME: gpu-image
+      GCS_BUCKET: jaxtoolbox-ci
 
     steps:
       - uses: actions/checkout@v4
@@ -106,7 +107,7 @@ jobs:
           "
 
           POSTLUDE="
-              \$HOME/google-cloud-sdk/bin/gsutil cp -r /opt/output/ ${{ env.WORKLOAD_NAME_PREFIX}}/${{ env.DATE }}/${{ env.WORKLOAD_NAME }}-node0\${NODE_RANK};
+              \$HOME/google-cloud-sdk/bin/gsutil cp -r /opt/output/ gs://${{ env.GCS_BUCKET }}/${{ env.WORKLOAD_NAME_PREFIX}}/${{ env.DATE }}/${{ env.WORKLOAD_NAME }}/node0\${NODE_RANK};
               exit \$PIPESTATUS
           "
 
@@ -212,3 +213,17 @@ jobs:
         run: |
           kubectl delete -f ${SERVICE_MANIFEST}
 
+      - name: Download artifacts from GCS
+        run: |
+          gsutil cp -r gs://${GCS_BUCKET}/${WORKLOAD_NAME_PREFIX}/${DATE}/${WORKLOAD_NAME} output/${WORKLOAD_NAME}
+
+      - name: Upload artifacts to GitHub Acions
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${WORKLOAD_NAME_PREFIX}-${TEST}
+          path: output/${WORKLOAD_NAME}/*
+
+      - name: Clean up GCS artifacts
+        if: ${{ always() }}
+        run: |
+          rm -rf output/${WORKLOAD_NAME}

--- a/.github/workflows/_test_nccl_gke.yaml
+++ b/.github/workflows/_test_nccl_gke.yaml
@@ -81,7 +81,7 @@ jobs:
 
       - name: Set workload name
         run: |
-          echo "WORKLOAD_NAME=${WORKLOAD_NAME_PREFIX}-${GITHUB_RUN_ID}-${GITHUB_RUN_NUMBER}-${GITHUB_RUN_ATTEMPT}" >> ${GITHUB_ENV}
+          echo "WORKLOAD_NAME=${WORKLOAD_NAME_PREFIX}-${{ matrix.test }}-${GITHUB_RUN_ID}-${GITHUB_RUN_NUMBER}-${GITHUB_RUN_ATTEMPT}" >> ${GITHUB_ENV}
 
       - name: Create NCCL test service
         run: |

--- a/.github/workflows/_test_nccl_gke.yaml
+++ b/.github/workflows/_test_nccl_gke.yaml
@@ -17,41 +17,42 @@ on:
 
 
 jobs:
-  build-nccl-gke:
-    runs-on: [self-hosted, "amd64", "large"]
-    steps:
-      - uses: actions/checkout@v4
-      - name: Build NCCL image
-        id: build
-        uses: ./.github/actions/build-container
-        with:
-          ARCHITECTURE: amd64
-          ARTIFACT_NAME: artifact-nccl-gke-build
-          BADGE_FILENAME: badge-nccl-gke-build
-          BUILD_DATE: 0000-00-00 # not important; this image is never published
-          BASE_IMAGE: ghcr.io/nvidia/jax-toolbox-internal:15729070690-base-amd64
-          CONTAINER_NAME: nccl-gke
-          DOCKERFILE: .github/container/Dockerfile.nccl-gke
-          RUNNER_SIZE: small
-          DOCKER_CONTEXT: .
-          ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
-          ssh-known-hosts: ${{ vars.SSH_KNOWN_HOSTS }}
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          bazel-remote-cache-url: ${{ vars.BAZEL_REMOTE_CACHE_URL }}
-    outputs:
-      DOCKER_TAG_FINAL:   ${{ steps.build.outputs.DOCKER_TAG_FINAL }}
+#  build-nccl-gke:
+#    runs-on: [self-hosted, "amd64", "large"]
+#    steps:
+#      - uses: actions/checkout@v4
+#      - name: Build NCCL image
+#        id: build
+#        uses: ./.github/actions/build-container
+#        with:
+#          ARCHITECTURE: amd64
+#          ARTIFACT_NAME: artifact-nccl-gke-build
+#          BADGE_FILENAME: badge-nccl-gke-build
+#          BUILD_DATE: 0000-00-00 # not important; this image is never published
+#          BASE_IMAGE: ghcr.io/nvidia/jax-toolbox-internal:15729070690-base-amd64
+#          CONTAINER_NAME: nccl-gke
+#          DOCKERFILE: .github/container/Dockerfile.nccl-gke
+#          RUNNER_SIZE: small
+#          DOCKER_CONTEXT: .
+#          ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
+#          ssh-known-hosts: ${{ vars.SSH_KNOWN_HOSTS }}
+#          github-token: ${{ secrets.GITHUB_TOKEN }}
+#          bazel-remote-cache-url: ${{ vars.BAZEL_REMOTE_CACHE_URL }}
+#    outputs:
+#      DOCKER_TAG_FINAL:   ${{ steps.build.outputs.DOCKER_TAG_FINAL }}
 
   nccl-gke:
     runs-on: gke-a3mega
 
-    needs: build-nccl-gke
+#    needs: build-nccl-gke
 
     strategy:
       matrix:
         test: [all_gather_perf_mpi, all_reduce_perf_mpi, broadcast_perf_mpi, reduce_scatter_perf_mpi]
 
     env:
-      BASE_IMAGE: ${{ needs.build-nccl-gke.outputs.DOCKER_TAG_FINAL }}
+#      BASE_IMAGE: ${{ needs.build-nccl-gke.outputs.DOCKER_TAG_FINAL }}
+      BASE_IMAGE: ghcr.io/nvidia/jax-toolbox-internal:15737233011-nccl-gke-amd64
       TEST_NAME: ${{ matrix.test }}
       WORKLOAD_NAME_PREFIX: nccl-gke
 

--- a/.github/workflows/_test_nccl_gke.yaml
+++ b/.github/workflows/_test_nccl_gke.yaml
@@ -106,7 +106,7 @@ jobs:
           "
 
           POSTLUDE="
-              ./google-cloud-sdk/bin/gsutil cp -r /opt/output/ gs://${{ env.GCS_BUCKET }}/${{ env.WORKLOAD_NAME_PREFIX}}/${{ env.DATE }}/${{ env.WORKLOAD_NAME }}/node0\$NODE_RANK;
+              ./google-cloud-sdk/bin/gsutil cp -r /opt/output/ gs://${GCS_BUCKET}/${WORKLOAD_NAME_PREFIX}/${DATE}/${WORKLOAD_NAME}/node0\$NODE_RANK;
               exit \$PIPESTATUS
           "
 

--- a/.github/workflows/_test_nccl_gke.yaml
+++ b/.github/workflows/_test_nccl_gke.yaml
@@ -89,6 +89,14 @@ jobs:
             /scripts/nccl-test-launch.sh ${{ matrix.test }} \${hosts[@]} |&
             tee /opt/output/output.log &> \${console};
 
+            apt install ripgrep;
+            MAYBE_MPI_EXIT_CODE=\$(tail /opt/output/output.log | rg 'Exit code:\W+([0-9]+)' -or '$1');
+            if [ -z \${MAYBE_MPI_EXIT_CODE} ]; then
+              EXIT_CODE=0;
+            else
+              EXIT_CODE=\${MAYBE_MPI_EXIT_CODE};
+            fi
+
       - name: Clean up NCCL test Services from cluster
         if: ${{ always() }}
         run: |

--- a/.github/workflows/_test_nccl_gke.yaml
+++ b/.github/workflows/_test_nccl_gke.yaml
@@ -100,14 +100,13 @@ jobs:
               tar xvf google-cloud-cli-linux-x86_64.tar.gz;
               ./google-cloud-sdk/install.sh --quiet;
               ./google-cloud-sdk/bin/gcloud init;
-              source \$HOME/.bashrc;
 
               mkdir -p /usr/share/workload;
               mkdir -p /opt/output;
           "
 
           POSTLUDE="
-              \$HOME/google-cloud-sdk/bin/gsutil cp -r /opt/output/ gs://${{ env.GCS_BUCKET }}/${{ env.WORKLOAD_NAME_PREFIX}}/${{ env.DATE }}/${{ env.WORKLOAD_NAME }}/node0\${NODE_RANK};
+              ./google-cloud-sdk/bin/gsutil cp -r /opt/output/ gs://${{ env.GCS_BUCKET }}/${{ env.WORKLOAD_NAME_PREFIX}}/${{ env.DATE }}/${{ env.WORKLOAD_NAME }}/node0\${NODE_RANK};
               exit \$PIPESTATUS
           "
 

--- a/.github/workflows/_test_nccl_gke.yaml
+++ b/.github/workflows/_test_nccl_gke.yaml
@@ -76,7 +76,7 @@ jobs:
           cat .github/gke-workflow/nccl/service.yml | yq '.spec.selector."jobset.sigs.k8s.io/jobset-name" = "'${WORKLOAD_NAME}'"' --yaml-output | tee ${SERVICE_MANIFEST}
           kubectl apply -f ${SERVICE_MANIFEST}
 
-      - name: Launch XPK workload  on cluster
+      - name: Launch XPK workload on cluster
         uses: ./.github/actions/gke-xpk
         with:
           IMAGE: ${{ env.BASE_IMAGE }}

--- a/.github/workflows/_test_nccl_gke.yaml
+++ b/.github/workflows/_test_nccl_gke.yaml
@@ -164,11 +164,12 @@ jobs:
             POD_READY=$(kubectl get pod ${POD} -o json | jq -r '.status.containerStatuses[]? | select(.name == "'${MAIN_CONTAINER_NAME}'").ready')
           done;
 
-      - name: Stream logs from JobSet
+      - name: Stream logs from JobSet Pods
         run: |
-          # stream gpu-image container logs from first (coordinator) pod in jobset
-          echo "Pod ${POD} in JobSet ${WORKLOAD_NAME} has become ready. Streaming logs..."
-          kubectl logs -f -c ${MAIN_CONTAINER_NAME} ${POD} |& tee ${WORKLOAD_NAME}-jobset.log
+          jobset_pods=($(kubectl get pods -o json | jq -r '.items[].metadata | select(.labels."jobset.sigs.k8s.io/jobset-name" == "'${workload_name}'") | .name' | tr '\n' ' '))
+          for jobset_pod in $jobset_pods; do
+            kubectl logs -f --prefix=true --timestamps=true -c ${main_container_name} ${jobset_pod} |& tee ${workload_name}-${jobset_pod}-jobset.log &
+          wait < <(jobs -p)
 
       - name: Set exit code from JobSet
         run: |

--- a/.github/workflows/_test_nccl_gke.yaml
+++ b/.github/workflows/_test_nccl_gke.yaml
@@ -175,7 +175,7 @@ jobs:
 
       - name: Set exit code from JobSet
         run: |
-          MAYBE_XPK_EXIT_CODE="$(tail -n 1 ${WORKLOAD_NAME}-${POD}jobset.log | awk '{ print $3 }' )"
+          MAYBE_XPK_EXIT_CODE="$(tail -n 1 ${WORKLOAD_NAME}-${POD}-jobset.log | awk '{ print $3 }' )"
           echo ${MAYBE_XPK_EXIT_CODE} | grep -E 'EXIT\_CODE=[0-9]+$'
 
           if [ $? -ne 0 ]; then

--- a/.github/workflows/_test_nccl_gke.yaml
+++ b/.github/workflows/_test_nccl_gke.yaml
@@ -82,6 +82,7 @@ jobs:
           IMAGE: ${{ env.BASE_IMAGE }}
           WORKLOAD_NAME_PREFIX: ${{ steps.workload-name.outputs.WORKLOAD_PREFIX }}
           COMMAND: |
+            unset NCCL_NET_PLUGIN;
             service ssh restart;
             console=/dev/stdout;
             declare -a hosts=('nccl-test-host-1' 'nccl-test-host-2');

--- a/.github/workflows/_test_nccl_gke.yaml
+++ b/.github/workflows/_test_nccl_gke.yaml
@@ -106,6 +106,7 @@ jobs:
           "
 
           POSTLUDE="
+              ./google-cloud-sdk/bin/gsutil cp -r /opt/output/ gs://${GCS_BUCKET}/${WORKLOAD_NAME_PREFIX}/${DATE}/${WORKLOAD_NAME}/node0\$NODE_RANK;
               exit \$PIPESTATUS
           "
 

--- a/.github/workflows/_test_nccl_gke.yaml
+++ b/.github/workflows/_test_nccl_gke.yaml
@@ -90,7 +90,7 @@ jobs:
             tee /opt/output/output.log &> \${console};
 
             apt install ripgrep;
-            MAYBE_MPI_EXIT_CODE=\$(tail /opt/output/output.log | rg 'Exit code:\W+([0-9]+)' -or '$1');
+            MAYBE_MPI_EXIT_CODE=\$(tail /opt/output/output.log | rg 'Exit code:\W+([0-9]+)' -or '\$1');
             if [ -z \${MAYBE_MPI_EXIT_CODE} ]; then
               EXIT_CODE=0;
             else

--- a/.github/workflows/_test_nccl_gke.yaml
+++ b/.github/workflows/_test_nccl_gke.yaml
@@ -106,7 +106,6 @@ jobs:
           "
 
           POSTLUDE="
-              ./google-cloud-sdk/bin/gsutil cp -r /opt/output/ gs://${GCS_BUCKET}/${WORKLOAD_NAME_PREFIX}/${DATE}/${WORKLOAD_NAME}/node0\$NODE_RANK;
               exit \$PIPESTATUS
           "
 

--- a/.github/workflows/_test_nccl_gke.yaml
+++ b/.github/workflows/_test_nccl_gke.yaml
@@ -1,12 +1,14 @@
 name: ~Test NCCL Kubernetes (GKE)
 
 on:
-  pull_request:
-    types:
-      - opened
-      - reopened
-      - ready_for_review
-      - synchronize
+  workflow_call:
+    inputs:
+      JAX_IMAGE:
+        type: string
+        description: JAX image from ghcr.io/nvidia
+        default: ghcr.io/nvidia/jax:latest
+        required: false
+
 
 jobs:
   build-nccl-gke:
@@ -21,7 +23,7 @@ jobs:
           ARTIFACT_NAME: artifact-nccl-gke-build
           BADGE_FILENAME: badge-nccl-gke-build
           BUILD_DATE: 0000-00-00 # not important; this image is never published
-          BASE_IMAGE: ghcr.io/nvidia/jax-toolbox-internal:15517097053-base-amd64
+          BASE_IMAGE: ${{ inputs.JAX_IMAGE }}
           CONTAINER_NAME: nccl-gke
           DOCKERFILE: .github/container/Dockerfile.nccl-gke
           RUNNER_SIZE: small
@@ -45,7 +47,7 @@ jobs:
     env:
       BASE_IMAGE: ${{ needs.build-mpi-operator-compatible-base.outputs.DOCKER_TAG_FINAL }}
       TEST_NAME: ${{ matrix.test }}
-      WORKLOAD_NAME_PREFIX: nccl-test
+      WORKLOAD_NAME_PREFIX: nccl-gke
       CLUSTER_NAME: jtb-2025-06-12
       ZONE: us-central1-a
       DEVICE_TYPE: h100-mega-80gb-8

--- a/.github/workflows/_test_nccl_gke.yaml
+++ b/.github/workflows/_test_nccl_gke.yaml
@@ -72,7 +72,7 @@ jobs:
           TEST_NAME=$(echo "${{ matrix.test }}" | sed 's/_perf_mpi//g' | sed 's/_/-/g')
           WORKLOAD_PREFIX="${{ env.WORKLOAD_NAME_PREFIX }}-${TEST_NAME}"
 
-          echo "WORKLOAD_PREFIX=${WORKLOAD_PREFIX}"
+          echo "WORKLOAD_PREFIX=${WORKLOAD_PREFIX}" >> ${GITHUB_OUTPUT}
 
       - name: Launch XPK workload 
         uses: ./.github/actions/gke-xpk

--- a/.github/workflows/_test_nccl_gke.yaml
+++ b/.github/workflows/_test_nccl_gke.yaml
@@ -166,15 +166,15 @@ jobs:
 
       - name: Stream logs from JobSet Pods
         run: |
-          jobset_pods=($(kubectl get pods -o json | jq -r '.items[].metadata | select(.labels."jobset.sigs.k8s.io/jobset-name" == "'${workload_name}'") | .name' | tr '\n' ' '))
+          jobset_pods=($(kubectl get pods -o json | jq -r '.items[].metadata | select(.labels."jobset.sigs.k8s.io/jobset-name" == "'${WORKLOAD_NAME}'") | .name' | tr '\n' ' '))
           for jobset_pod in $jobset_pods; do
-            kubectl logs -f --prefix=true --timestamps=true -c ${main_container_name} ${jobset_pod} |& tee ${workload_name}-${jobset_pod}-jobset.log &
+            kubectl logs -f --prefix=true --timestamps=true -c ${main_container_name} ${jobset_pod} |& tee ${WORKLOAD_NAME}-${jobset_pod}-jobset.log &
           done
           wait < <(jobs -p)
 
       - name: Set exit code from JobSet
         run: |
-          MAYBE_XPK_EXIT_CODE="$(tail -n 1 ${WORKLOAD_NAME}-jobset.log)"
+          MAYBE_XPK_EXIT_CODE="$(tail -n 1 ${WORKLOAD_NAME}-${POD}-jobset.log)"
           echo ${MAYBE_XPK_EXIT_CODE} |  grep -E '^EXIT\_CODE=*'
 
           if [ $? -ne 0 ]; then

--- a/.github/workflows/_test_nccl_gke.yaml
+++ b/.github/workflows/_test_nccl_gke.yaml
@@ -1,12 +1,18 @@
 name: ~Test NCCL Kubernetes (GKE)
 
 on:
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - ready_for_review
+      - synchronize
   workflow_call:
     inputs:
       JAX_IMAGE:
         type: string
         description: JAX image from ghcr.io/nvidia
-        default: ghcr.io/nvidia/jax:latest
+        default: ghcr.io/nvidia/jax-toolbox-internal:15729070690-base-amd64
         required: false
 
 
@@ -45,48 +51,12 @@ jobs:
         test: [all_gather_perf_mpi, all_reduce_perf_mpi, broadcast_perf_mpi, reduce_scatter_perf_mpi]
 
     env:
-      BASE_IMAGE: ${{ needs.build-mpi-operator-compatible-base.outputs.DOCKER_TAG_FINAL }}
+      BASE_IMAGE: ${{ needs.build-nccl-gke.outputs.DOCKER_TAG_FINAL }}
       TEST_NAME: ${{ matrix.test }}
       WORKLOAD_NAME_PREFIX: nccl-gke
-      CLUSTER_NAME: jtb-2025-06-12
-      ZONE: us-central1-a
-      DEVICE_TYPE: h100-mega-80gb-8
-      NUM_NODES: 2
-      MAIN_CONTAINER_NAME: gpu-image
-      GCS_BUCKET: jaxtoolbox-ci
 
     steps:
       - uses: actions/checkout@v4
-
-      - name: Show environment
-        run: |
-          set -x
-
-          gcloud version
-
-          source $HOME/.venv/bin/activate
-          python --version
-          xpk version
-
-      - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3
-        with:
-          registry: ghcr.io
-          username: ${{ github.repository_owner }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Apply xpk workload create patch
-        run: |
-          cd ${HOME}/xpk && git checkout src/xpk && cd -
-          git apply --unsafe-paths .github/gke-workflow/xpk/tcpxo_decorator.patch --directory ${HOME}/xpk
-          git apply --unsafe-paths .github/gke-workflow/xpk/docker_resources.patch --directory ${HOME}/xpk
-          git apply --unsafe-paths .github/gke-workflow/xpk/workload.patch --directory ${HOME}/xpk
-
-      - name: Set workload name
-        run: |
-          TEST=$(echo "${{ matrix.test }}" | sed 's/_perf_mpi//g' | sed 's/_/-/g')
-          echo "WORKLOAD_NAME=${WORKLOAD_NAME_PREFIX}-${TEST}-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}" >> ${GITHUB_ENV}
-          echo "DATE=$(date +'%Y-%m-%d')" >> ${GITHUB_ENV}
 
       - name: Create NCCL test service
         run: |
@@ -95,137 +65,28 @@ jobs:
           cat .github/gke-workflow/nccl/service.yml | yq '.spec.selector."jobset.sigs.k8s.io/jobset-name" = "'${WORKLOAD_NAME}'"' --yaml-output | tee ${SERVICE_MANIFEST}
           kubectl apply -f ${SERVICE_MANIFEST}
 
-      - name: Create NCCL test workload
+      - name: Set workload name prefix # due to 40 char limit
+        id: workload-name
         run: |
-          PRELUDE="
-              curl -LO https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-cli-linux-x86_64.tar.gz;
-              tar xf google-cloud-cli-linux-x86_64.tar.gz;
-              ./google-cloud-sdk/install.sh --quiet;
-              ./google-cloud-sdk/bin/gcloud init;
+          TEST_NAME=$(echo "${{ matrix.test }}" | sed 's/_perf_mpi//g' | sed 's/_/-/g')
+          WORKLOAD_PREFIX="${{ env.WORKLOAD_NAME_PREFIX }}-${TEST_NAME}"
 
-              mkdir -p /usr/share/workload;
-              mkdir -p /opt/output;
-          "
+          echo "WORKLOAD_PREFIX=${WORKLOAD_PREFIX}"
 
-          POSTLUDE="
-              ./google-cloud-sdk/bin/gsutil cp -r /opt/output/ gs://${GCS_BUCKET}/${WORKLOAD_NAME_PREFIX}/${DATE}/${WORKLOAD_NAME}/node0\$NODE_RANK;
-              exit \$PIPESTATUS
-          "
+      - name: Launch XPK workload 
+        uses: ./.github/actions/gke-xpk
+        with:
+          IMAGE: ${{ env.BASE_IMAGE }}
+          WORKLOAD_NAME_PREFIX: ${{ steps.workload-name.outputs.WORKLOAD_PREFIX }}
+          COMMAND: |
+            console=/dev/stdout;
+            declare -a hosts=('nccl-test-host-1' 'nccl-test-host-2');
 
-          CMD="
-              service ssh restart;
-              unset NCCL_NET_PLUGIN;
-
-              console=/dev/stdout;
-              declare -a hosts=('nccl-test-host-1' 'nccl-test-host-2');
-
-              /scripts/nccl-test-launch.sh ${{ matrix.test }} \${hosts[@]} |&
-              tee /opt/output/output.log &> \${console};
-          "
-
-          # set container commands in-line
-          PRELUDE=$(echo ${PRELUDE} | sed 's/\n/\ /g')
-          POSTLUDE=$(echo ${POSTLUDE} | sed 's/\n/\ /g')
-          CMD=$(echo ${CMD} | sed 's/\n/\ /g')
-
-          cd ${HOME}/xpk
-          source ${HOME}/.venv/bin/activate
-          python xpk.py workload create \
-                        --cluster ${CLUSTER_NAME} \
-                        --zone ${ZONE} \
-                        --workload ${WORKLOAD_NAME} \
-                        --docker-image ${{ needs.build-nccl-gke.outputs.DOCKER_TAG_FINAL }} \
-                        --device-type ${DEVICE_TYPE} \
-                        --num-nodes ${NUM_NODES} \
-                        --num-slices ${NUM_NODES} \
-                        --priority=high \
-                        --scheduler=gke.io/topology-aware-auto \
-                        --command "${PRELUDE} ${CMD} ${POSTLUDE}"
-
-      - name: Wait for JobSet to unsuspend
-        env:
-          POLL_TIMEOUT: 3600
-        run: |
-          START=$(date +%s)
-          JOBSET_ACTIVE=false
-          while ! ${JOBSET_ACTIVE}  || [ -z ${JOBSET_ACTIVE} ]; do
-            JOBSET_ACTIVE=$(kubectl get jobset -o json | jq -r '.items[] | select(.metadata.name == "'${WORKLOAD_NAME}'").status.replicatedJobsStatus[0] | .active == 1')
-            NOW=$(date +%s)
-            ELAPSED=$(( NOW - START ))
-            if (( ELAPSED > POLL_TIMEOUT )) ; then
-              echo "Timeout after waiting for JobSet ${WORKLOAD_NAME} to become active in cluster ${CLUSTER_NAME}"
-              exit 1
-            fi
-            echo "Waiting for JobSet ${WORKLOAD_NAME} to become active in cluster ${CLUSTER_NAME}"
-            sleep 5
-          done
-
-          echo "JobSet ${WORKLOAD_NAME} has just become active in cluster ${CLUSTER_NAME}"
-
-      - name: Set Pod name
-        run: |
-          echo "POD=$(kubectl get pods -o json | jq -r '.items[] | select(.metadata.labels."'jobset.sigs.k8s.io/jobset-name'" == "'${WORKLOAD_NAME}'") | .metadata.name ' | sort | head -n1 )" >> ${GITHUB_ENV}
-
-      - name: Wait for Pod readiness
-        run: |
-          POD_READY=false
-          while ! ${POD_READY}  || [ -z ${POD_READY} ]; do
-            echo "Waiting for pod ${POD} in JobSet ${WORKLOAD_NAME} to become ready"
-            sleep 10
-
-            POD_ERROR=$(kubectl get pod ${POD} -o json | jq -r '.status.containerStatuses[]? | select(.name == "'${MAIN_CONTAINER_NAME}'") | .state | ( has("terminated") and (.terminated.reason == "Error" ))')
-            if ${POD_ERROR} ; then
-              echo "There was an issue starting the JobSet ${WORKLOAD_NAME} on ${CLUSTER_NAME}"
-              break
-            fi
-
-            POD_READY=$(kubectl get pod ${POD} -o json | jq -r '.status.containerStatuses[]? | select(.name == "'${MAIN_CONTAINER_NAME}'").ready')
-          done;
-
-      - name: Stream logs from JobSet Pods
-        run: |
-          jobset_pods=($(kubectl get pods -o json | jq -r '.items[].metadata | select(.labels."jobset.sigs.k8s.io/jobset-name" == "'${WORKLOAD_NAME}'") | .name' | tr '\n' ' '))
-
-          for jobset_pod in ${jobset_pods[@]}; do
-              kubectl logs  --pod-running-timeout=1m -f --prefix=true --timestamps=true -c gpu-image ${jobset_pod} 2>&1 | tee -a ${WORKLOAD_NAME}-${jobset_pod}-jobset.log &
-          done
-          wait < <(jobs -p)
-
-      - name: Set exit code from JobSet
-        run: |
-          MAYBE_XPK_EXIT_CODE="$(tail -n 1 ${WORKLOAD_NAME}-${POD}-jobset.log | awk '{ print $3 }' )"
-          echo ${MAYBE_XPK_EXIT_CODE} | grep -E 'EXIT\_CODE=[0-9]+$'
-
-          if [ $? -ne 0 ]; then
-            echo "The JobSet ${WORKLOAD_NAME} on ${CLUSTER_NAME} did not complete as expected "
-            exit 1
-          fi
-
-          eval "export ${MAYBE_XPK_EXIT_CODE}"
-          exit ${EXIT_CODE}
-
-      - name: Clean up JobSet
-        if: ${{ always() }}
-        run: |
-          kubectl delete jobset --wait ${WORKLOAD_NAME} || echo "JobSet ${WORKLOAD_NAME} does not exist in ${CLUSTER_NAME}"
+            /scripts/nccl-test-launch.sh ${{ matrix.test }} \${hosts[@]} |&
+            tee /opt/output/output.log &> \${console};
 
       - name: Clean up NCCL test service
         if: ${{ always() }}
         run: |
           kubectl delete -f ${SERVICE_MANIFEST}
 
-      - name: Download artifacts from GCS
-        run: |
-          mkdir -p output/${WORKLOAD_NAME}
-          gsutil cp -r gs://${GCS_BUCKET}/${WORKLOAD_NAME_PREFIX}/${DATE}/${WORKLOAD_NAME} output/${WORKLOAD_NAME}
-
-      - name: Upload artifacts to GitHub Acions
-        uses: actions/upload-artifact@v4
-        with:
-          name: ${{ env.WORKLOAD_NAME_PREFIX }}-${{ matrix.test }}
-          path: output/${{ env.WORKLOAD_NAME }}/*
-
-      - name: Clean up GCS artifacts
-        if: ${{ always() }}
-        run: |
-          rm -rf output/${WORKLOAD_NAME}

--- a/.github/workflows/_test_nccl_gke.yaml
+++ b/.github/workflows/_test_nccl_gke.yaml
@@ -47,6 +47,11 @@ jobs:
       BASE_IMAGE: ${{ needs.build-nccl-gke.outputs.DOCKER_TAG_FINAL }}
       TEST_NAME: ${{ matrix.test }}
       WORKLOAD_NAME_PREFIX: nccl-gke
+      NHOSTS: 2
+      NCCL_MINBYTES: 8
+      NCCL_MAXBYTES: 16G
+      NCCL_STEPFACTOR: 2
+      NCCL_ITERS: 100
 
     steps:
       - uses: actions/checkout@v4
@@ -74,6 +79,15 @@ jobs:
           IMAGE: ${{ env.BASE_IMAGE }}
           WORKLOAD_NAME_PREFIX: ${{ steps.workload-name.outputs.WORKLOAD_PREFIX }}
           COMMAND: |
+            export NHOSTS=${{ env.NHOSTS }};
+            export NCCL_LIB_DIR=/opt/nvida/nccl/lib;
+            export SCRIPT_DIR=/scripts;
+
+            export NCCL_MINBYTES=${{ env.NCCL_MINBYTES }};
+            export NCCL_MAXBYTES=${{ env.NCCL_MAXBYTES }};
+            export NCCL_STEPFACTOR=${{ env.NCCL_STEPFACTOR }};
+            export NCCL_ITERS=${{ env.NCCL_ITERS }};
+
             service ssh restart;
             console=/dev/stdout;
             declare -a hosts=('nccl-test-host-1' 'nccl-test-host-2');

--- a/.github/workflows/_test_nccl_gke.yaml
+++ b/.github/workflows/_test_nccl_gke.yaml
@@ -90,7 +90,7 @@ jobs:
             tee /opt/output/output.log &> \${console};
 
             apt install ripgrep;
-            MAYBE_MPI_EXIT_CODE=\$(tail /opt/output/output.log | rg 'Exit code:    ([0-9]+)' -or '\$1');
+            MAYBE_MPI_EXIT_CODE=\$(tail /opt/output/output.log | rg 'Exit code:[ ]+([0-9]+)' -or '\$1');
             if [ -z \${MAYBE_MPI_EXIT_CODE} ]; then
               EXIT_CODE=0;
             else

--- a/.github/workflows/_test_nccl_gke.yaml
+++ b/.github/workflows/_test_nccl_gke.yaml
@@ -82,8 +82,8 @@ jobs:
 
       - name: Set workload name
         run: |
-          TEST=$(echo "${{ matrix.test }}" | sed 's/perf_mpi//g')
-          echo "WORKLOAD_NAME=${WORKLOAD_NAME_PREFIX}-${TEST}-${GITHUB_RUN_ID}-${GITHUB_RUN_NUMBER}-${GITHUB_RUN_ATTEMPT}" >> ${GITHUB_ENV}
+          TEST=$(echo "${{ matrix.test }}" | sed 's/_perf_mpi//g' | sed 's/_/-/g')
+          echo "WORKLOAD_NAME=${WORKLOAD_NAME_PREFIX}-${TEST}-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}" >> ${GITHUB_ENV}
           echo "DATE=$(date +'%Y-%m-%d')" >> ${GITHUB_ENV}
 
       - name: Create NCCL test service

--- a/.github/workflows/_test_nccl_gke.yaml
+++ b/.github/workflows/_test_nccl_gke.yaml
@@ -90,7 +90,7 @@ jobs:
             tee /opt/output/output.log &> \${console};
 
             apt install ripgrep;
-            MAYBE_MPI_EXIT_CODE=\$(tail /opt/output/output.log | rg 'Exit code:\\s+([0-9]+)' -or '\$1');
+            MAYBE_MPI_EXIT_CODE=\$(tail /opt/output/output.log | rg 'Exit code:\\\s+([0-9]+)' -or '\$1');
             if [ -z \${MAYBE_MPI_EXIT_CODE} ]; then
               EXIT_CODE=0;
             else

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -3,15 +3,15 @@ name: CI
 on:
   schedule:
     - cron: '30 9 * * *'  # Pacific Time 01:30 AM in UTC
-  pull_request:
-    types:
-      - opened
-      - reopened
-      - ready_for_review
-      - synchronize
-    paths-ignore:
-      - '**.md'
-      - '.github/triage/**'
+#  pull_request:
+#    types:
+#      - opened
+#      - reopened
+#      - ready_for_review
+#      - synchronize
+#    paths-ignore:
+#      - '**.md'
+#      - '.github/triage/**'
   workflow_dispatch:
     inputs:
       PUBLISH:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -3,15 +3,15 @@ name: CI
 on:
   schedule:
     - cron: '30 9 * * *'  # Pacific Time 01:30 AM in UTC
-#  pull_request:
-#    types:
-#      - opened
-#      - reopened
-#      - ready_for_review
-#      - synchronize
-#    paths-ignore:
-#      - '**.md'
-#      - '.github/triage/**'
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - ready_for_review
+      - synchronize
+    paths-ignore:
+      - '**.md'
+      - '.github/triage/**'
   workflow_dispatch:
     inputs:
       PUBLISH:
@@ -52,7 +52,7 @@ on:
           - maxtext - run only the tests for maxtext
           - axlearn - run only the tests for axlearn
         options: [full, jax, te, t5x, maxtext, axlearn]
-        default: maxtext
+        default: full
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -3,15 +3,15 @@ name: CI
 on:
   schedule:
     - cron: '30 9 * * *'  # Pacific Time 01:30 AM in UTC
-  #pull_request:
-  #  types:
-  #    - opened
-  #    - reopened
-  #    - ready_for_review
-  #    - synchronize
-  #  paths-ignore:
-  #    - '**.md'
-  #    - '.github/triage/**'
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - ready_for_review
+      - synchronize
+    paths-ignore:
+      - '**.md'
+      - '.github/triage/**'
   workflow_dispatch:
     inputs:
       PUBLISH:

--- a/.github/workflows/nccl-k8s.yaml
+++ b/.github/workflows/nccl-k8s.yaml
@@ -2,15 +2,15 @@ name: NCCL on Kubernetes
 on:
   schedule:
     - cron: '30 8 * * *'
-  #pull_request:
-  #  types:
-  #    - opened
-  #    - reopened
-  #    - ready_for_review
-  #    - synchronize
-  #  paths-ignore:
-  #    - '**.md'
-  #    - '.github/triage/**'
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - ready_for_review
+      - synchronize
+    paths-ignore:
+      - '**.md'
+      - '.github/triage/**'
   workflow_dispatch:
     inputs:
       CONTAINER:

--- a/.github/workflows/nccl-k8s.yaml
+++ b/.github/workflows/nccl-k8s.yaml
@@ -1,16 +1,5 @@
 name: NCCL on Kubernetes
 on:
-  schedule:
-    - cron: '30 8 * * *'
-  pull_request:
-    types:
-      - opened
-      - reopened
-      - ready_for_review
-      - synchronize
-    paths-ignore:
-      - '**.md'
-      - '.github/triage/**'
   workflow_dispatch:
     inputs:
       CONTAINER:

--- a/.github/workflows/nsys-jax.yaml
+++ b/.github/workflows/nsys-jax.yaml
@@ -5,15 +5,15 @@ concurrency:
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 on:
-  #pull_request:
-  #  types:
-  #    - opened
-  #    - reopened
-  #    - ready_for_review
-  #    - synchronize
-  #  paths-ignore:
-  #    - '**.md'
-  #    - '.github/triage/**'
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - ready_for_review
+      - synchronize
+    paths-ignore:
+      - '**.md'
+      - '.github/triage/**'
   push:
     branches:
       - main

--- a/.github/workflows/triage-ci.yaml
+++ b/.github/workflows/triage-ci.yaml
@@ -5,14 +5,14 @@ concurrency:
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 on:
-  #pull_request:
-  #  types:
-  #    - opened
-  #    - reopened
-  #    - ready_for_review
-  #    - synchronize
-  #  paths-ignore:
-  #    - '**.md'
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - ready_for_review
+      - synchronize
+    paths-ignore:
+      - '**.md'
   push:
     branches:
       - main


### PR DESCRIPTION
Add `GKE` `MaxText` train ([example run](https://github.com/NVIDIA/JAX-Toolbox/actions/runs/15744603099/job/44379358307)) and `NCCL` test ([example run](https://github.com/NVIDIA/JAX-Toolbox/actions/runs/15744603099/job/44378422712)) workflows with reusable composite action for managing `xpk` job lifecycle (launch, logs streaming, clean up, artifact upload).

Patches on `xpk` address the following identified issues:
- https://github.com/AI-Hypercomputer/xpk/issues/476
- https://github.com/AI-Hypercomputer/xpk/issues/488
- https://github.com/AI-Hypercomputer/xpk/issues/490
- https://github.com/AI-Hypercomputer/xpk/issues/491
- https://github.com/AI-Hypercomputer/xpk/issues/492

Cluster create with `xpk` ([example run](https://github.com/NVIDIA/JAX-Toolbox/actions/runs/15591134618/job/43910254644#step:5:1)) - added as a separate [workflow](https://github.com/NVIDIA/JAX-Toolbox/pull/1481/files#diff-801fc28cafbf1e0fa0ea521355fa8a1c9e6c01dcb8b1083c47f66e2ead4d560a) for demonstration purposes (will not be operational in the CI)