### PR TITLE
Make sure scale-training runs every 2 weeks

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -3,7 +3,7 @@ name: CI
 on:
   schedule:
     - cron: '30 9 * * *' # Pacific Time 01:30 AM in UTC
-    - cron: '0 0 * * 6' #midnight every Saturday UTC for scale-training
+    - cron: '0 0 * * 6' # midnight every Saturday UTC; workflow gates to biweekly scale-training runs
   pull_request:
     types:
       - opened
@@ -72,6 +72,7 @@ permissions:
 
 env:
   DEFAULT_MANIFEST_ARTIFACT_NAME: bumped-manifest
+  SCALE_TRAINING_BIWEEKLY_ANCHOR_BUILD_DATE: 2026-04-17
 
 jobs:
 
@@ -85,6 +86,7 @@ jobs:
       MANIFEST_BRANCH: ${{ steps.manifest-branch.outputs.MANIFEST_BRANCH }}
       MERGE_BUMPED_MANIFEST: ${{ steps.manifest-branch.outputs.MERGE_BUMBED_MANIFEST }}
       CUDA_IMAGE: ${{ steps.cuda-image.outputs.CUDA_IMAGE }}
+      SHOULD_RUN_WORKFLOW: ${{ steps.run-type.outputs.SHOULD_RUN_WORKFLOW }}
       IS_SCALE_TRAINING: ${{ steps.run-type.outputs.IS_SCALE_TRAINING }}
       SUFFIX: ${{ steps.run-type.outputs.SUFFIX }}
     steps:
@@ -154,11 +156,33 @@ jobs:
 
       - name: Determine if scale-training run
         id: run-type
+        shell: bash -x -e {0}
         run: |
-          if [[ "${{ github.event.schedule }}" == "0 0 * * 6" || "${{ inputs.SCALE_TRAINING }}" == "true" ]]; then
+          SCALE_TRAINING_SCHEDULE='0 0 * * 6'
+
+          if [[ "${{ inputs.SCALE_TRAINING }}" == "true" ]]; then
+            echo "Manual scale-training run requested"
+            echo "SHOULD_RUN_WORKFLOW=true" >> $GITHUB_OUTPUT
             echo "IS_SCALE_TRAINING=true" >> $GITHUB_OUTPUT
             echo "SUFFIX=-scale-training" >> $GITHUB_OUTPUT
+          elif [[ "${{ github.event.schedule }}" == "${SCALE_TRAINING_SCHEDULE}" ]]; then
+            anchor_epoch=$(date -u -d "${{ env.SCALE_TRAINING_BIWEEKLY_ANCHOR_BUILD_DATE }}" +%s)
+            build_epoch=$(date -u -d "${{ steps.date.outputs.BUILD_DATE }}" +%s)
+            days_since_anchor=$(( (build_epoch - anchor_epoch) / 86400 ))
+
+            if (( days_since_anchor >= 0 && days_since_anchor % 14 == 0 )); then
+              echo "Scheduled biweekly scale-training run for build date ${{ steps.date.outputs.BUILD_DATE }}"
+              echo "SHOULD_RUN_WORKFLOW=true" >> $GITHUB_OUTPUT
+              echo "IS_SCALE_TRAINING=true" >> $GITHUB_OUTPUT
+              echo "SUFFIX=-scale-training" >> $GITHUB_OUTPUT
+            else
+              echo "Skipping off-week scale-training schedule for build date ${{ steps.date.outputs.BUILD_DATE }}"
+              echo "SHOULD_RUN_WORKFLOW=false" >> $GITHUB_OUTPUT
+              echo "IS_SCALE_TRAINING=false" >> $GITHUB_OUTPUT
+              echo "SUFFIX=" >> $GITHUB_OUTPUT
+            fi
           else
+            echo "SHOULD_RUN_WORKFLOW=true" >> $GITHUB_OUTPUT
             echo "IS_SCALE_TRAINING=false" >> $GITHUB_OUTPUT
             echo "SUFFIX=" >> $GITHUB_OUTPUT
           fi
@@ -166,6 +190,7 @@ jobs:
 
   bump-manifest:
     needs: metadata
+    if: ${{ needs.metadata.outputs.SHOULD_RUN_WORKFLOW == 'true' }}
     runs-on: ubuntu-22.04
     outputs:
       SOURCE_URLREFS: ${{ steps.source-urlrefs.outputs.SOURCE_URLREFS }}
@@ -241,15 +266,13 @@ jobs:
 
           # for scale training we need a specific XLA ref
           if [[ "${{ needs.metadata.outputs.IS_SCALE_TRAINING }}" == "true" ]]; then
