### PR TITLE
Re-add google-jetstream dependency for infer workloads

### DIFF
--- a/.github/container/Dockerfile.maxtext
+++ b/.github/container/Dockerfile.maxtext
@@ -19,6 +19,13 @@ EOF
 RUN <<"EOF" bash -ex -o pipefail
 echo "-e file://${SRC_PATH_MAXTEXT}" >> /opt/pip-tools.d/requirements-maxtext.in
 echo "-r ${SRC_PATH_MAXTEXT}/src/dependencies/requirements/base_requirements/requirements.txt" >> /opt/pip-tools.d/requirements-maxtext.in
+
+# MaxText's base_requirements/requirements.txt (above) does not include google-jetstream,
+# but inference code paths (maxtext.inference.maxengine, maxtext.input_pipeline.packing.prefill_packing)
+# import the `jetstream` package at module load time and DECOUPLE_GCLOUD=TRUE does not
+# unblock prefill_packing. Now re-add this dependency
+grep -E '^google-jetstream' ${SRC_PATH_MAXTEXT}/src/dependencies/requirements/requirements.txt \
+  >> /opt/pip-tools.d/requirements-maxtext.in
 EOF
 
 RUN <<"EOF" bash -exuo pipefail


### PR DESCRIPTION
MaxText's base_requirements/requirements.txt does not include `google-jetstream`, but inference code paths (`maxtext.inference.maxengine`, `maxtext.input_pipeline.packing.prefill_packing`) import the `jetstream` package.

We are now seeing failure:
```
0:   File "<frozen runpy>", line 198, in _run_module_as_main
0:   File "<frozen runpy>", line 88, in _run_code
0:   File "/opt/maxtext/src/maxtext/inference/inference_microbenchmark.py", line 27, in <module>
0:     from maxtext.inference.maxengine import maxengine
0:   File "/opt/maxtext/src/maxtext/inference/maxengine/maxengine.py", line 52, in <module>
0:     config_lib, engine_api, token_utils, tokenizer_api, _token_params_ns = jetstream()
0:                                                                            ^^^^^^^^^^^
0:   File "/opt/maxtext/src/maxtext/common/gcloud_stub.py", line 223, in jetstream
0:     if importlib.util.find_spec(mod) is None:
0:        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
0:   File "<frozen importlib.util>", line 92, in find_spec
0: ModuleNotFoundError: No module named 'jetstream'
```