### PR TITLE
Keep restrict on tensorflow to be 2.18.1

### DIFF
--- a/.github/container/Dockerfile.maxtext
+++ b/.github/container/Dockerfile.maxtext
@@ -37,8 +37,7 @@ for pattern in \
     "s|absl-py|absl-py>=2.1.0|g" \
     "s|protobuf==3.20.3|protobuf>=3.19.0|g" \
     "s|tensorflow-datasets|tensorflow-datasets>=4.8.0|g" \
-    "s|sentencepiece==0.1.97|sentencepiece>=0.2|g" \
-    "s|tensorflow>=2.13.0|tensorflow==2.18.1|g" \
+    "s|tensorflow>=2.16.0|tensorflow==2.18.1|g" \
   ; do
     # tensorflow-cpu==2.19.0 is incompatible with tensorflow-text
     sed -i "${pattern}" ${SRC_PATH_MAXTEXT}/requirements.txt


### PR DESCRIPTION
Yep, it bites us again with the newer version of tensorflow-text such as `2.19.0`:
```
12:   File "/usr/local/lib/python3.12/dist-packages/tensorflow/python/framework/load_library.py", line 54, in load_op_library
12:     lib_handle = py_tf.TF_LoadLibrary(library_filename)
12:                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
12: tensorflow.python.framework.errors_impl.NotFoundError: /usr/local/lib/python3.12/dist-packages/tensorflow_text/python/ops/_boise_offset_converter.so: undefined symbol: _ZN6tflite4shim23TfShapeInferenceContextC1EPN10tensorflow15shape_inference16InferenceContextE
```