### PR TITLE
[jax-inference-offloading] update CUDA 13 vLLM/PyTorch stack and replace stale CI with 1B smoke

### DIFF
--- a/.github/actions/build-container/action.yml
+++ b/.github/actions/build-container/action.yml
@@ -66,6 +66,10 @@ inputs:
     description: "Optional named build context to source from a runner registry for the final image handoff"
     required: false
     default: ""
+  require-nsys-jax-version-artifact:
+    description: "Whether this container build requires the nsys-jax version.py artifact"
+    required: false
+    default: "true"
 
 outputs:
   DOCKER_TAG_MEALKIT:
@@ -113,11 +117,13 @@ runs:
 
 
     - name: Download nsys-jax version.py
+      if: ${{ inputs.require-nsys-jax-version-artifact == 'true' && inputs.CONTAINER_NAME != 'jio' }}
       uses: actions/download-artifact@v8
       with:
         name: nsys-jax-version-file
 
     - name: Move version.py
+      if: ${{ inputs.require-nsys-jax-version-artifact == 'true' && inputs.CONTAINER_NAME != 'jio' }}
       shell: bash
       run: |
         ls

--- a/.github/actions/gke-xpk/action.yml
+++ b/.github/actions/gke-xpk/action.yml
@@ -265,7 +265,7 @@ runs:
         IFS=';' read -ra env_vars <<< "${envs_flat}"
         for env in "${env_vars[@]}"; do
             env=$(echo "${env}" | xargs)
-            [[ -n "${env}" ]] && args+=(--env="${env}")
+            [[ -n "${env}" ]] && args+=("--env=${env}")
         done
       fi
 
@@ -274,7 +274,7 @@ runs:
       else
         XPK_COMMAND="python xpk.py"
       fi
-      ${XPK_COMMAND} workload create ${args[@]} --command="${CMD}"
+      ${XPK_COMMAND} workload create "${args[@]}" --command="${CMD}"
 
   - name: Show JobSet manifest
     if: steps.check.outputs.online == 'true'

--- a/.github/actions/gke-xpk/action.yml
+++ b/.github/actions/gke-xpk/action.yml
@@ -205,8 +205,10 @@ runs:
           mkdir -p ${{ inputs.CONTAINER_OUTPUT_PATH }};"
 
       PRELUDE+="
-          export LD_LIBRARY_PATH=/opt/nvidia/nccl/lib:\${NCCL_LIB_DIR}:\${LD_LIBRARY_PATH};
-          env;
+          test -f \${NCCL_LIB_DIR}/nccl-env-profile.sh && NCCL_LIB_DIR=\${NCCL_LIB_DIR} . \${NCCL_LIB_DIR}/nccl-env-profile.sh;
+          export LD_LIBRARY_PATH=\${NCCL_LIB_DIR}:\${LD_LIBRARY_PATH};
+          export NCCL_TUNER_CONFIG_PATH=\${NCCL_LIB_DIR}/a3plus_tuner_config.textproto;
+          export NCCL_SHIMNET_GUEST_CONFIG_CHECKER_CONFIG_FILE=\${NCCL_LIB_DIR}/a3plus_guest_config.textproto;
       "
 
       # gsutil command to export logs from container's /opt/output to bucket
@@ -449,4 +451,3 @@ runs:
     shell: bash -x -u {0}
     run: |
       sudo rm -rf ${JOBSET_NAME}
-

--- a/.github/gke-workflow/xpk/v1.0.0/tcpxo_decorator.patch
+++ b/.github/gke-workflow/xpk/v1.0.0/tcpxo_decorator.patch
@@ -1,5 +1,5 @@
 diff --git a/src/xpk/core/workload_decorators/tcpxo_decorator.py b/src/xpk/core/workload_decorators/tcpxo_decorator.py
-index 93a2c0b..4a701f3 100644
+index 93a2c0b..d380def 100644
 --- a/src/xpk/core/workload_decorators/tcpxo_decorator.py
 +++ b/src/xpk/core/workload_decorators/tcpxo_decorator.py
 @@ -146,7 +146,8 @@ def add_tcpxo_daemon_container(job_manifest):
