### PR TITLE
build-jax.sh: plumb through building + saving extra targets

### DIFF
--- a/.github/container/Dockerfile.jax
+++ b/.github/container/Dockerfile.jax
@@ -52,7 +52,7 @@ RUN ARCH="$(dpkg --print-architecture)" && \
 RUN mkdir -p /builder/extra-targets && build-jax.sh \
     --bazel-cache ${BAZEL_CACHE} \
     --build-path-jaxlib ${BUILD_PATH_JAXLIB} \
-    --extra-targets ${EXTRA_BAZEL_TARGETS} \
+    --extra-targets "${EXTRA_BAZEL_TARGETS}" \
     --extra-target-dest /builder/extra-targets \
     --no-install \
     --src-path-jax ${SRC_PATH_JAX} \
@@ -97,7 +97,7 @@ COPY --from=builder ${BUILD_PATH_JAXLIB} ${BUILD_PATH_JAXLIB}
 COPY --from=builder ${SRC_PATH_JAX} ${SRC_PATH_JAX}
 COPY --from=builder ${SRC_PATH_XLA} ${SRC_PATH_XLA}
 COPY --from=builder /usr/local/bin/bazel /usr/local/bin/bazel
-COPY --from=builder /builder/extra-targets /usr/local/bin
+COPY --from=builder /builder/extra-targets/* /usr/local/bin/
 # Preserve the versions of jax and xla
 COPY --from=builder /opt/manifest.d/git-clone.yaml /opt/manifest.d/git-clone.yaml
 ADD build-jax.sh build-te.sh local_cuda_arch pytest-xdist.sh test-jax.sh /usr/local/bin/

--- a/.github/container/Dockerfile.jax
+++ b/.github/container/Dockerfile.jax
@@ -1,6 +1,9 @@
 # syntax=docker/dockerfile:1-labs
 ARG BASE_IMAGE=ghcr.io/nvidia/jax:base
 ARG BUILD_PATH_JAXLIB=/opt/jaxlibs
+# Extra targets to build and copy outputs of, can be used for HLO tools. For example
+# @xla//xla/tools/multihost_hlo_runner:hlo_runner_main,@xla//xla/hlo/tools:hlo-opt
+ARG EXTRA_BAZEL_TARGETS=""
 ARG URLREF_JAX=https://github.com/google/jax.git#main
 ARG URLREF_XLA=https://github.com/openxla/xla.git#main
 ARG URLREF_FLAX=https://github.com/google/flax.git#main
@@ -28,6 +31,7 @@ ARG SRC_PATH_TRANSFORMER_ENGINE
 ARG SRC_PATH_XLA
 ARG BAZEL_CACHE
 ARG BUILD_PATH_JAXLIB
+ARG EXTRA_BAZEL_TARGETS
 ARG GIT_USER_NAME
 ARG GIT_USER_EMAIL
 
@@ -45,9 +49,11 @@ RUN ARCH="$(dpkg --print-architecture)" && \
     chmod +x /usr/local/bin/bazel
 # Populate ${BUILD_PATH_JAXLIB} with editable wheels; --no-install because
 # (a) this is the builder stage, and (b) pip-finalize.sh does the install
-RUN build-jax.sh \
+RUN mkdir -p /builder/extra-targets && build-jax.sh \
     --bazel-cache ${BAZEL_CACHE} \
     --build-path-jaxlib ${BUILD_PATH_JAXLIB} \
+    --extra-targets ${EXTRA_BAZEL_TARGETS} \
+    --extra-target-dest /builder/extra-targets \
     --no-install \
     --src-path-jax ${SRC_PATH_JAX} \
     --src-path-xla ${SRC_PATH_XLA} \
@@ -91,6 +97,7 @@ COPY --from=builder ${BUILD_PATH_JAXLIB} ${BUILD_PATH_JAXLIB}
 COPY --from=builder ${SRC_PATH_JAX} ${SRC_PATH_JAX}
 COPY --from=builder ${SRC_PATH_XLA} ${SRC_PATH_XLA}
 COPY --from=builder /usr/local/bin/bazel /usr/local/bin/bazel
+COPY --from=builder /builder/extra-targets /usr/local/bin
 # Preserve the versions of jax and xla
 COPY --from=builder /opt/manifest.d/git-clone.yaml /opt/manifest.d/git-clone.yaml
 ADD build-jax.sh build-te.sh local_cuda_arch pytest-xdist.sh test-jax.sh /usr/local/bin/

--- a/.github/container/test-jax.sh
+++ b/.github/container/test-jax.sh
@@ -140,7 +140,7 @@ FLAGS+=("--//jaxlib/tools:add_pypi_cuda_wheel_deps=false")
 
 # Default parallelism: at least 10GB per test, no more than 4 tests per GPU.
 DEFAULT_JOBS_PER_GPU=$(( GPU_MEMORIES_MIB[0] / 10000))
-if (( DEFAULT_JOBS_PER_GPU > 8 )); then DEFAULT_JOBS_PER_GPU=4; fi
+if (( DEFAULT_JOBS_PER_GPU > 4 )); then DEFAULT_JOBS_PER_GPU=4; fi
 set_default JOBS_PER_GPU ${DEFAULT_JOBS_PER_GPU}
 FLAGS+=(
     "--cache_test_results=${CACHE_TEST_RESULTS}"


### PR DESCRIPTION
Example usage: `--extra-targets=@xla//xla/tools/multihost_hlo_runner:hlo_runner_main` to build the multi-host HLO runner.
Integrating `--extra-target-dest` into the script makes it useful in conjunction with `--clean`.