-            TAG_INFO=$(python3 .github/workflows/scripts/extract_commits.py)
-            echo ${TAG_INFO} | jq
-            XLA_SHA=$(jq -r '.commit.sha' <<< "$TAG_INFO")
-            urlrefs=$(echo "$urlrefs" | jq -c ". + {\"XLA\": \"https://github.com/sfvaroglu/xla#${XLA_SHA}\"}")
-            JAX_COMMIT=$(jq -r '.name | split("-") | last' <<< "$TAG_INFO")
-            urlrefs=$(echo "$urlrefs" | jq -c ". + {\"JAX\": \"https://github.com/jax-ml/jax#${JAX_COMMIT}\"}")
+            BRANCH_INFO=$(python3 .github/workflows/scripts/extract_commits.py)
+            echo ${BRANCH_INFO} | jq
+            XLA_BRANCH=$(jq -r '.name' <<< "$BRANCH_INFO")
+            XLA_SHA=$(jq -r '.commit.sha' <<< "$BRANCH_INFO")
+            urlrefs=$(echo "$urlrefs" | jq -c ". + {\"XLA\": \"https://github.com/openxla/xla.git#${XLA_SHA}\"}")
 
-            echo "Using XLA sha ${XLA_SHA} for scale-training run"
-            echo "Using JAX commit ${JAX_COMMIT} for scale-training run"
+            echo "Using XLA branch ${XLA_BRANCH} at sha ${XLA_SHA} for scale-training run"
           fi
           echo "SOURCE_URLREFS=${urlrefs}" >> $GITHUB_OUTPUT
           echo "Final URLREF going to be used"
@@ -257,6 +280,7 @@ jobs:
 
   amd64:
     needs: [metadata, bump-manifest]
+    if: ${{ needs.metadata.outputs.SHOULD_RUN_WORKFLOW == 'true' }}
     uses: ./.github/workflows/_ci.yaml
     with:
       ARCHITECTURE: amd64
@@ -269,6 +293,7 @@ jobs:
 
   arm64:
     needs: [metadata, bump-manifest]
+    if: ${{ needs.metadata.outputs.SHOULD_RUN_WORKFLOW == 'true' }}
     uses: ./.github/workflows/_ci.yaml
     with:
       ARCHITECTURE: arm64
@@ -282,7 +307,7 @@ jobs:
   # Only merge if everything succeeds
   merge-new-manifest:
     runs-on: ubuntu-22.04
-    if: ${{ !cancelled() && needs.metadata.outputs.MERGE_BUMPED_MANIFEST == 'true' && needs.metadata.outputs.MANIFEST_BRANCH != github.sha }}
+    if: ${{ !cancelled() && needs.metadata.outputs.SHOULD_RUN_WORKFLOW == 'true' && needs.metadata.outputs.MERGE_BUMPED_MANIFEST == 'true' && needs.metadata.outputs.MANIFEST_BRANCH != github.sha }}
     needs:
       - metadata
       - amd64
@@ -393,7 +418,7 @@ jobs:
 
   make-publish-configs:
     runs-on: ubuntu-22.04
-    if:  ${{ !cancelled() }}
+    if:  ${{ !cancelled() && needs.metadata.outputs.SHOULD_RUN_WORKFLOW == 'true' }}
     env:
       MEALKIT_IMAGE_REPO: ${{ needs.metadata.outputs.PUBLISH == 'true' && 'jax-mealkit' || 'mock-jax-mealkit' }}
       FINAL_IMAGE_REPO: ${{ needs.metadata.outputs.PUBLISH == 'true' && 'jax' || 'mock-jax' }}
@@ -482,7 +507,7 @@ jobs:
     needs:
       - metadata
       - make-publish-configs
-    if:  ${{ !cancelled() && needs.make-publish-configs.outputs.PUBLISH_CONFIGS.config != '{"config":[]}' }}
+    if:  ${{ !cancelled() && needs.metadata.outputs.SHOULD_RUN_WORKFLOW == 'true' && needs.make-publish-configs.outputs.PUBLISH_CONFIGS.config != '{"config":[]}' }}
     strategy:
       fail-fast: false
       matrix: ${{ fromJson(needs.make-publish-configs.outputs.PUBLISH_CONFIGS) }}
@@ -498,7 +523,7 @@ jobs:
 
   finalize:
     needs: [metadata, amd64, arm64, publish-containers]
-    if: "!cancelled()"
+    if: ${{ !cancelled() && needs.metadata.outputs.SHOULD_RUN_WORKFLOW == 'true' }}
     uses: ./.github/workflows/_finalize.yaml
     with:
       BUILD_DATE: ${{ needs.metadata.outputs.BUILD_DATE }}

--- a/.github/workflows/scripts/extract_commits.py
+++ b/.github/workflows/scripts/extract_commits.py
@@ -1,10 +1,10 @@
 import json
 import os
-import re
+import urllib.parse
 import urllib.request
 
 OWNER, REPO = "openxla", "xla"
