### PR TITLE
Update `xpk` `GKE` cluster create workflow

### DIFF
--- a/.github/container/Dockerfile.maxtext
+++ b/.github/container/Dockerfile.maxtext
@@ -37,8 +37,7 @@ for pattern in \
     "s|absl-py|absl-py>=2.1.0|g" \
     "s|protobuf==3.20.3|protobuf>=3.19.0|g" \
     "s|tensorflow-datasets|tensorflow-datasets>=4.8.0|g" \
-    "s|sentencepiece==0.1.97|sentencepiece>=0.2|g" \
-    "s|tensorflow>=2.13.0|tensorflow==2.18.1|g" \
+    "s|tensorflow>=2.16.0|tensorflow==2.18.1|g" \
   ; do
     # tensorflow-cpu==2.19.0 is incompatible with tensorflow-text
     sed -i "${pattern}" ${SRC_PATH_MAXTEXT}/requirements.txt

--- a/.github/gke-workflow/gke/gpu-operator-quota.yml
+++ b/.github/gke-workflow/gke/gpu-operator-quota.yml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: ResourceQuota
+metadata:
+  name: gpu-operator-quota
+spec:
+  hard:
+    pods: 100
+  scopeSelector:
+    matchExpressions:
+    - operator: In
+      scopeName: PriorityClass
+      values:
+        - system-node-critical
+        - system-cluster-critical

--- a/.github/gke-workflow/gke/namespace.yml
+++ b/.github/gke-workflow/gke/namespace.yml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  creationTimestamp: null
+  name: gpu-operator
+spec: {}
+status: {}