@@ -29,7 +29,7 @@ index 93a2c0b..4a701f3 100644
        )
        container['env'].append({
            'name': 'NCCL_FASTRAK_LLCM_DEVICE_DIRECTORY',
-@@ -176,7 +181,7 @@ def update_gpu_containers(job_manifest):
+@@ -176,8 +181,11 @@ def update_gpu_containers(job_manifest):
            {'name': 'aperture-devices', 'mountPath': '/dev/aperture_devices'}
        )
        container['volumeMounts'].append(
@@ -38,3 +38,7 @@ index 93a2c0b..4a701f3 100644
        )
        container['volumeMounts'].append(
            {'name': 'dshm', 'mountPath': '/dev/shm'}
+       )
++      container['env'].append(
++          {'name': 'HF_TOKEN', 'valueFrom': {'secretKeyRef': {'name': 'hf-token-secret', 'key': 'token'}}}
++      )

--- a/.github/workflows/jax-vllm-offloading-gke-grpo.yml
+++ b/.github/workflows/jax-vllm-offloading-gke-grpo.yml
@@ -24,17 +24,6 @@ jobs:
     steps:
     - uses: actions/checkout@v6
 
-    - name: Login to GitHub Container Registry
-      uses: docker/login-action@v4
-      with:
-        registry: ghcr.io
-        username: ${{ github.repository_owner }}
-        password: ${{ secrets.GITHUB_TOKEN }}
-
-    - name: K8s GHCR store and delete token
-      id: store-token
-      uses: ./.github/actions/store-delete-k8s-ghcr
-
     - name: Format workload name
       id: workload-name
       run: |
@@ -46,8 +35,7 @@ jobs:
       uses: ./.github/actions/gke-xpk
       with:
         IMAGE: ${{ env.JAX_VLLM_OFFLOADING_IMAGE }}
-        IMAGE_PULL_SECRET_NAME: ${{ steps.store-token.outputs.token-name }}
-        WORKLOAD_NAME_PREFIX: ${{ steps.workload-name.outputs.WORKLOAD_NAME_PREFIX }}
+        NAME: ${{ steps.workload-name.outputs.WORKLOAD_NAME_PREFIX }}
         ENVS: |
           CUDA_VISIBLE_DEVICES=0,1,2,3,4,5,6,7;
           CUDA_DEVICE_ORDER=PCI_BUS_ID;
@@ -58,24 +46,18 @@ jobs:
           VLLM_DISTRIBUTED_BACKEND=mp;
           VLLM_ATTENTION_BACKEND=TRITON_ATTN;
           VLLM_LOAD_FORMAT=dummy;
-          NCCL_NET_PLUGIN=/opt/hpcx/nccl_rdma_sharp_plugin/lib/libnccl-net.so;
-          NCCL_TUNER_PLUGIN=none;
           MODEL_NAME=${{ matrix.model }};
           NCCL_CUMEM_ENABLE=0;
           NCCL_BUFFSIZE=16777216;
           XLA_FLAGS=--xla_gpu_enable_latency_hiding_scheduler=true --xla_gpu_enable_command_buffer=FUSION,CUBLAS,CUDNN,CUSTOM_CALL --xla_gpu_collective_permute_combine_threshold_bytes=8589934592 --xla_gpu_reduce_scatter_combine_threshold_bytes=8589934592 --xla_gpu_all_gather_combine_threshold_bytes=8589934592 --xla_gpu_all_reduce_combine_threshold_bytes=8589934592;
           TRANSFER_MODE=grouped;
           USE_POLYMORPHIC_MESH=0;
-          JAX_COORDINATOR_PORT=3389;
-          JAX_COORDINATOR_ADDRESS=\$(JOBSET_NAME)-\$(REPLICATED_JOB_NAME)-0-0.\$(JOBSET_NAME):\$(JAX_COORDINATOR_PORT);
           GATEWAY_PORT=50051;
           GATEWAY_URL=\$(JOBSET_NAME):\$(GATEWAY_PORT);
           OUTPUT_DIR=/opt/output;
 
         COMMAND: |
           set -x;
-
-          export LD_LIBRARY_PATH=/usr/lib/x86_64-linux-gnu:/usr/local/cuda-12.9/compat/lib.real:\${LD_LIBRARY_PATH};
 
           pip install tensorflow_datasets;
 
@@ -102,3 +84,5 @@ jobs:
 
           wait \${PIDS[@]};
           EXIT_CODE=\$PIPESTATUS;
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        NVCR_TOKEN: ${{ secrets.NVCR_TOKEN }}

--- a/.github/workflows/jax-vllm-offloading-gke-transfer.yml
+++ b/.github/workflows/jax-vllm-offloading-gke-transfer.yml
@@ -24,17 +24,6 @@ jobs:
     steps:
     - uses: actions/checkout@v6
 
-    - name: Login to GitHub Container Registry
-      uses: docker/login-action@v4
-      with:
-        registry: ghcr.io
-        username: ${{ github.repository_owner }}
-        password: ${{ secrets.GITHUB_TOKEN }}
-
-    - name: K8s GHCR store and delete token
-      id: store-token
-      uses: ./.github/actions/store-delete-k8s-ghcr
-
     - name: Format workload name
       id: workload-name
       run: |
@@ -46,8 +35,7 @@ jobs:
       uses: ./.github/actions/gke-xpk
       with:
         IMAGE: ${{ env.JAX_VLLM_OFFLOADING_IMAGE }}
-        IMAGE_PULL_SECRET_NAME: ${{ steps.store-token.outputs.token-name }}
-        WORKLOAD_NAME_PREFIX: ${{ steps.workload-name.outputs.WORKLOAD_NAME_PREFIX }}
+        NAME: ${{ steps.workload-name.outputs.WORKLOAD_NAME_PREFIX }}
         ENVS: |
           CUDA_VISIBLE_DEVICES=0,1,2,3,4,5,6,7;
           CUDA_DEVICE_ORDER=PCI_BUS_ID;
@@ -59,22 +47,16 @@ jobs:
           VLLM_ATTENTION_BACKEND=TRITON_ATTN;
           VLLM_LOAD_FORMAT=dummy;
           MODEL_NAME=${{ matrix.model }};
-          NCCL_NET_PLUGIN=/opt/hpcx/nccl_rdma_sharp_plugin/lib/libnccl-net.so;
-          NCCL_TUNER_PLUGIN=none;
           NCCL_CUMEM_ENABLE=0;
           NCCL_BUFFSIZE=16777216;
           XLA_FLAGS=--xla_gpu_enable_latency_hiding_scheduler=true --xla_gpu_enable_command_buffer=FUSION,CUBLAS,CUDNN,CUSTOM_CALL --xla_gpu_collective_permute_combine_threshold_bytes=8589934592 --xla_gpu_reduce_scatter_combine_threshold_bytes=8589934592 --xla_gpu_all_gather_combine_threshold_bytes=8589934592 --xla_gpu_all_reduce_combine_threshold_bytes=8589934592;
           TRANSFER_MODE=grouped;
           USE_POLYMORPHIC_MESH=0;
-          JAX_COORDINATOR_PORT=3389;
-          JAX_COORDINATOR_ADDRESS=\$(JOBSET_NAME)-\$(REPLICATED_JOB_NAME)-0-0.\$(JOBSET_NAME):\$(JAX_COORDINATOR_PORT);
           GATEWAY_PORT=50051;
           GATEWAY_URL=\$(JOBSET_NAME):\$(GATEWAY_PORT);
           OUTPUT_DIR=/opt/output;
         COMMAND: |
           set -x;
-
-          export LD_LIBRARY_PATH=/usr/lib/x86_64-linux-gnu:/usr/local/cuda-12.9/compat/lib.real:\${LD_LIBRARY_PATH};
 
           python -c 'import jax; jax.distributed.initialize(); print(jax.devices()); print(jax.local_devices()); assert jax.process_count() > 1; assert len(jax.devices()) > len(jax.local_devices());';
 
@@ -97,3 +79,5 @@ jobs:
 
           wait \${PIDS[@]};
           EXIT_CODE=\$PIPESTATUS;
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        NVCR_TOKEN: ${{ secrets.NVCR_TOKEN }}

--- a/.github/workflows/jax-vllm-offloading.yml
+++ b/.github/workflows/jax-vllm-offloading.yml
@@ -230,37 +230,41 @@ jobs:
       PUBLISH_BADGE: ${{ needs.metadata.outputs.PUBLISH == 'true' }}
     secrets: inherit
 
-  jio-single-controller-gke-smoke:
+  jio-decoupled-sync-8b-gke-smoke:
     needs: amd64
     runs-on: gke-a3mega
     steps:
     - uses: actions/checkout@v6
 
-    - name: Run JIO single-controller smoke
+    - name: Run JIO decoupled sync 8B smoke
       uses: ./.github/actions/gke-xpk
       with:
-        NAME: jio-sc-smoke
+        NAME: jio-dec-sync-8b
         IMAGE: ${{ needs.amd64.outputs.DOCKER_TAG_FINAL }}
         NUM_NODES: 1
         ENVS: |
           CUDA_VISIBLE_DEVICES=0,1,2,3;
-          MODEL_NAME=meta-llama/Llama-3.2-1B-Instruct;
+          JIO_RESPONSE_TOPIC=inference/results/shared;
+          MODEL_NAME=meta-llama/Llama-3.1-8B-Instruct;
           NCCL_CUMEM_ENABLE=0;
+          NCCL_DEBUG=INFO;
+          NCCL_DEBUG_SUBSYS=INIT,ENV,NET;
         COMMAND: |
           set -x;
-          cd /opt/jtbx/jax-inference-offloading/examples/single_controller;
-          timeout --kill-after=10s 120s bash ./run_single_controller.sh \
-            --mode=sync \
-            --model-path=/Llama-3.2-1B-Instruct \
-            --param-mapping-path=../mappings/llama3_1b_param_mapping.json \
+          python -m pip install --upgrade huggingface-hub==1.17.0;
+          MODEL_PATH=\$(hf download \${MODEL_NAME} --quiet);
+          cd /opt/jtbx/jax-inference-offloading/examples/decoupled_synchronous;
+          timeout --kill-after=30s 900s bash ./decoupled_sync.sh \
+            --model-path=\${MODEL_PATH} \
+            --param-mapping-path=../mappings/llama3_8b_param_mapping.json \
             --num-iterations=1 \
             --transfer-mode=grouped \
             --n-gpus-vllm=2 \
             --n-gpus-jax=2 \
             --vllm-enforce-eager \
             --vllm-gpu-memory-utilization=0.7 \
-            --output-dir=/opt/output/jio-single-controller;
-          EXIT_CODE=$?;
+            --output-dir=/opt/output/jio-decoupled-sync-8b;
+          EXIT_CODE=\$?;
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         NVCR_TOKEN: ${{ secrets.NVCR_TOKEN }}
 

--- a/.github/workflows/jax-vllm-offloading.yml
+++ b/.github/workflows/jax-vllm-offloading.yml
@@ -68,7 +68,7 @@ jobs:
             ARCHITECTURE: amd64
             ARTIFACT_NAME: artifact-jio-build
             BADGE_FILENAME: badge-jio-build
-            BASE_IMAGE: nvcr.io/nvidia/cuda-dl-base:25.06-cuda12.9-devel-ubuntu24.04
+            BASE_IMAGE: nvcr.io/nvidia/cuda-dl-base:26.05-cuda13.2-devel-ubuntu24.04
             BUILD_DATE: ${{ needs.metadata.outputs.BUILD_DATE }}
             CONTAINER_NAME: jio
             DOCKERFILE: jax-inference-offloading/dockerfile/oss.dockerfile
@@ -95,7 +95,7 @@ jobs:
             ARCHITECTURE: arm64
             ARTIFACT_NAME: artifact-jio-build
             BADGE_FILENAME: badge-jio-build
-            BASE_IMAGE: nvcr.io/nvidia/cuda-dl-base:25.06-cuda12.9-devel-ubuntu24.04
+            BASE_IMAGE: nvcr.io/nvidia/cuda-dl-base:26.05-cuda13.2-devel-ubuntu24.04
             BUILD_DATE: ${{ needs.metadata.outputs.BUILD_DATE }}
             CONTAINER_NAME: jio
             DOCKERFILE: jax-inference-offloading/dockerfile/oss.dockerfile
@@ -235,12 +235,14 @@ jobs:
     needs: amd64
     with:
      JAX_VLLM_OFFLOADING_IMAGE: ${{ needs.amd64.outputs.DOCKER_TAG_FINAL }}
+    secrets: inherit
 
   grpo-gke-xpk:
     uses: ./.github/workflows/jax-vllm-offloading-gke-grpo.yml
     needs: amd64
     with:
      JAX_VLLM_OFFLOADING_IMAGE: ${{ needs.amd64.outputs.DOCKER_TAG_FINAL }}
+    secrets: inherit
 
   jax-vllm-offloading-transfer-eks:
     needs: amd64

--- a/.github/workflows/jax-vllm-offloading.yml
+++ b/.github/workflows/jax-vllm-offloading.yml
@@ -230,61 +230,98 @@ jobs:
       PUBLISH_BADGE: ${{ needs.metadata.outputs.PUBLISH == 'true' }}
     secrets: inherit
 
-  transfer-gke-xpk:
-    uses: ./.github/workflows/jax-vllm-offloading-gke-transfer.yml
+  jio-single-controller-gke-smoke:
     needs: amd64
-    with:
-     JAX_VLLM_OFFLOADING_IMAGE: ${{ needs.amd64.outputs.DOCKER_TAG_FINAL }}
-    secrets: inherit
-
-  grpo-gke-xpk:
-    uses: ./.github/workflows/jax-vllm-offloading-gke-grpo.yml
-    needs: amd64
-    with:
-     JAX_VLLM_OFFLOADING_IMAGE: ${{ needs.amd64.outputs.DOCKER_TAG_FINAL }}
-    secrets: inherit
-
-  jax-vllm-offloading-transfer-eks:
-    needs: amd64
-    runs-on: eks
-    env:
-      JOB_NAME: jax-vllm-offloading-${{ github.run_id }}
-      JAX_VLLM_OFFLOADING_IMAGE: ${{ needs.amd64.outputs.DOCKER_TAG_FINAL }}
-      MODEL: "meta-llama/Llama-3.1-8B-Instruct"
-
+    runs-on: gke-a3mega
     steps:
     - uses: actions/checkout@v6
 
-    - name: Login to GitHub Container Registry
-      uses: docker/login-action@v4
+    - name: Run JIO single-controller smoke
+      uses: ./.github/actions/gke-xpk
       with:
-        registry: ghcr.io
-        username: ${{ github.repository_owner }}
-        password: ${{ secrets.GITHUB_TOKEN }}
+        NAME: jio-sc-smoke
+        IMAGE: ${{ needs.amd64.outputs.DOCKER_TAG_FINAL }}
+        NUM_NODES: 1
+        ENVS: |
+          CUDA_VISIBLE_DEVICES=0,1,2,3;
+          MODEL_NAME=meta-llama/Llama-3.2-1B-Instruct;
+          NCCL_CUMEM_ENABLE=0;
+        COMMAND: |
+          set -x;
+          cd /opt/jtbx/jax-inference-offloading/examples/single_controller;
+          timeout --kill-after=10s 120s bash ./run_single_controller.sh \
+            --mode=sync \
+            --model-path=/Llama-3.2-1B-Instruct \
+            --param-mapping-path=../mappings/llama3_1b_param_mapping.json \
+            --num-iterations=1 \
+            --transfer-mode=grouped \
+            --n-gpus-vllm=2 \
+            --n-gpus-jax=2 \
+            --vllm-enforce-eager \
+            --vllm-gpu-memory-utilization=0.7 \
+            --output-dir=/opt/output/jio-single-controller;
+          EXIT_CODE=$?;
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        NVCR_TOKEN: ${{ secrets.NVCR_TOKEN }}
 
-    - name: K8s GHCR store and delete token
-      id: store-token
-      uses: ./.github/actions/store-delete-k8s-ghcr
-
-    - name: Configure jax-vllm job
-      run: |
-        yq -i '
-          # 1. Update the JobSet Name
-          .metadata.name = strenv(JOB_NAME)
-
-          # 2. Update Image (Applies to Gateway, vLLM, and JAX nodes)
-          | .spec.replicatedJobs[].template.spec.template.spec.containers[].image = strenv(JAX_VLLM_OFFLOADING_IMAGE)
-
-          # 3. Update Model Name (Finds the env var named "MODEL_NAME" and updates its value)
-          | (.spec.replicatedJobs[].template.spec.template.spec.containers[].env[] | select(.name == "MODEL_NAME").value) = strenv(MODEL)
-
-          # 4. Add imagePullSecrets to all replicatedJobs (Gateway, vLLM, and JAX nodes)
-          | .spec.replicatedJobs[].template.spec.template.spec.imagePullSecrets[].name = "${{ steps.store-token.outputs.token-name }}"
-        ' .github/eks-workflow-files/jio-eks/jio-template.yaml
-        git diff .github/eks-workflow-files/jio-eks/jio-template.yaml
-
-    - name: Apply jax-vllm offloading job to EKS cluster
-      uses: ./.github/actions/submit-delete-k8s-jobset
-      with:
-        jobset-config-file:  ".github/eks-workflow-files/jio-eks/jio-template.yaml"
-        jobset-name: ${{ env.JOB_NAME }}
+  # TODO: Port these legacy 8B/70B transfer, GRPO, and EKS checks to the
+  # current JIO example structure before re-enabling them.
+  #
+  # transfer-gke-xpk:
+  #   uses: ./.github/workflows/jax-vllm-offloading-gke-transfer.yml
+  #   needs: amd64
+  #   with:
+  #    JAX_VLLM_OFFLOADING_IMAGE: ${{ needs.amd64.outputs.DOCKER_TAG_FINAL }}
+  #   secrets: inherit
+  #
+  # grpo-gke-xpk:
+  #   uses: ./.github/workflows/jax-vllm-offloading-gke-grpo.yml
+  #   needs: amd64
+  #   with:
+  #    JAX_VLLM_OFFLOADING_IMAGE: ${{ needs.amd64.outputs.DOCKER_TAG_FINAL }}
+  #   secrets: inherit
+  #
+  # jax-vllm-offloading-transfer-eks:
+  #   needs: amd64
+  #   runs-on: eks
+  #   env:
+  #     JOB_NAME: jax-vllm-offloading-${{ github.run_id }}
+  #     JAX_VLLM_OFFLOADING_IMAGE: ${{ needs.amd64.outputs.DOCKER_TAG_FINAL }}
+  #     MODEL: "meta-llama/Llama-3.1-8B-Instruct"
+  #
+  #   steps:
+  #   - uses: actions/checkout@v6
+  #
+  #   - name: Login to GitHub Container Registry
+  #     uses: docker/login-action@v4
+  #     with:
+  #       registry: ghcr.io
+  #       username: ${{ github.repository_owner }}
+  #       password: ${{ secrets.GITHUB_TOKEN }}
+  #
+  #   - name: K8s GHCR store and delete token
+  #     id: store-token
+  #     uses: ./.github/actions/store-delete-k8s-ghcr
+  #
+  #   - name: Configure jax-vllm job
+  #     run: |
+  #       yq -i '
+  #         # 1. Update the JobSet Name
+  #         .metadata.name = strenv(JOB_NAME)
+  #
+  #         # 2. Update Image (Applies to Gateway, vLLM, and JAX nodes)
+  #         | .spec.replicatedJobs[].template.spec.template.spec.containers[].image = strenv(JAX_VLLM_OFFLOADING_IMAGE)
+  #
+  #         # 3. Update Model Name (Finds the env var named "MODEL_NAME" and updates its value)
+  #         | (.spec.replicatedJobs[].template.spec.template.spec.containers[].env[] | select(.name == "MODEL_NAME").value) = strenv(MODEL)
+  #
+  #         # 4. Add imagePullSecrets to all replicatedJobs (Gateway, vLLM, and JAX nodes)
+  #         | .spec.replicatedJobs[].template.spec.template.spec.imagePullSecrets[].name = "${{ steps.store-token.outputs.token-name }}"
+  #       ' .github/eks-workflow-files/jio-eks/jio-template.yaml
+  #       git diff .github/eks-workflow-files/jio-eks/jio-template.yaml
+  #
+  #   - name: Apply jax-vllm offloading job to EKS cluster
+  #     uses: ./.github/actions/submit-delete-k8s-jobset
+  #     with:
+  #       jobset-config-file:  ".github/eks-workflow-files/jio-eks/jio-template.yaml"
+  #       jobset-name: ${{ env.JOB_NAME }}

--- a/README.md
+++ b/README.md
@@ -281,7 +281,8 @@ Refer to this page [STAGING.md](https://github.com/openxla/xla/blob/nv-staging/l
 Staging releases:
 | Release date | Container | XLA branch (includes pending PRs) |
 | ------------------------------------- | -------------- |-------------- |
-| 2026-05-11 | [ghcr.io/nvidia/jax:jax-scale-training-2026-05-11](https://github.com/NVIDIA/JAX-Toolbox/pkgs/container/jax/856082965?tag=jax-scale-training-2026-05-11) | [5dfe2147](https://github.com/openxla/xla/blob/552b0a3ef06453c74de9f62f778a0f3a960d7e6d/STAGING.md)
+| 2026-05-30 | [ghcr.io/nvidia/jax:jax-scale-training-2026-05-30](https://github.com/NVIDIA/JAX-Toolbox/pkgs/container/jax/906936355?tag=jax-scale-training-2026-05-30) | [00de6b34](https://github.com/openxla/xla/blob/00de6b342f7f02f1b306121dab98706ae1d180b4)
+| 2026-05-11 | [ghcr.io/nvidia/jax:jax-scale-training-2026-05-11](https://github.com/NVIDIA/JAX-Toolbox/pkgs/container/jax/856082965?tag=jax-scale-training-2026-05-11) | [552b0a3e](https://github.com/openxla/xla/blob/552b0a3ef06453c74de9f62f778a0f3a960d7e6d/STAGING.md)
 | 2026-04-24 | [ghcr.io/nvidia/jax:jax-scale-training-2026-04-24](https://github.com/NVIDIA/JAX-Toolbox/pkgs/container/jax/820220988?tag=jax-scale-training-2026-04-24) | [5dfe2147](https://github.com/openxla/xla/blob/5dfe2147cbdd54b2fa1d76da817c64a1847373ca/STAGING.md)
 | 2026-04-18 | [ghcr.io/nvidia/jax:jax-scale-training-2026-04-18](https://github.com/NVIDIA/JAX-Toolbox/pkgs/container/jax/805313885?tag=jax-scale-training-2026-04-18) | [8147118](https://github.com/sfvaroglu/xla/tree/8147118a7b9707d26dcb747767a9c0dd9081325f)
 

--- a/jax-inference-offloading/dockerfile/cuda_package_skiplist.py
+++ b/jax-inference-offloading/dockerfile/cuda_package_skiplist.py
@@ -27,19 +27,33 @@ CUDA_LIB_DIRS = (
 # Package skiplist: these Python wheel packages only carry CUDA runtime payloads
 # that the CUDA DL base image already owns under /usr/local/cuda.
 PACKAGE_SKIPLIST = {
+    "nvidia-cublas": ("libcublas.so*",),
     "nvidia-cublas-cu13": ("libcublas.so*",),
+    "nvidia-cuda-cupti": ("libcupti.so*",),
     "nvidia-cuda-cupti-cu13": ("libcupti.so*",),
+    "nvidia-cuda-nvrtc": ("libnvrtc.so*",),
     "nvidia-cuda-nvrtc-cu13": ("libnvrtc.so*",),
+    "nvidia-cuda-runtime": ("libcudart.so.13*",),
     "nvidia-cuda-runtime-cu13": ("libcudart.so.13*",),
+    "nvidia-cudnn": ("libcudnn.so*",),
     "nvidia-cudnn-cu13": ("libcudnn.so*",),
+    "nvidia-cufft": ("libcufft.so*",),
     "nvidia-cufft-cu13": ("libcufft.so*",),
+    "nvidia-cufile": ("libcufile.so*",),
     "nvidia-cufile-cu13": ("libcufile.so*",),
+    "nvidia-curand": ("libcurand.so*",),
     "nvidia-curand-cu13": ("libcurand.so*",),
+    "nvidia-cusolver": ("libcusolver.so*",),
     "nvidia-cusolver-cu13": ("libcusolver.so*",),
+    "nvidia-cusparse": ("libcusparse.so*",),
     "nvidia-cusparse-cu13": ("libcusparse.so*",),
+    "nvidia-cusparselt": ("libcusparseLt.so*",),
     "nvidia-cusparselt-cu13": ("libcusparseLt.so*",),
+    "nvidia-nccl": ("libnccl.so*",),
     "nvidia-nccl-cu13": ("libnccl.so*",),
+    "nvidia-nvjitlink": ("libnvJitLink.so*",),
     "nvidia-nvjitlink-cu13": ("libnvJitLink.so*",),
+    "nvidia-nvtx": ("libnvToolsExt.so*",),
     "nvidia-nvtx-cu13": ("libnvToolsExt.so*",),
 }
 

--- a/jax-inference-offloading/dockerfile/cuda_package_skiplist.py
+++ b/jax-inference-offloading/dockerfile/cuda_package_skiplist.py
@@ -1,0 +1,189 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Filter CUDA wheel payload packages that are already provided by the base image."""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import email.message
+import fnmatch
+import os
+import pathlib
+import re
+import sys
+from dataclasses import dataclass
+
+
+CUDA_LIB_DIRS = (
+    "/usr/local/cuda/lib64",
+    "/usr/local/cuda/lib",
+    "/usr/local/cuda/targets/sbsa-linux/lib",
+    "/usr/local/cuda/targets/x86_64-linux/lib",
+)
+
+
+# Package skiplist: these Python wheel packages only carry CUDA runtime payloads
+# that the CUDA DL base image already owns under /usr/local/cuda.
+PACKAGE_SKIPLIST = {
+    "nvidia-cublas-cu13": ("libcublas.so*",),
+    "nvidia-cuda-cupti-cu13": ("libcupti.so*",),
+    "nvidia-cuda-nvrtc-cu13": ("libnvrtc.so*",),
+    "nvidia-cuda-runtime-cu13": ("libcudart.so.13*",),
+    "nvidia-cudnn-cu13": ("libcudnn.so*",),
+    "nvidia-cufft-cu13": ("libcufft.so*",),
+    "nvidia-cufile-cu13": ("libcufile.so*",),
+    "nvidia-curand-cu13": ("libcurand.so*",),
+    "nvidia-cusolver-cu13": ("libcusolver.so*",),
+    "nvidia-cusparse-cu13": ("libcusparse.so*",),
+    "nvidia-cusparselt-cu13": ("libcusparseLt.so*",),
+    "nvidia-nccl-cu13": ("libnccl.so*",),
+    "nvidia-nvjitlink-cu13": ("libnvJitLink.so*",),
+    "nvidia-nvtx-cu13": ("libnvToolsExt.so*",),
+}
+
+REQ_LINE_RE = re.compile(r"^([A-Za-z0-9_.-]+)==([^;\\\s]+)(.*)$")
+
+
+@dataclass(frozen=True)
+class SkippedPackage:
+    name: str
+    version: str
+    requirement: str
+
+
+def normalize_name(name: str) -> str:
+    return re.sub(r"[-_.]+", "-", name).lower()
+
+
+def dist_info_name(name: str) -> str:
+    return normalize_name(name).replace("-", "_")
+
+
+def find_library(pattern: str, lib_dirs: tuple[str, ...]) -> pathlib.Path | None:
+    for lib_dir in lib_dirs:
+        root = pathlib.Path(lib_dir)
+        if not root.exists():
+            continue
+        for path in root.iterdir():
+            if fnmatch.fnmatch(path.name, pattern):
+                return path
+    return None
+
+
+def verify_base_libraries(packages: list[SkippedPackage], lib_dirs: tuple[str, ...]) -> None:
+    missing: list[str] = []
+    seen: set[str] = set()
+    for package in packages:
+        normalized = normalize_name(package.name)
+        if normalized in seen:
+            continue
+        seen.add(normalized)
+        for pattern in PACKAGE_SKIPLIST[normalized]:
+            if find_library(pattern, lib_dirs) is None:
+                missing.append(f"{package.name}: {pattern}")
+    if missing:
+        joined = "\n  ".join(missing)
+        raise SystemExit(
+            "Cannot skip CUDA wheel payload packages because the base image is "
+            f"missing required libraries:\n  {joined}"
+        )
+
+
+def filter_requirements(input_path: pathlib.Path, output_path: pathlib.Path, skipped_path: pathlib.Path,
+                        lib_dirs: tuple[str, ...]) -> None:
+    skipped: list[SkippedPackage] = []
+    output_lines: list[str] = []
+
+    for line in input_path.read_text().splitlines(keepends=True):
+        match = REQ_LINE_RE.match(line.strip())
+        if match and normalize_name(match.group(1)) in PACKAGE_SKIPLIST:
+            skipped.append(
+                SkippedPackage(
+                    name=match.group(1),
+                    version=match.group(2),
+                    requirement=line.strip(),
+                )
+            )
+            output_lines.append(f"# skipped CUDA wheel payload: {line}")
+            continue
+        output_lines.append(line)
+
+    verify_base_libraries(skipped, lib_dirs)
+    output_path.write_text("".join(output_lines))
+    with skipped_path.open("w", newline="") as file:
+        writer = csv.writer(file)
+        writer.writerow(("name", "version", "requirement"))
+        for package in skipped:
+            writer.writerow((package.name, package.version, package.requirement))
+
+
+def marker_metadata(package: SkippedPackage) -> str:
+    message = email.message.Message()
+    message["Metadata-Version"] = "2.1"
+    message["Name"] = package.name
+    message["Version"] = package.version
+    message["Summary"] = "CUDA runtime payload supplied by the base image"
+    return str(message)
+
+
+def write_markers(skipped_path: pathlib.Path, site_packages: pathlib.Path) -> None:
+    with skipped_path.open(newline="") as file:
+        packages = [
+            SkippedPackage(name=row["name"], version=row["version"], requirement=row["requirement"])
+            for row in csv.DictReader(file)
+        ]
+
+    for package in packages:
+        dist_info = site_packages / f"{dist_info_name(package.name)}-{package.version}.dist-info"
+        dist_info.mkdir(parents=True, exist_ok=True)
+        (dist_info / "METADATA").write_text(marker_metadata(package))
+        (dist_info / "INSTALLER").write_text("cuda-package-skiplist\n")
+        (dist_info / "WHEEL").write_text(
+            "Wheel-Version: 1.0\n"
+            "Generator: cuda-package-skiplist\n"
+            "Root-Is-Purelib: true\n"
+            "Tag: py3-none-any\n"
+        )
+        (dist_info / "RECORD").write_text("")
+
+
+def default_site_packages() -> pathlib.Path:
+    import site
+
+    candidates = site.getsitepackages()
+    if not candidates:
+        raise SystemExit("Could not determine site-packages path")
+    return pathlib.Path(candidates[0])
+
+
+def main(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser()
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    filter_parser = subparsers.add_parser("filter")
+    filter_parser.add_argument("--input", type=pathlib.Path, required=True)
+    filter_parser.add_argument("--output", type=pathlib.Path, required=True)
+    filter_parser.add_argument("--skipped", type=pathlib.Path, required=True)
+    filter_parser.add_argument(
+        "--lib-dir",
+        action="append",
+        default=list(CUDA_LIB_DIRS),
+        help="CUDA library directory to inspect; may be provided more than once",
+    )
+
+    mark_parser = subparsers.add_parser("mark-installed")
+    mark_parser.add_argument("--skipped", type=pathlib.Path, required=True)
+    mark_parser.add_argument("--site-packages", type=pathlib.Path, default=None)
+
+    args = parser.parse_args(argv)
+    if args.command == "filter":
+        filter_requirements(args.input, args.output, args.skipped, tuple(args.lib_dir))
+    elif args.command == "mark-installed":
+        write_markers(args.skipped, args.site_packages or default_site_packages())
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/jax-inference-offloading/dockerfile/cuda_package_skiplist.py
+++ b/jax-inference-offloading/dockerfile/cuda_package_skiplist.py
@@ -72,23 +72,11 @@ def find_library(pattern: str, lib_dirs: tuple[str, ...]) -> pathlib.Path | None
     return None
 
 
-def verify_base_libraries(packages: list[SkippedPackage], lib_dirs: tuple[str, ...]) -> None:
-    missing: list[str] = []
-    seen: set[str] = set()
-    for package in packages:
-        normalized = normalize_name(package.name)
-        if normalized in seen:
-            continue
-        seen.add(normalized)
-        for pattern in PACKAGE_SKIPLIST[normalized]:
-            if find_library(pattern, lib_dirs) is None:
-                missing.append(f"{package.name}: {pattern}")
-    if missing:
-        joined = "\n  ".join(missing)
-        raise SystemExit(
-            "Cannot skip CUDA wheel payload packages because the base image is "
-            f"missing required libraries:\n  {joined}"
-        )
+def has_base_libraries(package_name: str, lib_dirs: tuple[str, ...]) -> bool:
+    return all(
+        find_library(pattern, lib_dirs) is not None
+        for pattern in PACKAGE_SKIPLIST[normalize_name(package_name)]
+    )
 
 
 def filter_requirements(input_path: pathlib.Path, output_path: pathlib.Path, skipped_path: pathlib.Path,
@@ -99,18 +87,19 @@ def filter_requirements(input_path: pathlib.Path, output_path: pathlib.Path, ski
     for line in input_path.read_text().splitlines(keepends=True):
         match = REQ_LINE_RE.match(line.strip())
         if match and normalize_name(match.group(1)) in PACKAGE_SKIPLIST:
-            skipped.append(
-                SkippedPackage(
-                    name=match.group(1),
-                    version=match.group(2),
-                    requirement=line.strip(),
-                )
+            package = SkippedPackage(
+                name=match.group(1),
+                version=match.group(2),
+                requirement=line.strip(),
             )
-            output_lines.append(f"# skipped CUDA wheel payload: {line}")
+            if has_base_libraries(package.name, lib_dirs):
+                skipped.append(package)
+                output_lines.append(f"# skipped CUDA wheel payload: {line}")
+            else:
+                output_lines.append(line)
             continue
         output_lines.append(line)
 
-    verify_base_libraries(skipped, lib_dirs)
     output_path.write_text("".join(output_lines))
     with skipped_path.open("w", newline="") as file:
         writer = csv.writer(file)

--- a/jax-inference-offloading/dockerfile/oss.dockerfile
+++ b/jax-inference-offloading/dockerfile/oss.dockerfile
@@ -55,7 +55,9 @@ ARG SUB_PATH_JIO
 ENV SRC_PATH_JIO=${BASE_PATH_JIO}/${SUB_PATH_JIO}
 
 # Check out source code
-RUN <<"EOF" bash -ex -o pipefail
+RUN --mount=type=ssh <<"EOF" bash -ex -o pipefail
+mkdir -p -m 0700 ~/.ssh
+ssh-keyscan github.com >> ~/.ssh/known_hosts
 git clone --no-checkout ${URL_JIO} ${BASE_PATH_JIO}
 pushd ${BASE_PATH_JIO}
 git sparse-checkout init --cone

--- a/jax-inference-offloading/dockerfile/oss.dockerfile
+++ b/jax-inference-offloading/dockerfile/oss.dockerfile
@@ -75,6 +75,7 @@ mkdir -p /opt/pip-tools.d
 pip freeze | grep wheel >> /opt/pip-tools.d/overrides.in
 echo "jax[cuda13-local,k8s]>=0.8.3,<0.9" >> /opt/pip-tools.d/requirements.in
 echo "-e file://${SRC_PATH_JIO}[checkpoint]" >> /opt/pip-tools.d/requirements.in
+echo "setuptools>=77.0.3,<81.0.0" >> /opt/pip-tools.d/requirements.in
 EOF
 
 ###############################################################################
@@ -88,7 +89,7 @@ RUN <<"EOF" bash -ex -o pipefail
 export PIP_INDEX_URL=https://download.pytorch.org/whl/cu130
 export PIP_EXTRA_INDEX_URL="https://flashinfer.ai/whl/cu130 https://pypi.org/simple"
 pushd /opt/pip-tools.d
-pip-compile -o requirements.txt $(ls requirements*.in) --constraint overrides.in
+pip-compile --allow-unsafe -o requirements.txt $(ls requirements*.in) --constraint overrides.in
 cuda-package-skiplist filter \
   --input requirements.txt \
   --output requirements.runtime.txt \

--- a/jax-inference-offloading/dockerfile/oss.dockerfile
+++ b/jax-inference-offloading/dockerfile/oss.dockerfile
@@ -14,14 +14,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-ARG BASE_IMAGE=nvcr.io/nvidia/cuda-dl-base:25.06-cuda12.9-devel-ubuntu24.04
+ARG BASE_IMAGE=nvcr.io/nvidia/cuda-dl-base:26.05-cuda13.2-devel-ubuntu24.04
 ARG URL_JIO=https://github.com/NVIDIA/JAX-Toolbox.git
 ARG REF_JIO=main
-ARG URL_TUNIX=https://github.com/google/tunix.git
-ARG REF_TUNIX=v0.1.5
 ARG BASE_PATH_JIO=/opt/jtbx
 ARG SUB_PATH_JIO=jax-inference-offloading
-ARG SRC_PATH_TUNIX=/opt/tunix
 
 ###############################################################################
 ## Install system dependencies and pip-tools
@@ -41,7 +38,7 @@ apt-get clean
 apt-get autoremove -y
 rm -rf /var/lib/apt/lists/*
 
-pip install pip-tools pip-mark-installed
+pip install pip-tools
 rm -rf ~/.cache/pip
 EOF
 
@@ -52,11 +49,8 @@ EOF
 FROM base AS mealkit
 ARG URL_JIO
 ARG REF_JIO
-ARG URL_TUNIX
-ARG REF_TUNIX
 ARG BASE_PATH_JIO
 ARG SUB_PATH_JIO
-ARG SRC_PATH_TUNIX
 
 ENV SRC_PATH_JIO=${BASE_PATH_JIO}/${SUB_PATH_JIO}
 
@@ -69,17 +63,14 @@ git sparse-checkout set ${SUB_PATH_JIO}
 git fetch origin ${REF_JIO}
 git checkout FETCH_HEAD
 popd
-git clone --branch ${REF_TUNIX} ${URL_TUNIX} ${SRC_PATH_TUNIX}
 EOF
 
 # Aggregate requirements for pip-tools
 RUN <<"EOF" bash -ex -o pipefail
 mkdir -p /opt/pip-tools.d
 pip freeze | grep wheel >> /opt/pip-tools.d/overrides.in
-echo "jax[cuda12_local,k8s]" >> /opt/pip-tools.d/requirements.in
-echo "-e file://${SRC_PATH_JIO}" >> /opt/pip-tools.d/requirements.in
-echo "-e file://${SRC_PATH_TUNIX}" >> /opt/pip-tools.d/requirements.in
-cat "${SRC_PATH_JIO}/examples/requirements.in" >> /opt/pip-tools.d/requirements.in
+echo "jax[cuda13_local,k8s]>=0.8.3,<0.9" >> /opt/pip-tools.d/requirements.in
+echo "-e file://${SRC_PATH_JIO}[checkpoint]" >> /opt/pip-tools.d/requirements.in
 EOF
 
 ###############################################################################
@@ -90,24 +81,11 @@ FROM mealkit AS final
 
 # Finalize installation
 RUN <<"EOF" bash -ex -o pipefail
-export PIP_INDEX_URL=https://download.pytorch.org/whl/cu129
-export PIP_EXTRA_INDEX_URL="https://flashinfer.ai/whl/cu129 https://pypi.org/simple"
 pushd /opt/pip-tools.d
 pip-compile -o requirements.txt $(ls requirements*.in) --constraint overrides.in
-# remove cuda wheels from install list since the container already has them
-sed -i 's/^nvidia-/# nvidia-/g' requirements.txt
-sed -i 's/# nvidia-nvshmem/nvidia-nvshmem/g' requirements.txt
 pip install --no-deps --src /opt -r requirements.txt
-# make pip happy about the missing torch dependencies
-pip-mark-installed nvidia-cublas-cu12 nvidia-cuda-cupti-cu12 \
-  nvidia-cuda-nvrtc-cu12 nvidia-cuda-runtime-cu12 nvidia-cudnn-cu12 \
-  nvidia-cufft-cu12 nvidia-cufile-cu12 nvidia-curand-cu12 nvidia-cusolver-cu12 \
-  nvidia-cusparse-cu12 nvidia-cusparselt-cu12 nvidia-nccl-cu12 \
-  nvidia-nvjitlink-cu12 nvidia-nvtx-cu12
 popd
 rm -rf ~/.cache/*
-# perform a general cleaning of tensorflow libraries that are conflicting with nccl
-pip uninstall -y tensorflow_cpu tensorflow-datasets tensorflow-metadata
 EOF
 
 

--- a/jax-inference-offloading/dockerfile/oss.dockerfile
+++ b/jax-inference-offloading/dockerfile/oss.dockerfile
@@ -71,7 +71,7 @@ EOF
 # Aggregate requirements for pip-tools
 RUN <<"EOF" bash -ex -o pipefail
 mkdir -p /opt/pip-tools.d
-pip freeze | grep wheel >> /opt/pip-tools.d/overrides.in
+pip freeze --all | grep wheel >> /opt/pip-tools.d/overrides.in
 echo "jax[cuda13-local,k8s]>=0.8.3,<0.9" >> /opt/pip-tools.d/requirements.in
 echo "-e file://${SRC_PATH_JIO}[checkpoint]" >> /opt/pip-tools.d/requirements.in
 echo "setuptools>=77.0.3,<81.0.0" >> /opt/pip-tools.d/requirements.in

--- a/jax-inference-offloading/dockerfile/oss.dockerfile
+++ b/jax-inference-offloading/dockerfile/oss.dockerfile
@@ -42,6 +42,8 @@ pip install pip-tools
 rm -rf ~/.cache/pip
 EOF
 
+COPY --chmod=755 dockerfile/cuda_package_skiplist.py /usr/local/bin/cuda-package-skiplist
+
 ###############################################################################
 ## Download source and configure pip-tools
 ###############################################################################
@@ -71,7 +73,7 @@ EOF
 RUN <<"EOF" bash -ex -o pipefail
 mkdir -p /opt/pip-tools.d
 pip freeze | grep wheel >> /opt/pip-tools.d/overrides.in
-echo "jax[cuda13_local,k8s]>=0.8.3,<0.9" >> /opt/pip-tools.d/requirements.in
+echo "jax[cuda13-local,k8s]>=0.8.3,<0.9" >> /opt/pip-tools.d/requirements.in
 echo "-e file://${SRC_PATH_JIO}[checkpoint]" >> /opt/pip-tools.d/requirements.in
 EOF
 
@@ -83,9 +85,17 @@ FROM mealkit AS final
 
 # Finalize installation
 RUN <<"EOF" bash -ex -o pipefail
+export PIP_INDEX_URL=https://download.pytorch.org/whl/cu130
+export PIP_EXTRA_INDEX_URL="https://flashinfer.ai/whl/cu130 https://pypi.org/simple"
 pushd /opt/pip-tools.d
 pip-compile -o requirements.txt $(ls requirements*.in) --constraint overrides.in
-pip install --no-deps --src /opt -r requirements.txt
+cuda-package-skiplist filter \
+  --input requirements.txt \
+  --output requirements.runtime.txt \
+  --skipped cuda-wheel-payload-skipped.csv
+pip install --no-deps --src /opt -r requirements.runtime.txt
+cuda-package-skiplist mark-installed --skipped cuda-wheel-payload-skipped.csv
+pip check
 popd
 rm -rf ~/.cache/*
 EOF

--- a/jax-inference-offloading/dockerfile/oss.dockerfile
+++ b/jax-inference-offloading/dockerfile/oss.dockerfile
@@ -42,8 +42,6 @@ pip install pip-tools
 rm -rf ~/.cache/pip
 EOF
 
-COPY --chmod=755 dockerfile/cuda_package_skiplist.py /usr/local/bin/cuda-package-skiplist
-
 ###############################################################################
 ## Download source and configure pip-tools
 ###############################################################################
@@ -67,6 +65,7 @@ git sparse-checkout set ${SUB_PATH_JIO}
 git fetch origin ${REF_JIO}
 git checkout FETCH_HEAD
 popd
+install -D -m 0755 ${SRC_PATH_JIO}/dockerfile/cuda_package_skiplist.py /usr/local/bin/cuda-package-skiplist
 EOF
 
 # Aggregate requirements for pip-tools

--- a/jax-inference-offloading/examples/decoupled_synchronous/decoupled_sync.sh
+++ b/jax-inference-offloading/examples/decoupled_synchronous/decoupled_sync.sh
@@ -164,7 +164,16 @@ MODEL_NAME=${MODEL_NAME:-"meta-llama/Llama-3.2-1B-Instruct"}
 # ------------------------------------------------------------------------------
 # Kill all processes when done.
 # ------------------------------------------------------------------------------
-trap "trap - SIGTERM && kill -- -$$ 2>/dev/null || true" SIGINT SIGTERM EXIT
+cleanup() {
+  local status=$?
+  trap - SIGINT EXIT
+  trap '' SIGTERM
+  kill -- -$$ 2>/dev/null || true
+  wait 2>/dev/null || true
+  exit "${status}"
+}
+
+trap cleanup SIGINT SIGTERM EXIT
 
 # ------------------------------------------------------------------------------
 # load environment variables from .env file

--- a/jax-inference-offloading/examples/decoupled_synchronous/decoupled_sync.sh
+++ b/jax-inference-offloading/examples/decoupled_synchronous/decoupled_sync.sh
@@ -164,7 +164,7 @@ MODEL_NAME=${MODEL_NAME:-"meta-llama/Llama-3.2-1B-Instruct"}
 # ------------------------------------------------------------------------------
 # Kill all processes when done.
 # ------------------------------------------------------------------------------
-trap "trap - SIGTERM && kill -- -$$" SIGINT SIGTERM EXIT
+trap "trap - SIGTERM && kill -- -$$ 2>/dev/null || true" SIGINT SIGTERM EXIT
 
 # ------------------------------------------------------------------------------
 # load environment variables from .env file
@@ -212,7 +212,7 @@ JAX_GPU_ARRAY=("${CUDA_VISIBLE_DEVICES_ARRAY[@]:N_GPUS_VLLM:N_GPUS}")
 # ------------------------------------------------------------------------------
 export CUDA_DEVICE_ORDER=PCI_BUS_ID
 export CUDA_DEVICE_MAX_CONNECTIONS=16
-export NCCL_BUFFSIZE=16777216
+export NCCL_BUFFSIZE=${NCCL_BUFFSIZE:-16777216}
 export GATEWAY_PORT
 export GATEWAY_URL="localhost:${GATEWAY_PORT}"
 export MODEL_NAME
@@ -238,7 +238,6 @@ if [ "$DEBUG" == "true" ]; then
     export NCCL_DEBUG=INFO  # Enable NCCL debug logs
 else
     export TF_CPP_MIN_LOG_LEVEL=2  # Suppress TensorFlow debug logs
-    export VLLM_CONFIGURE_LOGGING=0  # Suppress vLLM logging
 fi
 
 PIDS=()
@@ -293,4 +292,16 @@ echo "All processes started. Waiting for completion..."
 echo "Check logs in: ${OUTPUT_DIR}"
 echo ""
 
-wait "${PIDS[@]}"
+EXIT_STATUS=0
+for _ in "${PIDS[@]}"; do
+  if wait -n; then
+    continue
+  else
+    child_status=$?
+    echo "A component exited with status ${child_status}; terminating remaining processes."
+    EXIT_STATUS=${child_status}
+    exit "${EXIT_STATUS}"
+  fi
+done
+
+exit "${EXIT_STATUS}"

--- a/jax-inference-offloading/examples/decoupled_synchronous/prompt_dispatcher.py
+++ b/jax-inference-offloading/examples/decoupled_synchronous/prompt_dispatcher.py
@@ -50,6 +50,7 @@ from jax_inference_offloading.controller.utils import create_topic
 # --- Configuration ---
 gateway_url = os.environ.get("GATEWAY_URL", "localhost:50051")
 num_iterations = int(os.environ.get("NUM_ITERATIONS", "3"))
+response_topic = os.environ.get("JIO_RESPONSE_TOPIC", "inference/results/shared")
 
 # Shared topic ID for synchronization
 SYNC_TOPIC = "sync/weights_ready"
@@ -73,10 +74,12 @@ def main():
     print(f"Gateway URL: {gateway_url}")
 
     # --- Create VLLMRolloutRequester ---
-    # This will automatically wait for the JAX controller to complete setup
-    # by polling the gateway KV store for the response topic.
-    print("Creating VLLMRolloutRequester (waiting for JAX controller setup)...")
-    requester = VLLMRolloutRequester(gateway_url=gateway_url)
+    print("Creating VLLMRolloutRequester...")
+    print(f"Using response topic: {response_topic}")
+    requester = VLLMRolloutRequester(
+        gateway_url=gateway_url,
+        response_topic=response_topic,
+    )
     print("VLLMRolloutRequester ready.")
 
     # --- Setup gRPC connection for sync subscription ---

--- a/jax-inference-offloading/examples/mappings/llama3_8b_param_mapping.json
+++ b/jax-inference-offloading/examples/mappings/llama3_8b_param_mapping.json
@@ -1,0 +1,157 @@
+{
+  "mesh_axes": ["fsdp", "tp"],
+  "num_layers": 32,
+  "mappings": [
+    {
+      "jax_param": {
+        "name": "embedder.input_embedding"
+      },
+      "vllm_param": {
+        "name": "model.embed_tokens.weight",
+        "shape": [128256, 4096]
+      }
+    },
+    {
+      "jax_param": {
+        "name": "final_norm.w"
+      },
+      "vllm_param": {
+        "name": "model.norm.weight",
+        "shape": [4096]
+      }
+    },
+    {
+      "jax_param": {
+        "name": "layers.{layer}.input_layernorm.w"
+      },
+      "vllm_param": {
+        "name": "model.layers.{layer}.input_layernorm.weight",
+        "shape": [4096]
+      }
+    },
+    {
+      "jax_param": {
+        "name": "layers.{layer}.post_attention_layernorm.w"
+      },
+      "vllm_param": {
+        "name": "model.layers.{layer}.post_attention_layernorm.weight",
+        "shape": [4096]
+      }
+    },
+    {
+      "jax_param": {
+        "name": "layers.{layer}.mlp.gate_proj.kernel",
+        "transform": {
+          "transpose": [1, 0]
+        }
+      },
+      "vllm_param": {
+        "name": "model.layers.{layer}.mlp.gate_proj.weight",
+        "shape": [14336, 4096],
+        "transform": {
+          "transpose": [1, 0]
+        }
+      }
+    },
+    {
+      "jax_param": {
+        "name": "layers.{layer}.mlp.up_proj.kernel",
+        "transform": {
+          "transpose": [1, 0]
+        }
+      },
+      "vllm_param": {
+        "name": "model.layers.{layer}.mlp.up_proj.weight",
+        "shape": [14336, 4096],
+        "transform": {
+          "transpose": [1, 0]
+        }
+      }
+    },
+    {
+      "jax_param": {
+        "name": "layers.{layer}.mlp.down_proj.kernel",
+        "transform": {
+          "transpose": [1, 0]
+        }
+      },
+      "vllm_param": {
+        "name": "model.layers.{layer}.mlp.down_proj.weight",
+        "shape": [4096, 14336],
+        "transform": {
+          "transpose": [1, 0]
+        }
+      }
+    },
+    {
+      "jax_param": {
+        "name": "layers.{layer}.attn.q_proj.w",
+        "transform": {
+          "transpose": [1, 2, 0],
+          "reshape": [-1, 4096]
+        }
+      },
+      "vllm_param": {
+        "name": "model.layers.{layer}.self_attn.q_proj.weight",
+        "shape": [4096, 4096],
+        "transform": {
+          "transpose": [1, 0],
+          "reshape": [4096, 32, 128]
+        }
+      }
+    },
+    {
+      "jax_param": {
+        "name": "layers.{layer}.attn.k_proj.w",
+        "transform": {
+          "transpose": [1, 2, 0],
+          "reshape": [-1, 4096],
+          "replication_axis": 2
+        }
+      },
+      "vllm_param": {
+        "name": "model.layers.{layer}.self_attn.k_proj.weight",
+        "shape": [1024, 4096],
+        "transform": {
+          "transpose": [1, 0],
+          "reshape": [4096, 8, 128]
+        }
+      }
+    },
+    {
+      "jax_param": {
+        "name": "layers.{layer}.attn.v_proj.w",
+        "transform": {
+          "transpose": [1, 2, 0],
+          "reshape": [-1, 4096],
+          "replication_axis": 2
+        }
+      },
+      "vllm_param": {
+        "name": "model.layers.{layer}.self_attn.v_proj.weight",
+        "shape": [1024, 4096],
+        "transform": {
+          "transpose": [1, 0],
+          "reshape": [4096, 8, 128]
+        }
+      }
+    },
+    {
+      "jax_param": {
+        "name": "layers.{layer}.attn.o_proj.w",
+        "transform": {
+          "transpose": [2, 0, 1],
+          "reshape": [4096, -1]
+        }
+      },
+      "vllm_param": {
+        "name": "model.layers.{layer}.self_attn.o_proj.weight",
+        "shape": [4096, 4096],
+        "transform": {
+          "transpose": [1, 0],
+          "reshape": [32, 128, 4096]
+        }
+      }
+    }
+  ]
+}

--- a/jax-inference-offloading/examples/single_controller/run_single_controller.sh
+++ b/jax-inference-offloading/examples/single_controller/run_single_controller.sh
@@ -175,7 +175,7 @@ done
 
 MODEL_NAME=${MODEL_NAME:-"meta-llama/Llama-3.2-1B-Instruct"}
 
-trap "trap - SIGTERM && kill -- -$$" SIGINT SIGTERM EXIT
+trap "trap - SIGTERM EXIT && kill -- -$$ 2>/dev/null || true" SIGINT SIGTERM EXIT
 
 if [[ -f "${PWD}/.env" ]]; then
   echo "Loading ${PWD}/.env"

--- a/jax-inference-offloading/examples/single_controller/run_single_controller.sh
+++ b/jax-inference-offloading/examples/single_controller/run_single_controller.sh
@@ -175,7 +175,16 @@ done
 
 MODEL_NAME=${MODEL_NAME:-"meta-llama/Llama-3.2-1B-Instruct"}
 
-trap "trap - SIGTERM EXIT && kill -- -$$ 2>/dev/null || true" SIGINT SIGTERM EXIT
+cleanup() {
+  local status=$?
+  trap - SIGINT EXIT
+  trap '' SIGTERM
+  kill -- -$$ 2>/dev/null || true
+  wait 2>/dev/null || true
+  exit "${status}"
+}
+
+trap cleanup SIGINT SIGTERM EXIT
 
 if [[ -f "${PWD}/.env" ]]; then
   echo "Loading ${PWD}/.env"

--- a/jax-inference-offloading/jax_inference_offloading/controller/rollout_client.py
+++ b/jax-inference-offloading/jax_inference_offloading/controller/rollout_client.py
@@ -136,7 +136,7 @@ class RolloutServicer:
     logger.info(f"Receiving weight update via NCCL (mode={mode})...")
     if mode in ('fused', 'unfused'):
       self._llm.collective_rpc(
-        "update_weights",
+        "jio_update_weights",
         timeout=None,
         args=(self._mapping_specs, ),
       )

--- a/jax-inference-offloading/jax_inference_offloading/models/mapping_util.py
+++ b/jax-inference-offloading/jax_inference_offloading/models/mapping_util.py
@@ -325,15 +325,16 @@ def add_sharding_specs(model_mapping: mapping.TpModelMappingSpecs, llm: LLM, jax
   for param in augmented_mapping.mappings:
     if spec := per_tensor_sharding_specs.get(param.vllm_param.name):
       dim, parallelism = spec["dim"], spec["parallelism"]
-      assert parallelism > 1, (
-        f'Unsharded or singleton sharding parallelism {parallelism} does not '
-        f'need explicit specification for {param.vllm_param.name}.'
-      )
-      # find auxiliary dim for sharding, if JAX TP size is larger than VLLM TP size
-      masked_shape = np.array(param.vllm_param.shape)
-      masked_shape[dim] = 0
-      aux_dim = np.argmax(masked_shape)
-      replication_count = spec.get('replication_count', 1)
+      if parallelism > 1:
+        # find auxiliary dim for sharding, if JAX TP size is larger than VLLM TP size
+        masked_shape = np.array(param.vllm_param.shape)
+        masked_shape[dim] = 0
+        aux_dim = np.argmax(masked_shape)
+        replication_count = spec.get('replication_count', 1)
+      else:
+        dim, parallelism = 999999, -1
+        aux_dim = np.argmax(param.vllm_param.shape)
+        replication_count = 1
     else:
       dim, parallelism = 999999, -1  # 999999 is an ugly sentinel value but likely never used in reality
       aux_dim = np.argmax(param.vllm_param.shape)

--- a/jax-inference-offloading/jax_inference_offloading/vllm/extension.py
+++ b/jax-inference-offloading/jax_inference_offloading/vllm/extension.py
@@ -172,7 +172,7 @@ class VLLMWorkerExtension:
     """
     self._staged_weights = []
 
-  def update_weights(self, mapping_specs: TpModelMappingSpecs):
+  def jio_update_weights(self, mapping_specs: TpModelMappingSpecs):
     self.reset_stage()
 
     tp_rank = get_tensor_model_parallel_rank()

--- a/jax-inference-offloading/pyproject.toml
+++ b/jax-inference-offloading/pyproject.toml
@@ -3,7 +3,7 @@ requires = [
   "setuptools>=69",
   "wheel",
   "grpcio-tools>=1.76,<1.77",
-  "protobuf>=6.31.1,<7"
+  "protobuf>=6.33.5,<7"
 ]
 build-backend = "pep517_backend"
 backend-path = ["."]
@@ -15,15 +15,15 @@ readme = "README.md"
 requires-python = ">=3.10"
 dependencies = [
   "cloudpickle",
-  "cupy-cuda12x",
+  "cupy-cuda13x",
   "flax>=0.8.2",
   "grpcio>=1.76,<2",
-  "jax>=0.8.1,<0.9",
+  "jax>=0.8.3,<0.9",
   "jaxtyping",
   "numpy",
   "packaging",
-  "protobuf>=6.31.1,<7",
-  "vllm>=0.14.1,<0.15",
+  "protobuf>=6.33.5,<7",
+  "vllm>=0.22.0,<0.23",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
Supersedes #2128.

## Summary

- update the JIO CUDA 13 dependency stack, including vLLM 0.22 and PyTorch CUDA 13 wheels
- add custom JIO Docker refs so image builds can select a specific JIO repository and commit
- add a CUDA package skiplist helper so the Docker build does not reinstall CUDA payloads already provided by the base image, while still installing missing runtime packages
- keep the JIO examples compatible with the updated JAX/vLLM surface
- replace stale JIO CI coverage with an 8B decoupled synchronous smoke that uses the CI-accessible `meta-llama/Llama-3.1-8B-Instruct` model
- pin `huggingface-hub` for the smoke download path and use the HF CLI with the CI HF token
- preserve the GKE TCPXO NCCL path update, source the TCPXO NCCL env profile, pass the tuner and guest-checker configs, and let that profile provide enforced NCCL values such as `NCCL_BUFFSIZE`
- keep vLLM logs visible and fail fast when any decoupled smoke component exits non-zero, so CI reports real failures instead of silent passes

## Validation

- `python3 -m py_compile jax-inference-offloading/dockerfile/cuda_package_skiplist.py`
- `git diff --check`
- CUDA 13 image build completed successfully
- smoke-checked the rebuilt container:
  - PyTorch reports CUDA 13
  - vLLM 0.22 imports successfully
  - JAX sees CUDA devices
  - `pip check` passes
- #2147 validation before stack merge:
  - JAX-vLLM offloading workflow run `26973090959` passed
  - `jio-decoupled-sync-8b-gke-smoke` passed with `EXIT_CODE=0`
  - smoke sitrep reported `1/1 passed`

## CI note

The active JIO runtime smoke is now the 8B decoupled synchronous path. This avoids the CI HF-token access issue seen with the 1B gated model and exercises the current split JAX/vLLM offloading flow.

The legacy 8B/70B transfer, GRPO, and EKS jobs still target removed flat example entrypoints, so they are preserved but disabled pending a follow-up port.
