### PR TITLE
nccl-tests: set LD_LIBRARY_PATH through mpirun

### DIFF
--- a/.github/eks-workflow-files/mpi-nccl-test.yml
+++ b/.github/eks-workflow-files/mpi-nccl-test.yml
@@ -41,7 +41,8 @@ spec:
                     echo "Workers were still not reachable after ${limit}, exiting"
                     exit 1
                   fi
-                  mpirun --allow-run-as-root -np 16 -N 8 $0 \
+                  mpirun --allow-run-as-root --tag-output -N 1 -x LD_LIBRARY_PATH=/usr/local/cuda/compat/lib nvidia-smi
+                  mpirun --allow-run-as-root -N 8 -x LD_LIBRARY_PATH=/usr/local/cuda/compat/lib $0 \
                     -b 8 \
                     -e 16G \
                     -f 2 \


### PR DESCRIPTION
This helps CUDA forward compatibility work when spawning processes over SSH, as those processes do not see environment variables set by the container entrypoint that handles forward compatibility.
`/usr/local/cuda/compat/lib` will only exist if the entrypoint detects that forward compatibility mode is enabled.