### PR TITLE
Remove `NCCL_NVLS_ENABLE` setting from JAX image

### DIFF
--- a/.github/container/Dockerfile.jax
+++ b/.github/container/Dockerfile.jax
@@ -97,7 +97,6 @@ ENV BUILD_DATE=${BUILD_DATE}
 # The following environment variables tune performance
 ENV XLA_FLAGS=""
 ENV XLA_FLAGS="${XLA_FLAGS} --xla_gpu_enable_latency_hiding_scheduler=true"
-ENV NCCL_NVLS_ENABLE=0
 
 COPY --from=builder ${BUILD_PATH_JAXLIB} ${BUILD_PATH_JAXLIB}
 COPY --from=builder ${SRC_PATH_JAX} ${SRC_PATH_JAX}

--- a/README.md
+++ b/README.md
@@ -218,10 +218,6 @@ The [JAX image](https://github.com/NVIDIA/JAX-Toolbox/pkgs/container/jax) is emb
 | --------- | ----- | ----------- |
 | `--xla_gpu_enable_latency_hiding_scheduler` | `true`  | allows XLA to move communication collectives to increase overlap with compute kernels |
 
-| Environment Variable | Value | Explanation |
-| -------------------- | ----- | ----------- |
-| `NCCL_NVLS_ENABLE` | `0` | Disables NVLink SHARP ([1](https://docs.nvidia.com/deeplearning/nccl/user-guide/docs/env.html#nccl-nvls-enable)). Future releases will re-enable this feature. |
-
 There are various other XLA flags users can set to improve performance. For a detailed explanation of these flags, please refer to the [GPU performance](./rosetta/docs/GPU_performance.md) doc. XLA flags can also be tuned per workload. For example, each script includes a directory [xla_flags](./rosetta/rosetta/projects/maxtext/xla_flags).
 
 For a list of previously used XLA flags that are no longer needed, please also refer to the [GPU performance](./rosetta/docs/GPU_performance.md#previously-used-xla-flags) page.


### PR DESCRIPTION
Removal of [NCCL_NVLS_ENABLE](https://docs.nvidia.com/deeplearning/nccl/user-guide/docs/env.html#nccl-nvls-enable)=0 setting enables NVLink SHARP on systems which support it by default. Change (to be) added for 25.10 NGC release.



- [x] Performance regression tests on internal clusters
- [x] Performance regression tests on GKE, EKS (due to @nouiz)
    - Observed [regression to ~180 toks/s](https://github.com/NVIDIA/JAX-Toolbox/actions/runs/18220385244/job/51880864677#step:5:16253) vs [~210 toks/s before](https://github.com/NVIDIA/JAX-Toolbox/actions/runs/18220385244/job/51880864677#step:5:16253)