### PR TITLE
base container: do not install nsys 2025.3.1 after base container bump

### DIFF
--- a/.github/workflows/_build_base.yaml
+++ b/.github/workflows/_build_base.yaml
@@ -135,7 +135,6 @@ jobs:
             GIT_USER_EMAIL=${{ inputs.GIT_USER_EMAIL }}
             BUILD_DATE=${{ inputs.BUILD_DATE }}
             JAX_TOOLBOX_REF=${{ github.head_ref || github.sha }}
-            NSIGHT_SYSTEMS_VERSION_OVERRIDE=2025.3.1
             ${{ inputs.BASE_IMAGE != 'latest' && format('BASE_IMAGE={0}', inputs.BASE_IMAGE) || '' }}
         
       - name: Generate sitrep


### PR DESCRIPTION
This change should have been included in https://github.com/NVIDIA/JAX-Toolbox/pull/1635.