### PR TITLE
triage-tool: two bugfixes

### DIFF
--- a/.github/triage/jax_toolbox_triage/pyxis.py
+++ b/.github/triage/jax_toolbox_triage/pyxis.py
@@ -37,7 +37,7 @@ class PyxisContainer(Container):
             [
                 "sh",
                 "-c",
-                "echo 'startup --host_jvm_args=-XX:-UseContainerSupport' > ${JAX_TOOLBOX_TRIAGE_PREFIX}/root/.bazelrc",
+                "echo 'startup --host_jvm_args=-XX:-UseContainerSupport' > ${JAX_TOOLBOX_TRIAGE_PREFIX}root/.bazelrc",
             ]
         )
         return self

--- a/.github/triage/jax_toolbox_triage/utils.py
+++ b/.github/triage/jax_toolbox_triage/utils.py
@@ -85,9 +85,15 @@ def run_and_log(
     )
     assert result.stdout is not None
     stdouterr = ""
-    for line in iter(result.stdout.readline, ""):
-        stdouterr += line
-        logger.log(log_level, line.strip())
+    try:
+        for line in iter(result.stdout.readline, ""):
+            stdouterr += line
+            logger.log(log_level, line.strip())
+    except KeyboardInterrupt:
+        # Ctrl-C of the triage tool should not leave children alive
+        logger.warning("Killing child process due to KeyboardInterrupt")
+        result.terminate()
+        raise
     result.wait()
     return subprocess.CompletedProcess(
         args=command,

--- a/.github/triage/pyproject.toml
+++ b/.github/triage/pyproject.toml
@@ -1,6 +1,9 @@
 [project]
 name = "jax-toolbox-triage"
 dynamic = ["version"]
+dependencies = [
+    "psutil",
+]
 # Because this script needs to run on compute clusters *outside* the containers that it
 # orchestrates, it tries to tolerate old Python versions
 requires-python = ">= 3.8"

--- a/.github/triage/tests/mock_scripts/installPACKAGE.sh
+++ b/.github/triage/tests/mock_scripts/installPACKAGE.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+new_version=$1
+echo "Setting PACKAGE_VERSION to $new_version"
+cat ${JAX_TOOLBOX_TRIAGE_PREFIX}.env
+sed -i "s|^PACKAGE_VERSION=.*$|PACKAGE_VERSION=$new_version|" ${JAX_TOOLBOX_TRIAGE_PREFIX}.env
+cat ${JAX_TOOLBOX_TRIAGE_PREFIX}.env

--- a/.github/triage/tests/mock_scripts/srun
+++ b/.github/triage/tests/mock_scripts/srun
@@ -36,8 +36,18 @@ if args.ntasks is not None:
 
 # JAX_TOOLBOX_TRIAGE_PREFIX is a lazy alternative to making something chroot-like work
 def env(prefix):
+    assert len(prefix)
+    if prefix[:-1] != "/":
+        prefix += "/"
     env = os.environ.copy()
     env["JAX_TOOLBOX_TRIAGE_PREFIX"] = prefix
+    try:
+        with open(f"{prefix}.env") as env_file:
+            for line in env_file:
+                k, v = line.strip().split("=", 1)
+                env[k] = v
+    except OSError:
+        pass
     return env
 
 print("srun: warning: sometimes srun likes to print warnings on stderr", file=sys.stderr)

--- a/.github/triage/tests/test_utils.py
+++ b/.github/triage/tests/test_utils.py
@@ -1,0 +1,39 @@
+import logging
+import os
+import psutil
+import signal
+import time
+
+from jax_toolbox_triage.utils import run_and_log
+
+
+def test_run_and_log():
+    pid = os.fork()
+    if pid == 0:
+        # We are the child of the fork
+        try:
+            run_and_log(["sleep", "30"], logging.getLogger(), stderr="interleaved")
+        except KeyboardInterrupt:
+            os._exit(42)
+    else:
+        # We are the parent of the fork
+        child = psutil.Process(pid)
+        assert child.is_running()
+        # Wait until the grandchild `sleep` has appeared
+        for _ in range(50):
+            children = child.children(recursive=False)
+            if len(children):
+                break
+            time.sleep(0.1)
+        else:
+            raise Exception(f"Never saw any children of {pid} that we forked")
+        # Expect exactly one grandchild
+        assert len(children) == 1, children
+        (grandchild,) = children
+        # Trigger KeyboardInterrupt in the child Python that we forked
+        child.send_signal(signal.SIGINT)
+        # Child becomes a zombie until we wait on it; we should not get None
+        assert child.wait(timeout=5) == 42
+        # Wait until the grandchild `sleep` has been killed by SIGTERM in
+        # run_and_log, it's possible that we'll be too slow to see the code
+        assert grandchild.wait(timeout=5) in {None, -signal.SIGTERM}

--- a/.github/workflows/triage-ci.yaml
+++ b/.github/workflows/triage-ci.yaml
@@ -33,7 +33,7 @@ jobs:
         with:
           python-version: '3.12'
       - name: "Install mypy"
-        run: pip install mypy pytest
+        run: pip install mypy pytest types-psutil
       - name: "Run mypy checks"
         shell: bash -x -e {0}
         run: |


### PR DESCRIPTION
Bug one: if a package FOO has different versions in the two endpoint containers of a triage, as given by the FOO_VERSION environment variable inside those containers, but no installFOO.sh script is available, previously it was not excluded properly from the triage.

Bug two: manually interrupting a triage with Ctrl-C did not kill the child processes, leading to orphaned `srun` commands etc.

Tests added covering both issues.