### PR TITLE
Add TransformerEngine test triton dependency

### DIFF
--- a/.github/workflows/_ci.yaml
+++ b/.github/workflows/_ci.yaml
@@ -306,7 +306,7 @@ jobs:
 
             mkdir -p /opt/output;
 
-            pip install pytest-reportlog pytest-xdist;
+            pip install pytest-reportlog pytest-xdist triton;
             nvidia-cuda-mps-control -d;
             export TE_PATH=\${SRC_PATH_TRANSFORMER_ENGINE};
 


### PR DESCRIPTION
E.g. in [L0_jax_unittest](https://github.com/NVIDIA/JAX-Toolbox/actions/runs/25162996572/job/73765580139#step:3:13942)