### PR TITLE
nsys-jax: stop disabling the compilation cache by default

### DIFF
--- a/.github/container/nsys_jax/nsys_jax/scripts/nsys_jax.py
+++ b/.github/container/nsys_jax/nsys_jax/scripts/nsys_jax.py
@@ -278,10 +278,6 @@ def main() -> None:
     if "JAX_TRACEBACK_IN_LOCATIONS_LIMIT" not in env:
         env["JAX_TRACEBACK_IN_LOCATIONS_LIMIT"] = "-1"
 
-    # Disable the compilation cache so that we get the full set of .pb files
-    if "JAX_ENABLE_COMPILATION_CACHE" not in env:
-        env["JAX_ENABLE_COMPILATION_CACHE"] = "false"
-
     def format_flag(tup):
         n, v = tup
         return f"--{n}" if v is None else f"--{n}={v}"

--- a/.github/container/nsys_jax/tests/multi_process_program.py
+++ b/.github/container/nsys_jax/tests/multi_process_program.py
@@ -81,18 +81,23 @@ if jax.process_index() == 1:
     square = only_in_process_one(square)
 
 
+@jax.jit
+def different_stacktraces(x):
+    return x * 934
+
+
 # This means the stack traces are different for the two calls
-def trampoline0():
-    sync_global_devices("barrier")
+def trampoline0(square):
+    return different_stacktraces(square)
 
 
-def trampoline1():
-    sync_global_devices("barrier")
+def trampoline1(square):
+    return different_stacktraces(square)
 
 
 if jax.process_index() == 0:
-    trampoline0()
-    trampoline1()
+    square = trampoline0(square)
+    square = trampoline1(square)
 else:
-    trampoline1()
-    trampoline0()
+    square = trampoline1(square)
+    square = trampoline0(square)

--- a/.github/container/nsys_jax/tests/multi_process_program.py
+++ b/.github/container/nsys_jax/tests/multi_process_program.py
@@ -1,7 +1,6 @@
 import argparse
 import functools
 import jax
-from jax.experimental.multihost_utils import sync_global_devices
 
 parser = argparse.ArgumentParser()
 parser.add_argument("--rank", type=int)

--- a/.github/container/nsys_jax/tests/test_jax_nccl_test.py
+++ b/.github/container/nsys_jax/tests/test_jax_nccl_test.py
@@ -1,0 +1,103 @@
+from ctypes import byref, cdll, c_int, POINTER
+import os
+import pytest  # type: ignore
+import subprocess
+import sys
+import tempfile
+
+helper_dir = os.path.join(os.path.dirname(__file__), "nsys_jax_test_helpers")
+if helper_dir not in sys.path:
+    sys.path.insert(0, helper_dir)
+from nsys_jax_test_helpers import multi_process_nsys_jax, nsys_jax  # noqa: E402
+
+
+def visible_device_count() -> int:
+    """
+    Query the number of local devices visible to this process.
+    """
+    libcudart = cdll.LoadLibrary("libcudart.so")
+    cudaGetDeviceCount = libcudart.cudaGetDeviceCount
+    cudaGetDeviceCount.argtypes = [POINTER(c_int)]
+    cudaGetDeviceCount.restype = c_int
+    count = c_int()
+    assert cudaGetDeviceCount(byref(count)) == 0
+    return count.value
+
+
+def capture_args(collection):
+    return {
+        "full": [],
+        "partial": [],
+    }[collection]
+
+
+def set_env(monkeypatch):
+    monkeypatch.setenv("XLA_PYTHON_CLIENT_MEM_FRACTION", "0.85")
+    # Disable CUDA graphs
+    monkeypatch.setenv("XLA_FLAGS", "--xla_gpu_enable_command_buffer=")
+
+
+@pytest.mark.parametrize("collection", ["full", "partial"])
+def test_jax_nccl_single_process(monkeypatch, collection):
+    set_env(monkeypatch)
+    nsys_jax(
+        capture_args(collection)
+        + [
+            "--nsys-jax-analysis",
+            "communication",
+            "--nsys-jax-analysis",
+            "summary",
+            "--",
+            "jax-nccl-test",
+        ]
+    )
+
+
+process_counts_to_test = []
+device_count = visible_device_count()
+if device_count >= 2:
+    # Use two processes with GPUS_PER_NODE/2 GPUs per process in the hope that
+    # this will flush out more bugs than process-per-node or process-per-GPU.
+    process_counts_to_test.append(2)
+if device_count >= 3:
+    process_counts_to_test.append(device_count)
+
+
+@pytest.mark.parametrize("process_count", process_counts_to_test)
+@pytest.mark.parametrize("collection", ["full", "partial"])
+def test_jax_nccl_multi_process(monkeypatch, process_count, collection):
+    assert device_count % process_count == 0, (device_count, process_count)
+    gpus_per_process = device_count // process_count
+    set_env(monkeypatch)
+    outputs = multi_process_nsys_jax(
+        process_count,
+        lambda rank: capture_args(collection)
+        + [
+            "--",
+            "jax-nccl-test",
+            "--process-id",
+            str(rank),
+            "--process-count",
+            str(process_count),
+            "--coordinator-address",
+            "127.0.0.1:12345",
+            "--gpus-per-process",
+            str(gpus_per_process),
+            "--distributed",
+        ],
+    )
+    combined_output = tempfile.NamedTemporaryFile(suffix=".zip")
+    subprocess.run(
+        [
+            "nsys-jax-combine",
+            "--force-overwrite",
+            "--output",
+            combined_output.name,
+            "--analysis",
+            "communication",
+            "--analysis",
+            "summary",
+        ]
+        + [output.name for output in outputs],
+        check=True,
+    )

