### PR TITLE
Tweak pyproject.toml to adopt MaxText new build

### DIFF
--- a/.github/container/Dockerfile.maxtext
+++ b/.github/container/Dockerfile.maxtext
@@ -1,5 +1,7 @@
 # syntax=docker/dockerfile:1-labs
 
+# TODO: remove any JetStream references if not needed anymore
+
 ARG BASE_IMAGE=ghcr.io/nvidia/jax-mealkit:jax
 ARG URLREF_MAXTEXT=https://github.com/google/maxtext.git#main
 ARG URLREF_JETSTREAM=https://github.com/AI-Hypercomputer/JetStream.git#main
@@ -22,39 +24,37 @@ git-clone.sh ${URLREF_JETSTREAM} ${SRC_PATH_JETSTREAM}
 EOF
 
 RUN <<"EOF" bash -ex -o pipefail
-echo "-r ${SRC_PATH_MAXTEXT}/requirements.txt" >> /opt/pip-tools.d/requirements-maxtext.in
 echo "-e file://${SRC_PATH_MAXTEXT}" >> /opt/pip-tools.d/requirements-maxtext.in
-echo "-e file://${SRC_PATH_JETSTREAM}" >> /opt/pip-tools.d/requirements-maxtext.in
+#echo "-e file://${SRC_PATH_JETSTREAM}" >> /opt/pip-tools.d/requirements-maxtext.in
 EOF
 
-# remove GitHub direct-reference of JetStream in MaxText requirements
-RUN <<"EOF" bash -ex -o pipefail
-sed -i '/^google-jetstream/d' ${SRC_PATH_MAXTEXT}/requirements.txt
-EOF
+# # remove GitHub direct-reference of JetStream in MaxText requirements
+# RUN <<"EOF" bash -ex -o pipefail
+# sed -i '/^google-jetstream/d' ${SRC_PATH_MAXTEXT}/requirements.txt
+# EOF
 
 # add version constraints to avoid eternal dependency resolution
 RUN <<"EOF" bash -ex -o pipefail
 for pattern in \
-    "s|absl-py|absl-py>=2.1.0|g" \
-    "s|protobuf==3.20.3|protobuf>=3.19.0|g" \
-    "s|tensorflow-datasets|tensorflow-datasets>=4.8.0|g" \
-    "s|tensorflow>=2.16.0|tensorflow==2.18.1|g" \
+    "s|tensorflow>=2.19.1|tensorflow==2.18.1|g" \
+    "s|tensorboard>=2.19.0|tensorboard>=2.18,<2.19|g" \
+    "s|tensorflow-text>=2.19.0|tensorflow-text==2.18.1|g" \
   ; do
-    # tensorflow-cpu==2.19.0 is incompatible with tensorflow-text
-    sed -i "${pattern}" ${SRC_PATH_MAXTEXT}/requirements.txt
+    # tensorflow-cpu,tensorboard,tensorflow-text>=2.19.0 is incompatible with tensorflow==2.18.1
+    sed -i "${pattern}" ${SRC_PATH_MAXTEXT}/pyproject.toml
 done
 EOF
 
-# add extra dependencies
-RUN <<"EOF" bash -ex -o pipefail
-echo >> ${SRC_PATH_MAXTEXT}/requirements.txt  # add new line
-for requirement in \
-    "tensorflow-metadata>=1.15.0" \
-    "seqio@git+https://github.com/google/seqio.git" \
-  ; do
-    echo "${requirement}" >> ${SRC_PATH_MAXTEXT}/requirements.txt
-done
-EOF
+# # add extra dependencies
+# RUN <<"EOF" bash -ex -o pipefail
+# echo >> ${SRC_PATH_MAXTEXT}/requirements.txt  # add new line
+# for requirement in \
+#     "tensorflow-metadata>=1.15.0" \
+#     "seqio@git+https://github.com/google/seqio.git" \
+#   ; do
+#     echo "${requirement}" >> ${SRC_PATH_MAXTEXT}/requirements.txt
+# done
+# EOF
 
 ###############################################################################
 ## Add test script to the path


### PR DESCRIPTION
With https://github.com/AI-Hypercomputer/maxtext/pull/2310, the installation dependency moved to `pyproject.toml`, let's use this file as the single source of fact. To accommodate, we should not maintain our own `JetStream`. Also, we still need to use `tensorflow==2.18.1` to avoid the long standing UDR issues.