### PR TITLE
Add local runtime support for in-situ unit test bisection

### DIFF
--- a/.github/triage/jax_toolbox_triage/args.py
+++ b/.github/triage/jax_toolbox_triage/args.py
@@ -187,11 +187,25 @@ def parse_args(args=None) -> argparse.Namespace:
     parser.add_argument(
         "--container-runtime",
         default="docker",
-        help="Container runtime used, this can be either docker or pyxis.",
+        help="Container runtime used, can be docker, pyxis, or local.",
         type=lambda s: s.lower(),
     )
     args = parser.parse_args(args=args)
-    assert args.container_runtime in {"docker", "pyxis"}, args.container_runtime
+    assert args.container_runtime in {"docker", "pyxis", "local"}, args.container_runtime
+    
+    if args.container_runtime == "local":
+        assert (
+            args.passing_commits is not None and args.failing_commits is not None
+        ), "For local runtime, --passing-commits and --failing-commits must be provided."
+        assert (
+            args.container is None 
+            and args.start_date is None
+            and args.end_date is None
+            and args.passing_container is None
+            and args.failing_container is None
+        ), "Container-level search options are not applicable for local runtime."
+        return args
+
     passing_commits_known = (args.passing_container is not None) or (
         args.passing_commits is not None
     )

--- a/.github/triage/jax_toolbox_triage/local.py
+++ b/.github/triage/jax_toolbox_triage/local.py
@@ -1,0 +1,37 @@
+import logging
+import subprocess
+import typing
+
+from .container import Container
+from .utils import run_and_log
+
+
+class LocalContainer(Container):
+    def __init__(self, *, logger: logging.Logger):
+        super().__init__(logger=logger)
+
+    def __enter__(self) -> Container:
+        self._logger.debug("Running local mode inside current container")
+        return self
+
+    def __exit__(self, *exc_info) -> None:
+        pass
+
+    def __repr__(self) -> str:
+        return "Local"
+
+    def exec(
+        self,
+        command: typing.List[str],
+        policy: typing.Literal["once"]
+        | typing.Literal["once_per_container"]
+        | typing.Literal["default"] = "default",
+        stderr: typing.Literal["interleaved"]
+        | typing.Literal["separate"] = "interleaved",
+        workdir=None,
+    ) -> subprocess.CompletedProcess:
+        return run_and_log(command, logger=self._logger, stderr=stderr, cwd=workdir)
+
+    def exists(self) -> bool:
+        """The local environment always exists."""
+        return True

--- a/.github/triage/jax_toolbox_triage/main.py
+++ b/.github/triage/jax_toolbox_triage/main.py
@@ -13,6 +13,7 @@ import typing
 from .args import compulsory_software, optional_software, parse_args
 from .container import Container
 from .docker import DockerContainer
