### PR TITLE
triage-tool: minor improvements

### DIFF
--- a/.github/triage/jax_toolbox_triage/container.py
+++ b/.github/triage/jax_toolbox_triage/container.py
@@ -42,13 +42,25 @@ class Container(ABC):
         pass
 
     def check_exec(
-        self, cmd: typing.List[str], **kwargs
+        self,
+        cmd: typing.List[str],
+        *,
+        log_level: int = logging.DEBUG,
+        policy: typing.Literal["once", "once_per_container", "default"] = "default",
+        stderr: typing.Literal["interleaved", "separate"] = "interleaved",
+        workdir: typing.Optional[str] = None,
     ) -> subprocess.CompletedProcess:
-        result = self.exec(cmd, **kwargs)
+        result = self.exec(
+            cmd, log_level=log_level, policy=policy, stderr=stderr, workdir=workdir
+        )
         if result.returncode != 0:
             self._logger.fatal(
                 f"{' '.join(cmd)} exited with return code {result.returncode}"
             )
+            if stderr == "separate":
+                self._logger.fatal("stderr:")
+                self._logger.fatal(result.stderr)
+                self._logger.fatal("stdout:")
             self._logger.fatal(result.stdout)
             result.check_returncode()
         return result

--- a/.github/triage/jax_toolbox_triage/utils.py
+++ b/.github/triage/jax_toolbox_triage/utils.py
@@ -74,6 +74,7 @@ def run_and_log(
     cwd: typing.Optional[str] = None,
     log_level: int = logging.DEBUG,
 ) -> subprocess.CompletedProcess:
+    assert stderr in {"interleaved", "separate"}, stderr
     logger.debug(f"Executing in {cwd or '.'}: {shlex.join(command)}")
     result = subprocess.Popen(
         command,

--- a/.github/triage/tests/mock_scripts/srun
+++ b/.github/triage/tests/mock_scripts/srun
@@ -40,7 +40,7 @@ def env(prefix):
     env["JAX_TOOLBOX_TRIAGE_PREFIX"] = prefix
     return env
 
-
+print("srun: warning: sometimes srun likes to print warnings on stderr", file=sys.stderr)
 results = [
     subprocess.Popen(
         test_cmd,

--- a/.github/triage/tests/test_triage_logic.py
+++ b/.github/triage/tests/test_triage_logic.py
@@ -15,7 +15,7 @@ def wrap(b, versions={}):
     )
 
 
-@pytest.fixture
+@pytest.fixture(scope="module")
 def logger():
     logger = logging.getLogger("triage-tests")
     logger.setLevel(logging.DEBUG)


### PR DESCRIPTION
- Tolerate inconsistent sets of versions.
- pyxis backend: do not capture stderr from srun when parsing git output.
- Add a `--cherry-pick` flag to help smooth over orthogonal build issues.
- Add a `--workaround-buggy-container` flag to smooth over triaging certain containers.