### PR TITLE
triage: tune log output

### DIFF
--- a/.github/container/build-te.sh
+++ b/.github/container/build-te.sh
@@ -143,6 +143,7 @@ popd
 
 ## Install the built packages
 if [[ "${INSTALL}" == "1" ]]; then
+    pip uninstall -y transformer_engine
     pip install ${SRC_PATH_TE}/dist/*.whl
     pip list | grep ^transformer_engine
 fi

--- a/.github/triage/jax_toolbox_triage/args.py
+++ b/.github/triage/jax_toolbox_triage/args.py
@@ -14,7 +14,7 @@ import warnings
 # but they are not always installed in containers we want to triage.
 # Note this is not a `set` for the sake of run-to-run determinism.
 compulsory_software = ["xla", "jax"]
-optional_software = ["flax", "maxtext"]
+optional_software = ["flax", "maxtext", "transformer-engine"]
 
 
 def parse_version_argument(s: str) -> typing.Dict[str, str]:
@@ -262,6 +262,7 @@ def parse_args(args=None) -> argparse.Namespace:
     # --{passing,failing}-commits are deprecated aliases for --{passing,failing}-versions.
     for prefix in ["passing", "failing"]:
         commits = getattr(args, f"{prefix}_commits")
+        delattr(args, f"{prefix}_commits")
         if commits is None:
             continue
         if getattr(args, f"{prefix}_versions") is None:

--- a/.github/triage/jax_toolbox_triage/logic.py
+++ b/.github/triage/jax_toolbox_triage/logic.py
@@ -104,6 +104,7 @@ def container_search(
     else:
         # Default to the most recent container
         now = datetime.datetime.now()
+        logger.info(f"Searching for a valid container date close to {now}")
         end_date = adjust(now)
         if end_date is None:
             raise Exception(f"Could not find a valid container from {now}")

--- a/.github/triage/jax_toolbox_triage/main.py
+++ b/.github/triage/jax_toolbox_triage/main.py
@@ -9,17 +9,9 @@ def main() -> None:
     """
     args = parse_args()
     logger = get_logger(args.output_prefix)
-
-    try:
-        tool = TriageTool(args, logger)
-
-        passing_url, failing_url = tool.find_container_range()
-
-        passing_versions, failing_versions = tool.gather_version_info(
-            passing_url, failing_url
-        )
-
-        tool.run_version_bisection(passing_versions, failing_versions)
-
-    except Exception as e:
-        logger.fatal(f"Triage process failed: {e}")
+    tool = TriageTool(args, logger)
+    passing_url, failing_url = tool.find_container_range()
+    passing_versions, failing_versions = tool.gather_version_info(
+        passing_url, failing_url
+    )
+    tool.run_version_bisection(passing_versions, failing_versions)


### PR DESCRIPTION
Also enable TE triage by default, and make build-te.sh install the new TE wheel even if the same version is installed.