+from .local import LocalContainer
 from .logic import commit_search, container_search, TestResult
 from .pyxis import PyxisContainer
 from .utils import (
@@ -108,6 +109,9 @@ def main() -> None:
     def Container(
         url, test_output_host_directory: typing.Optional[pathlib.Path] = None
     ):
+        if args.container_runtime == "local":
+            return LocalContainer(logger=logger)
+        
         Imp = DockerContainer if args.container_runtime == "docker" else PyxisContainer
         mounts = bazel_cache_mounts + args.container_mount
         if test_output_host_directory is not None:
@@ -197,8 +201,11 @@ def main() -> None:
         return TestResult(
             host_output_directory=out_dir, result=test_pass, stdouterr=result.stdout
         )
-
-    if args.passing_container is None and args.failing_container is None:
+    
+    if args.container_runtime == "local":
+        passing_url = "local"
+        failing_url = "local"
+    elif args.passing_container is None and args.failing_container is None:
         # Search through the published containers, narrowing down to a pair of dates with
         # the property that the test passed on `range_start` and fails on `range_end`.
         range_start, range_end = container_search(
@@ -235,7 +242,10 @@ def main() -> None:
 
     # Choose a container to do the commit-level bisection in; use directory
     # names that match it.
-    if failing_url is not None:
+    if args.container_runtime == "local":
+        bisection_url = "local"
+        package_dirs = failing_package_dirs
+    elif failing_url is not None:
         bisection_url = failing_url
         package_dirs = failing_package_dirs
     else:

--- a/.github/triage/jax_toolbox_triage/utils.py
+++ b/.github/triage/jax_toolbox_triage/utils.py
@@ -82,14 +82,15 @@ def prepare_bazel_cache_mounts(
 
 
 def run_and_log(
-    command, logger: logging.Logger, stderr: typing.Literal["interleaved", "separate"]
+    command, logger: logging.Logger, stderr: typing.Literal["interleaved", "separate"], cwd: typing.Optional[str] = None
 ) -> subprocess.CompletedProcess:
-    logger.debug(shlex.join(command))
+    logger.debug(f"Executing in {cwd or '.'}: {shlex.join(command)}")
     result = subprocess.Popen(
         command,
         encoding="utf-8",
         stderr=subprocess.STDOUT if stderr == "interleaved" else subprocess.PIPE,
         stdout=subprocess.PIPE,
+        cwd=cwd
     )
     assert result.stdout is not None
     stdouterr = ""

--- a/.github/triage/tests/test_arg_parsing.py
+++ b/.github/triage/tests/test_arg_parsing.py
@@ -44,17 +44,32 @@ valid_start_end_date_args = [
     ["--container", "jax", "--end-date", "2024-10-02"],
     ["--container", "jax", "--start-date", "2024-10-01", "--end-date", "2024-10-02"],
 ]
-
+valid_local_args = [
+    "--container-runtime",
+    "local",
+    "--passing-commits",
+    "jax:0123,xla:4567",
+    "--failing-commits",
+    "jax:89ab,xla:cdef"
+]
 
 @pytest.mark.parametrize(
     "good_args",
-    [valid_start_end_container]
+    [valid_start_end_container, valid_local_args]
     + valid_start_end_date_args
     + valid_container_and_commits,
 )
 def test_good_container_args(good_args):
     args = parse_args(good_args + test_command)
     assert args.test_command == test_command
+
+
+def test_good_local_args():
+    args = parse_args(valid_local_args + test_command)
+    assert args.test_command == test_command
+    assert args.container_runtime == "local"
+    assert "jax" in args.passing_commits
+    assert "xla" in args.failing_commits
 
 
 @pytest.mark.parametrize("date_args", valid_start_end_date_args)
@@ -129,3 +144,20 @@ def test_unparsable_container_args(container_args):
 def test_invalid_container_runtime():
     with pytest.raises(Exception):
         parse_args(["--container-runtime=magic-beans"] + test_command)
+
+
+@pytest.mark.parametrize(
+    "bad_local_args",
+    [
+        ["--container-runtime", "local"],
+        ["--container-runtime", "local", "--passing-commits", "jax:1,xla:2"],
+        ["--container-runtime", "local", "--failing-commits", "jax:1,xla:2"],
+        valid_local_args + ["--container", "jax"],
+        valid_local_args + ["--start-date", "2024-01-01"],
+        valid_local_args + ["--passing-container", "url"],
+        valid_local_args + ["--failing-container", "url"],
+    ],
+)
+def test_bad_local_arg_combinations(bad_local_args):
+    with pytest.raises(Exception):
+        parse_args(bad_local_args + test_command)


### PR DESCRIPTION
This PR introduces a new `local` mode to the triage utility that allows developers to perform a commit-level bisection for unit tests without requiring container orchestration. This is designed for the case where a user is already inside a failing container and wants to find a culprit commit directly.

**Changes:**
1. Adds a new option, **--container-runtime=local**.
2. When this mode is active, all `git` operations and build/test commands are executed directly on the local machine using `subprocess`.
3. The `local` runtime skips the container search, so it requires the user to provide the bisection range explicitly using:
  - `--passing-commits="jax:<hash>,xla:<hash>"`
  - `--failing-commits="jax:<hash>,xla:<hash>"`
4. The argument parser has been updated to enforce these new rules and prevent mixing `local` mode with container-specific arguments (i.e, `--container`, `--start-date`).
5. Unit tests to the new argument parsing logic

Now, this command can be run inside a JAX development container:
```
jax-toolbox-triage \
    --container-runtime=local \
    --passing-commits="jax:<some_good_hash>,xla:<some_good_hash>" \
    --failing-commits="jax:<some_bad_hash>,xla:<some_bad_hash>" \
    /opt/jax-toolbox/.github/container/test-jax.sh "some_target"
```