-BRANCH_PATTERN = re.compile(r"^nv-staging/(\d{4}-\d{2}-\d{2})$")
+BRANCH_NAME = "nv-staging/latest"
 
 
 def return_json_from_url(url: str) -> dict:
@@ -22,43 +22,15 @@ def return_json_from_url(url: str) -> dict:
     return json.loads(data)
 
 
-def branch_date(branch_name: str) -> str:
-    """Extract the ISO date suffix from an nv-staging branch name."""
-    match = BRANCH_PATTERN.match(branch_name)
-    if match is None:
-        raise ValueError(f"Unexpected branch name: {branch_name}")
-    return match.group(1)
-
-
 H = {
     "Authorization": f"Bearer {os.environ['GH_TOKEN']}",
     "Accept": "application/vnd.github+json",
     "X-GitHub-Api-Version": "2022-11-28",
 }
 
-
-branches = []
-page = 1
-# here we're analysing the pages and retrieve the branches
-while True:
-    batch = return_json_from_url(
-        f"https://api.github.com/repos/{OWNER}/{REPO}/branches?per_page=100&page={page}"
-    )
-    if not batch:
-        break
-    branches.extend(batch)
-    page += 1
-
-matching_branches = [
-    branch for branch in branches if BRANCH_PATTERN.match(branch["name"]) is not None
-]
-
-if not matching_branches:
-    print("No nv-staging branches found in the repository.")
-    exit(1)
-
-# sort the branches by the date embedded in the branch name
-matching_branches.sort(key=lambda branch: branch_date(branch["name"]), reverse=True)
-latest = matching_branches[0]
+encoded_branch = urllib.parse.quote(BRANCH_NAME, safe="")
+latest = return_json_from_url(
+    f"https://api.github.com/repos/{OWNER}/{REPO}/branches/{encoded_branch}"
+)
 # return to the gha
 print(json.dumps({"name": latest["name"], "commit": {"sha": latest["commit"]["sha"]}}))

--- a/.github/workflows/scripts/extract_commits.py
+++ b/.github/workflows/scripts/extract_commits.py
@@ -1,8 +1,10 @@
 import json
 import os
+import re
 import urllib.request
 
-OWNER, REPO = "sfvaroglu", "xla"
+OWNER, REPO = "openxla", "xla"
+BRANCH_PATTERN = re.compile(r"^nv-staging/(\d{4}-\d{2}-\d{2})$")
 
 
 def return_json_from_url(url: str) -> dict:
@@ -20,16 +22,12 @@ def return_json_from_url(url: str) -> dict:
     return json.loads(data)
 
 
-def commit_date(sha: str) -> str:
-    """Return the commit date for a given commit sha
-    Args:
-        sha (str): The commit sha
-    Returns:
-        str: The commit date in ISO format
-    """
-    url = f"https://api.github.com/repos/{OWNER}/{REPO}/commits/{sha}"
-    commit_data = return_json_from_url(url)
-    return commit_data["commit"]["committer"]["date"]
+def branch_date(branch_name: str) -> str:
+    """Extract the ISO date suffix from an nv-staging branch name."""
+    match = BRANCH_PATTERN.match(branch_name)
+    if match is None:
+        raise ValueError(f"Unexpected branch name: {branch_name}")
+    return match.group(1)
 
 
 H = {
@@ -39,24 +37,28 @@ H = {
 }
 
 
-tags = []
+branches = []
 page = 1
-# here we're analysing the pages and retrieve the tags
+# here we're analysing the pages and retrieve the branches
 while True:
     batch = return_json_from_url(
-        f"https://api.github.com/repos/{OWNER}/{REPO}/tags?per_page=100&page={page}"
+        f"https://api.github.com/repos/{OWNER}/{REPO}/branches?per_page=100&page={page}"
     )
     if not batch:
         break
-    tags.extend(batch)
+    branches.extend(batch)
     page += 1
 
-if not tags:
-    print("No tags found in the repository.")
+matching_branches = [
+    branch for branch in branches if BRANCH_PATTERN.match(branch["name"]) is not None
+]
+
+if not matching_branches:
+    print("No nv-staging branches found in the repository.")
     exit(1)
 
-# sort the tags by commit date
-tags.sort(key=lambda tag: commit_date(tag["commit"]["sha"]), reverse=True)
-latest = tags[0]
+# sort the branches by the date embedded in the branch name
+matching_branches.sort(key=lambda branch: branch_date(branch["name"]), reverse=True)
+latest = matching_branches[0]
 # return to the gha
 print(json.dumps({"name": latest["name"], "commit": {"sha": latest["commit"]["sha"]}}))


### PR DESCRIPTION
- We want to run the scale-training every 2 weeks
- We won't target Sevin's XLA, but upstream XLA. In particular, there will be a `nv-staging/YYYY-MM-DD` branch
- Since we can't have in the CI a crontab simple enough to say:  "every 2 weeks", we anchor last Friday as the initial date to compare against.