--- a/.github/container/nsys_jax/tests/test_multi_process_program.py
+++ b/.github/container/nsys_jax/tests/test_multi_process_program.py
@@ -149,7 +149,7 @@ instances = [
     ("another_distinctively_named_function", 5, [0, 1], False),
     ("another_one_only_in_process_zero", 1, [0], False),
     ("only_in_process_one", 1, [1], False),
-    ("_psum", 2, [0, 1], True),  # sync_global_devices
+    ("different_stacktraces", 2, [0, 1], True),  # sync_global_devices
 ]
 
 
@@ -173,7 +173,7 @@ def test_combined_data(
         # that identical programs are compiled in both processes and that they are
         # mapped onto the same ProgramId values. Otherwise, there might be different
         # ProgramId values on each process.
-        assert len(remapped_ids) == 1
+        assert len(remapped_ids) == 1, combined_data.module["Name"].unique()
     module_data = combined_data.module.loc[list(remapped_ids)]
     assert (
         len(module_data.index.get_level_values("ProgramExecution").unique())
@@ -231,7 +231,7 @@ def get_stack_traces(hlo_module):
 
 @pytest.mark.parametrize(
     "module_name,should_be_consistent",
-    [("_psum", False), ("distinctively_named_function_with_lhs", True)],
+    [("different_stacktraces", False), ("distinctively_named_function_with_lhs", True)],
 )
 def test_metadata_consistency(
     combined_data_and_path, module_name, should_be_consistent

--- a/.github/workflows/_ci.yaml
+++ b/.github/workflows/_ci.yaml
@@ -335,11 +335,6 @@ jobs:
       TEST_NAME: nsys-jax
       EXECUTE: |
         set -o pipefail
-        num_tests=0
-        num_failures=0
-        # Run the pytest-driven tests; failure is explicitly handled below so set +e to
-        # avoid an early abort here.
-        set +e
         docker run -i --shm-size=1g --gpus all \
           -v $PWD:/opt/output \
           ${{ needs.build-jax.outputs.DOCKER_TAG_FINAL }} \
@@ -350,81 +345,20 @@ jobs:
             test_path=$(python -c 'import importlib.resources; print(importlib.resources.files("nsys_jax").joinpath("..", "tests").resolve())')
             pytest --report-log=/opt/output/pytest-report.jsonl "${test_path}"
         EOF
-        set -e
-        GPUS_PER_NODE=$(nvidia-smi -L | grep -c '^GPU')
-        for mode in 1-process 2-process process-per-gpu; do
-          DOCKER="docker run --shm-size=1g --gpus all --env XLA_FLAGS=--xla_gpu_enable_command_buffer= --env XLA_PYTHON_CLIENT_MEM_FRACTION=0.85 -v ${PWD}:/opt/output ${{ needs.build-jax.outputs.DOCKER_TAG_FINAL }}"
-          if [[ "${mode}" == "1-process" ]]; then
-            PROCESS_COUNT=1
-            ARGS=""
-          elif [[ "${mode}" == "2-process" ]]; then
-            # Use two processes with GPUS_PER_NODE/2 GPUs per process in the hope that
-            # this will flush out more bugs than process-per-node or process-per-GPU.
-            PROCESS_COUNT=2
-            ARGS="--process-id RANK --process-count ${PROCESS_COUNT} --coordinator-address 127.0.0.1:12345 --gpus-per-process $((GPUS_PER_NODE/2)) --distributed"
-          else
-            PROCESS_COUNT=${GPUS_PER_NODE}
-            ARGS="--process-id RANK --process-count ${PROCESS_COUNT} --coordinator-address 127.0.0.1:12345 --gpus-per-process 1 --distributed"
-          fi
-          for collection in full partial; do
-            NSYS_JAX="nsys-jax"
-            if [[ "${mode}" == "1-process" ]]; then
-              # We will not run nsys-jax-combine, so run analyses eagerly
-              NSYS_JAX+=" --nsys-jax-analysis communication --nsys-jax-analysis summary"
-            fi
-            NSYS_JAX+=" --output=/opt/output/${mode}-${collection}-execution-%q{RANK}"
-            if [[ "${collection}" == "partial" ]]; then
-              NSYS_JAX+=" --capture-range=cudaProfilerApi --capture-range-end=stop"
-              # nvbug/4801401
-              NSYS_JAX+=" --sample=none"
-            fi
-            set +e
-            ${DOCKER} parallel-launch RANK ${PROCESS_COUNT} ${NSYS_JAX} \
-              -- jax-nccl-test ${ARGS} |& tee ${mode}-${collection}-execution.log
-            num_failures=$((num_failures + ($? != 0)))
-            set -e
-            num_tests=$((num_tests + 1))
-          done
-          if [[ "${mode}" != "1-process" ]]; then
-            # Run nsys-jax-combine
-            NSYS_JAX_COMBINE="nsys-jax-combine --analysis communication --analysis summary --output=/opt/output/${mode}-${collection}-execution.zip"
-            for (( i=0; i<PROCESS_COUNT; i++ )); do
-              NSYS_JAX_COMBINE+=" /opt/output/${mode}-${collection}-execution-${i}.zip"
-            done
-            set +e
-            ${DOCKER} ${NSYS_JAX_COMBINE} |& tee ${mode}-${collection}-execution-combine.log
-            num_failures=$((num_failures + ($? != 0)))
-            set -e
-            num_tests=$((num_tests + 1))
-          fi
-        done
-        ls -R .
-        echo "NSYS_JAX_TEST_COUNT=${num_tests}" >> $GITHUB_ENV
-        echo "NSYS_JAX_FAIL_COUNT=${num_failures}" >> $GITHUB_ENV
-        exit $num_failures
       STATISTICS_SCRIPT: |
         summary_line=$(tail -n1 test-nsys-jax.log)
         num_errors=$(echo $summary_line | grep -oE '[0-9]+ error' | awk '{print $1} END { if (!NR) print 0}')
         passed_tests=$(cat pytest-report.jsonl | jq -r 'select(."$report_type" == "TestReport" and .when == "call" and .outcome == "passed") | .outcome' | wc -l)
         failed_tests=$(cat pytest-report.jsonl | jq -r 'select(."$report_type" == "TestReport" and .when == "call" and .outcome == "failed") | .outcome' | wc -l)
-        total_tests=$(( NSYS_JAX_TEST_COUNT + passed_tests + failed_tests ))
-        num_passed=$(( passed_tests + NSYS_JAX_TEST_COUNT - NSYS_JAX_FAIL_COUNT ))
-        num_failed=$(( failed_tests + NSYS_JAX_FAIL_COUNT ))
+        total_tests=$(( passed_tests + failed_tests ))
         echo "TOTAL_TESTS=${total_tests}" >> $GITHUB_OUTPUT
         echo "ERRORS=${num_errors}" >> $GITHUB_OUTPUT
-        echo "PASSED_TESTS=${num_passed}" >> $GITHUB_OUTPUT
-        echo "FAILED_TESTS=${num_failed}" >> $GITHUB_OUTPUT
+        echo "PASSED_TESTS=${passed_tests}" >> $GITHUB_OUTPUT
+        echo "FAILED_TESTS=${failed_tests}" >> $GITHUB_OUTPUT
       ARTIFACTS: |
         # pytest-driven part
         test-nsys-jax.log
         pytest-report.jsonl
-        # nsys-jax logfiles
-        *process-*-execution.log
-        # nsys-jax output for the case that doesn't use nsys-jax-combine
-        1-process-*-execution-0.zip
-        # nsys-jax-combine output/logfiles
-        *process*-*-execution.zip
-        *-execution-combine.log
     secrets: inherit
 
   # test-nsys-jax generates several fresh .zip archive outputs by running nsys-jax with real GPU hardware; this test

--- a/.github/workflows/_ci.yaml
+++ b/.github/workflows/_ci.yaml
@@ -353,7 +353,7 @@ jobs:
         set -e
         GPUS_PER_NODE=$(nvidia-smi -L | grep -c '^GPU')
         for mode in 1-process 2-process process-per-gpu; do
-          DOCKER="docker run --shm-size=1g --gpus all --env XLA_FLAGS=--xla_gpu_enable_command_buffer= --env XLA_PYTHON_CLIENT_MEM_FRACTION=0.9 -v ${PWD}:/opt/output ${{ needs.build-jax.outputs.DOCKER_TAG_FINAL }}"
+          DOCKER="docker run --shm-size=1g --gpus all --env XLA_FLAGS=--xla_gpu_enable_command_buffer= --env XLA_PYTHON_CLIENT_MEM_FRACTION=0.85 -v ${PWD}:/opt/output ${{ needs.build-jax.outputs.DOCKER_TAG_FINAL }}"
           if [[ "${mode}" == "1-process" ]]; then
             PROCESS_COUNT=1
             ARGS=""

--- a/docs/nsys-jax.md
+++ b/docs/nsys-jax.md
@@ -94,9 +94,9 @@ The only XLA flag that `nsys-jax` will **overwrite** is `--xla_dump_to`, which s
 Protobuf metadata. `nsys-jax` additionally changes the default value of `--xla_dump_hlo_as_proto` (`true`), but will
 not modify this if it has been set explicitly.
 
-> **Note**: because the Protobuf metadata is written at compilation time, using the JAX persistent compilation cache
-> prevents it from being written reliably. Because of this `nsys-jax` sets `JAX_ENABLE_COMPILATION_CACHE` to `false` if
-> it is not explicitly set.
+> **Note**: older versions of `nsys-jax` used to override the default value of `JAX_ENABLE_COMPILATION_CACHE` to
+> `false` because older versions of XLA did not dump the Protobuf metadata when reading from the JAX persistent
+> compilation cache. Support for this was added to XLA in https://github.com/openxla/xla/pull/28928.
 
 After collecting the Nsight Systems profile, `nsys-jax` triggers two extra processing steps:
 - the `.nsys-rep` file is converted into a `.parquet` and a `.csv.xz` file for offline analysis


### PR DESCRIPTION
- Previously `nsys-jax` would set `JAX_ENABLE_COMPILATION_CACHE` to false by default, because deserialising from the cache did not write the metadata needed for offline profile analysis. This is no longer done, as https://github.com/openxla/xla/pull/28928 and https://github.com/openxla/xla/pull/30685 added support for dumping when deserializing.
- Fix `nsys-jax` tests that relied on JAX's `sync_global_devices` helper generating a JIT called `_psum`, which it doesn't anymore.
- Reduce `XLA_PYTHON_CLIENT_MEM_FRACTION` setting to make `jax-nccl-test` execution fit on 40GB A100 cards now NVLS is no longer disabled by default.
- Move `nsys-jax` tests that used to be orchestrated manually in the GitHub Actions YAML to be `pytest` tests.