### PR TITLE
Upgrade werkzeug for MaxText

### DIFF
--- a/.github/container/Dockerfile.maxtext
+++ b/.github/container/Dockerfile.maxtext
@@ -39,6 +39,7 @@ for pattern in \
     "s|tensorflow-datasets|tensorflow-datasets>=4.8.0|g" \
     "s|sentencepiece==0.1.97|sentencepiece>=0.2|g" \
     "s|tensorflow>=2.13.0|tensorflow==2.18.1|g" \
+    "s|google-cloud-aiplatform==1.61.0|google-cloud-aiplatform>=1.90.0|g" \
   ; do
     # tensorflow-cpu==2.19.0 is incompatible with tensorflow-text
     sed -i "${pattern}" ${SRC_PATH_MAXTEXT}/requirements.txt

--- a/.github/container/Dockerfile.maxtext
+++ b/.github/container/Dockerfile.maxtext
@@ -51,6 +51,7 @@ echo >> ${SRC_PATH_MAXTEXT}/requirements.txt  # add new line
 for requirement in \
     "tensorflow-metadata>=1.15.0" \
     "seqio@git+https://github.com/google/seqio.git" \
+    "werkzeug>=3.0.3" \
   ; do
     echo "${requirement}" >> ${SRC_PATH_MAXTEXT}/requirements.txt
 done


### PR DESCRIPTION
Upgrade werkzeug to avoid vulnerabilities in 2.0.3. To be able to do that, google-cloud-aiplatform needs to at least >= 1.90.0 (refer to https://github.com/googleapis/python-aiplatform/blob/v1.90.0/setup.py#L51) 