### PR TITLE
nvshmem: install on base container

### DIFF
--- a/.github/container/Dockerfile.base
+++ b/.github/container/Dockerfile.base
@@ -171,6 +171,18 @@ ADD jax-nccl-test parallel-launch /usr/local/bin/
 ADD install-nsight-systems.sh /usr/local/bin
 RUN if [[ -n "${NSIGHT_SYSTEMS_VERSION_OVERRIDE}" ]]; then install-nsight-systems.sh "${NSIGHT_SYSTEMS_VERSION_OVERRIDE}"; fi
 
+##############################################################################
+## Install NVSHMEM
+##############################################################################
+ADD install-nvshmem.sh /usr/local/bin
+RUN install-nvshmem.sh
+
+##############################################################################
+## Create symlinks to help XLA find NVSHMEM
+##############################################################################
+ADD symlnk-nvshmem.sh /usr/local/bin
+RUN symlnk-nvshmem.sh
+
 ###############################################################################
 ## Install the nsys-jax JAX/XLA-aware profiling scripts, patch Nsight Systems
 ###############################################################################

--- a/.github/container/build-jax.sh
+++ b/.github/container/build-jax.sh
@@ -215,6 +215,9 @@ if [[ ${CLEANONLY} == 1 ]]; then
     exit
 fi
 
+# MOSAIC_GPU_NVSHMEM_{BC,SO}_PATH settings are a workaround for NVSHMEM
+# installations at the system level, not via PyPI wheels
+
 ## Build the compiled parts of JAX
 pushd ${SRC_PATH_JAX}
 time python "${SRC_PATH_JAX}/build/build.py" build \
@@ -227,6 +230,9 @@ time python "${SRC_PATH_JAX}/build/build.py" build \
     --bazel_options=--repo_env=LOCAL_CUDA_PATH="/usr/local/cuda" \
     --bazel_options=--repo_env=LOCAL_CUDNN_PATH="/opt/nvidia/cudnn" \
     --bazel_options=--repo_env=LOCAL_NCCL_PATH="/opt/nvidia/nccl" \
+    --bazel_options=--repo_env=LOCAL_NVSHMEM_PATH="/opt/nvidia/nvshmem" \
+    --bazel_options=--test_env=MOSAIC_GPU_NVSHMEM_BC_PATH="/opt/nvidia/nvshmem/lib/libnvshmem_device.bc" \
+    --bazel_options=--test_env=MOSAIC_GPU_NVSHMEM_SO_PATH="/opt/nvidia/nvshmem/lib/libnvshmem_host.so" \
     --bazel_options=--linkopt=-fuse-ld=lld \
     "--local_xla_path=${SRC_PATH_XLA}" \
     "--output_path=${BUILD_PATH_JAXLIB}" \

--- a/.github/container/install-nvshmem.sh
+++ b/.github/container/install-nvshmem.sh
@@ -10,11 +10,15 @@ fi
 UBUNTU_ARCH=$(dpkg --print-architecture)
 if [[ "${UBUNTU_ARCH}" == "arm64" ]]; then
   # nvshmem is only published for sbsa, not arm64
-  UBUNTU_ARCH="sbsa"
+  REPO_ARCH="sbsa"
+elif [[ "${UBUNTU_ARCH}" == "amd64" ]]; then
+  REPO_ARCH="x86_64"
+else
+  echo "Do not know how to map ${UBUNTU_ARCH} onto a compute/cuda repository URL"
+  exit 1
 fi
 UBUNTU_VERSION=$(. /etc/os-release && echo ${ID}${VERSION_ID/./}) # e.g. ubuntu2204
-COMPUTE_URL=https://developer.download.nvidia.com/compute/cuda/repos/${UBUNTU_VERSION}/${UBUNTU_ARCH}
-curl -o /tmp/keyring.deb "${COMPUTE_URL}/cuda-keyring_1.1-1_all.deb"
+curl -o /tmp/keyring.deb "https://developer.download.nvidia.com/compute/cuda/repos/${UBUNTU_VERSION}/${REPO_ARCH}/cuda-keyring_1.1-1_all.deb"
 dpkg -i /tmp/keyring.deb
 
 export DEBIAN_FRONTEND=noninteractive

--- a/.github/container/install-nvshmem.sh
+++ b/.github/container/install-nvshmem.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+set -exuo pipefail
+
+if [[ -z "${NVSHMEM_VERSION}" ]]; then
+  echo "NVSHMEM_VERSION not set; do not know what to install; aborting..."
+  exit 1
+fi
+
+# Repository for NVSHMEM
+UBUNTU_ARCH=$(dpkg --print-architecture)
+if [[ "${UBUNTU_ARCH}" == "arm64" ]]; then
+  # nvshmem is only published for sbsa, not arm64
+  UBUNTU_ARCH="sbsa"
+fi
+UBUNTU_VERSION=$(. /etc/os-release && echo ${ID}${VERSION_ID/./}) # e.g. ubuntu2204
+COMPUTE_URL=https://developer.download.nvidia.com/compute/cuda/repos/${UBUNTU_VERSION}/${UBUNTU_ARCH}
+curl -o /tmp/keyring.deb "${COMPUTE_URL}/cuda-keyring_1.1-1_all.deb"
+dpkg -i /tmp/keyring.deb
+
+export DEBIAN_FRONTEND=noninteractive
+export TZ=America/Los_Angeles
+
+apt-get update
+apt-get install -y nvshmem=${NVSHMEM_VERSION}*
+apt-get clean
+
+rm -rf /var/lib/apt/lists/* /tmp/keyring.deb

--- a/.github/container/symlnk-nvshmem.sh
+++ b/.github/container/symlnk-nvshmem.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+set -exuo pipefail
+
+# Create a prefix with bin/, include/ and lib/ directories containing symlinks
+# to the NVSHMEM version installed at the system level; this is useful to pass
+# to XLA to avoid it fetching its own copy.
+prefix=/opt/nvidia/nvshmem
+if [[ -d "${prefix}" ]]; then
+  echo "$0: ${prefix} already exists -- this is not expected!"
+  exit 0
+fi
+mkdir "${prefix}"
+packages=$(dpkg -l 'libnvshmem*' | awk '/^ii/ {print $2}')
+
+if [[ -z "${packages}" ]]; then
+  echo "No NVSHMEM packages installed."
+  exit 1
+fi
+
+for path in $(dpkg -L ${packages} | sort -u); do
+  dirn=$(dirname "${path}")
+  name=$(basename "${path}")
+  # ${prefix}/lib points to the directory where libnvshmem_host.so is
+  if [[ "${name}" == "libnvshmem_host.so" ]]; then
+    ln -sv "${dirn}" "${prefix}/lib"
+  # ${prefix}/include points to the directory where nvshmem.h is
+  elif [[ "${name}" == "nvshmem.h" ]]; then
+    ln -sv "${dirn}" "${prefix}/include"
+  # ${prefix}/bin points to the directory where nvshmem-info is
+  elif [[ "${name}" == "nvshmem-info" ]]; then
+    ln -sv "${dirn}" "${prefix}/bin"
+  fi
+done
+ls -l "${prefix}"


### PR DESCRIPTION
In container builds, we want to handle CUDA, cuDNN, NCCL and NVSHMEM at the container level.
The first three of these were already covered, NVSHMEM was not.

See: https://github.com/openxla/xla/blob/7787809e48da6df12f8adfba81ee43d18bc60ec8/docs/hermetic_cuda.md#pointing-to-cudacudnnncclnvshmem-redistributions-on-local-file-system as modified in https://github.com/openxla/xla/pull/27289