--- a/.github/gke-workflow/xpk/v0.10.1/blueprint.patch
+++ b/.github/gke-workflow/xpk/v0.10.1/blueprint.patch
@@ -1,0 +1,34 @@
+diff --git a/src/xpk/core/blueprint/blueprint_generator.py b/src/xpk/core/blueprint/blueprint_generator.py
+index 3d7f046..d94fe9e 100644
+--- a/src/xpk/core/blueprint/blueprint_generator.py
++++ b/src/xpk/core/blueprint/blueprint_generator.py
+@@ -201,12 +201,15 @@ class BlueprintGenerator:
+                 "type": "nvidia-h100-mega-80gb",
+                 "count": 8,
+                 "gpu_driver_installation_config": {
+-                    "gpu_driver_version": "LATEST"
++                    "gpu_driver_version": "INSTALLATION_DISABLED"
+                 },
+             }],
+             "auto_upgrade": (
+                 True if capacity_type != CapacityType.FLEX_START else False
+             ),
++            "labels": {
++                "gke-no-default-nvidia-gpu-device-plugin": True,
++            },
+         },
+         outputs=["instructions"],
+     )
+@@ -282,9 +285,9 @@ class BlueprintGenerator:
+             workload_configmap,
+         ],
+     )
+-    if set_placement_policy and reservation_placement_policy is None:
+-      a3_megagpu_pool_0.use.append(group_placement_0.id)
+-      primary_group.modules.append(group_placement_0)
++    #if set_placement_policy and reservation_placement_policy is None:
++    #  a3_megagpu_pool_0.use.append(group_placement_0.id)
++    #  primary_group.modules.append(group_placement_0)
+     a3_mega_blueprint = Blueprint(
+         terraform_backend_defaults=self._getblock_terraform_backend(
+             gcs_bucket, cluster_name, prefix

--- a/.github/gke-workflow/xpk/xpk-gcs-sa.yml
+++ b/.github/gke-workflow/xpk/xpk-gcs-sa.yml
@@ -1,0 +1,34 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: xpk-gcs-sa
+  namespace: default
+  annotations:
+    iam.gke.io/gcp-service-account: jobset-xpk-user@nv-jaxtoolboxgcp-20240925.iam.gserviceaccount.com
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: xpk-gcs-sa
+rules:
+  - apiGroups: [""]
+    resources: ["pods", "services"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["batch"]
+    resources: ["jobs"]
+    verbs: ["get", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: xpk-gcs-sa-binding
+  namespace: default
+subjects:
+  - kind: ServiceAccount
+    name: xpk-gcs-sa
+    namespace: default
+roleRef: 
+  kind: Role
+  name: xpk-gcs-sa
+  apiGroup: rbac.authorization.k8s.io
+

--- a/.github/workflows/_create_gke_cluster_xpk.yml
+++ b/.github/workflows/_create_gke_cluster_xpk.yml
@@ -1,65 +1,123 @@
 name: ~Create GKE cluster with XPK
 
 on:
-  workflow_call:
+  workflow_dispatch:
     inputs:
       CLUSTER_NAME:
         type: string
         description: Cluster name
-        default: jtb-2025-06-12
+        required: true
+      GKE_VERSION:
+        type: string
+        default: 1.31.6-gke.1221000 
         required: false
+      DEVICE_TYPE: 
+        type: string
+        default: h100-mega-80gb-8
+        required: false
+      DEFAULT_CPU_MACHINE: 
+        type: string
+        default: e2-standard-8
+        required: false
+      NUM_NODES: 
+        type: string
+        default: 2
+        required: false
+      GCP_PROJECT: 
+        type: string
+        default: nv-jaxtoolboxgcp-20240925
+        required: false
+      GCP_ZONE: 
+        type: string
+        default: us-central1-a
+        required: false
+      GCP_GCE_RESERVATION: 
+        type: string
+        default: jtb-reservation
+        required: false
+      XPK_VERSION:
+        description: 'XPK release tag'
+        required: false
+        default: 'v0.10.1'
+        type: string
+      XPK_PYTHON:
+        description: 'Python version for XPK'
+        required: false
+        default: '3.12.10'
+        type: string
 
 jobs:
   xpk-create-gke-cluster:
-    env:
-      GKE_VERSION: 1.31.6-gke.1221000 
-      DEVICE_TYPE: h100-mega-80gb-8
-      DEFAULT_CPU_MACHINE: e2-standard-8
-      NUM_NODES: 2
-      ZONE: us-central1-a
-      RESERVATION: jtb-reservation
-      PROJECT: nv-jaxtoolboxgcp-20240925
-
     runs-on: gke-a3mega
 
     steps:
-      - uses: actions/checkout@v4
+    - uses: actions/checkout@v4
 
-      - name: Show environment
-        run: |
-          set -x 
-          
-          gcloud version
+    - name: Set workload name
+      shell: bash -x -e -u {0}
+      run: |
+        WORKLOAD_NAME="cluster-create-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+        DATE=$(date +'%Y-%m-%d')
 
+        echo "WORKLOAD_NAME=${WORKLOAD_NAME}" >> ${GITHUB_ENV}
+        echo "DATE=${DATE}" >> ${GITHUB_ENV}
+
+    - name: Setup environment
+      shell: bash -x -e -u {0}
+      run: |
+        mkdir -p ${WORKLOAD_NAME}
+        uv venv --verbose --python=${{ inputs.XPK_PYTHON }} --directory=${WORKLOAD_NAME}
+        source ${WORKLOAD_NAME}/.venv/bin/activate
+
+        # install xpk
+        git clone --depth=1 --branch=${{ inputs.XPK_VERSION }} https://github.com/AI-Hypercomputer/xpk.git ${WORKLOAD_NAME}/xpk
+
+        sed 's@pip install \.@'$(which uv)' pip install \.@g' -i ${WORKLOAD_NAME}/xpk/Makefile
+        cd ${WORKLOAD_NAME}/xpk && sudo make install; cd -
+
+    - name: Apply XPK cluster create patch
+      shell: bash -x -e -u {0}
+      run: |
+        PATCH_PATH=.github/gke-workflow/xpk/${{ inputs.XPK_VERSION}}
+        ls ${PATCH_PATH} | xargs -I {} git apply --unsafe-paths ${PATCH_PATH}/{} --directory ${WORKLOAD_NAME}/xpk
+
+    - name: Show environment
+      run: |
+        set -x 
+        
+        gcloud version
+
+        source $HOME/.venv/bin/activate
+        python --version
+        xpk version
+
+    - name: Create cluster from compute reservation with xpk
+      run: |
+        CLUSTER_EXISTS=$(gcloud container clusters list  --format=json | jq -r  'any(.[].name; . == "'${{ inputs.CLUSTER_NAME }}'")')
+        
+        if ! [ $CLUSTER_EXISTS = true  ]; then
+          cd $HOME/xpk
           source $HOME/.venv/bin/activate
-          python --version
-          xpk version
+           python xpk.py cluster create \
+                  --cluster ${{ inputs.CLUSTER_NAME }} \
+                  --gke-version ${{ inputs.GKE_VERSION }} \
+                  --device-type ${{ inputs.DEVICE_TYPE }} \
+                  --num-nodes ${{ inputs.NUM_NODES }} \
+                  --default-pool-cpu-machine-type=${{ inputs.DEFAULT_CPU_MACHINE }} \
+                  --project=${{ inputs.GCP_PROJECT }} \
+                  --reservation ${{ inputs.GCP_GCE_RESERVATION }} \
+                  --zone ${{ inputs.GCP_ZONE }}
+        else
+          echo "Cluster ${{ inputs.CLUSTER_NAME }} already exists, skipping creation"
+        fi
 
-      - name: Apply xpk cluster create patch
-        run: |
-          cd $HOME/xpk && git checkout src/xpk/core/blueprint/blueprint_generator.py && cd -
-          git apply --unsafe-paths .github/gke-workflow/xpk/blueprint.patch --directory $HOME/xpk
-
-      - name: Create cluster from compute reservation with xpk
-        run: |
-          CLUSTER_EXISTS=$(gcloud container clusters list  --format=json | jq -r  'any(.[].name; . == "'${CLUSTER_NAME}'")')
-          
-          if ! [ $CLUSTER_EXISTS = true  ]; then
-            cd $HOME/xpk
-            source $HOME/.venv/bin/activate
-            python xpk.py cluster create \
-                    --cluster ${CLUSTER_NAME} \
-                    --gke-version ${GKE_VERSION} \
-                    --device-type ${DEVICE_TYPE} \
-                    --num-nodes ${NUM_NODES} \
-                    --default-pool-cpu-machine-type=${DEFAULT_CPU_MACHINE} \
-                    --project=${PROJECT} \
-                    --reservation ${RESERVATION} \
-                    --zone ${ZONE}
-          else
-            echo "Cluster ${CLUSTER_NAME} already exists, skipping creation"
-          fi
-
-      - name: Configure cluster ServiceAccount
-        run: |
+    - name: Configure cluster ServiceAccount
+      run: |
+  
+        # not configured in xpk pre v0.10.0
+        if [[ "${{ inputs.XPK_VERSION }}" == "v0.8.0" ]]; then
           kubectl apply -f .github/gke-workflow/xpk/xpk-sa-rbac.yml
+        fi
+
+        # enable GCS interactivity from pods
+        kubectl apply -f /github/gke-workflow/xpk/xpk-gcs-sa.yml

--- a/.github/workflows/_create_gke_cluster_xpk.yml
+++ b/.github/workflows/_create_gke_cluster_xpk.yml
@@ -121,3 +121,9 @@ jobs:
 
         # enable GCS interactivity from pods
         kubectl apply -f /github/gke-workflow/xpk/xpk-gcs-sa.yml
+
+    - name: Install GPU operator
+      run: |
+        kubectl apply -f .github/gke-workflow/gke/namespace.yml
+        kubectl apply -n gpu-operator -f .github/gke-workflow/gke/gpu-operator-quota.yml
+        kubectl apply -f https://raw.githubusercontent.com/GoogleCloudPlatform/container-engine-accelerators/master/nvidia-driver-installer/cos/daemonset-preloaded.yaml


### PR DESCRIPTION
Enable the `xpk` `GKE` cluster create workflow to trigger on workflow dispatch events, and upgrade `xpk` to `v0.10.1`

The included patch file on  `xpk@v0.10.1`is necessary for:
1. Addressing an error on GPU node pool creation (comment out placement policy)
```
Google Compute Engine: Not all instances running in IGM after 22.157464014s. Expected 2, running 0, transitioning 2. 
Current errors: [UNSUPPORTED_OPERATION]: Instance 'gke-jtb-2025-08-06-jtb-2025-08-06-a3--954bb82f-1rsz' 
creation failed: To consume reservation with placement policy, the instance has to specify the same resource policy as the
 reservation.
```
2. Enabling [GPU Operator](https://docs.nvidia.com/datacenter/cloud-native/gpu-operator/latest/google-gke.html) install (requires node label, and disabling of the GKE managed driver)

A service account to enable pod interactivity with GCS buckets is also added

Installation of GPU operator is added

n.b This workflow is not operational in the CI, it is added as reference recipe for `GKE` cluster creation with `xpk`