### PR TITLE
[jax-inference-offloading] add 8B decoupled sync smoke

### DIFF
--- a/.github/workflows/jax-vllm-offloading.yml
+++ b/.github/workflows/jax-vllm-offloading.yml
@@ -264,6 +264,40 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         NVCR_TOKEN: ${{ secrets.NVCR_TOKEN }}
 
+  jio-decoupled-sync-8b-gke-smoke:
+    needs: amd64
+    runs-on: gke-a3mega
+    steps:
+    - uses: actions/checkout@v6
+
+    - name: Run JIO decoupled sync 8B smoke
+      uses: ./.github/actions/gke-xpk
+      with:
+        NAME: jio-dec-sync-8b
+        IMAGE: ${{ needs.amd64.outputs.DOCKER_TAG_FINAL }}
+        NUM_NODES: 1
+        ENVS: |
+          CUDA_VISIBLE_DEVICES=0,1,2,3;
+          JIO_RESPONSE_TOPIC=inference/results/shared;
+          MODEL_NAME=meta-llama/Llama-3.1-8B-Instruct;
+          NCCL_CUMEM_ENABLE=0;
+        COMMAND: |
+          set -x;
+          cd /opt/jtbx/jax-inference-offloading/examples/decoupled_synchronous;
+          timeout --kill-after=30s 900s bash ./decoupled_sync.sh \
+            --model-path=/Llama-3.1-8B-Instruct \
+            --param-mapping-path=../mappings/llama3_8b_param_mapping.json \
+            --num-iterations=1 \
+            --transfer-mode=grouped \
+            --n-gpus-vllm=2 \
+            --n-gpus-jax=2 \
+            --vllm-enforce-eager \
+            --vllm-gpu-memory-utilization=0.7 \
+            --output-dir=/opt/output/jio-decoupled-sync-8b;
+          EXIT_CODE=$?;
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        NVCR_TOKEN: ${{ secrets.NVCR_TOKEN }}
+
   # TODO: Port these legacy 8B/70B transfer, GRPO, and EKS checks to the
   # current JIO example structure before re-enabling them.
   #

--- a/jax-inference-offloading/examples/decoupled_asynchronous/jax_controller.py
+++ b/jax-inference-offloading/examples/decoupled_asynchronous/jax_controller.py
@@ -77,7 +77,7 @@ update_interval = int(os.environ.get("UPDATE_INTERVAL", "5"))
 max_completed_prompts = int(os.environ.get("MAX_COMPLETED_PROMPTS", "100"))
 
 # Shared topic for results
-RESULTS_TOPIC = "inference/results/shared"
+RESULTS_TOPIC = os.environ.get("JIO_RESPONSE_TOPIC", "inference/results/shared")
 
 # Validate required environment variables
 if model_path is None:

--- a/jax-inference-offloading/examples/decoupled_asynchronous/prompt_dispatcher.py
+++ b/jax-inference-offloading/examples/decoupled_asynchronous/prompt_dispatcher.py
@@ -52,6 +52,7 @@ num_batches = int(os.environ.get("NUM_BATCHES", "10"))
 batch_size = int(os.environ.get("BATCH_SIZE", "3"))
 num_rollouts = int(os.environ.get("NUM_ROLLOUTS", "4"))
 dispatch_delay = float(os.environ.get("DISPATCH_DELAY", "0.0"))
+response_topic = os.environ.get("JIO_RESPONSE_TOPIC", "inference/results/shared")
 
 
 def get_prompts(batch_idx: int):
@@ -95,10 +96,12 @@ def main():
     print(f"Number of batches: {num_batches if num_batches > 0 else 'infinite'}")
 
     # --- Create VLLMRolloutRequester ---
-    # This will automatically wait for the JAX controller to complete setup
-    # by polling the gateway KV store for the response topic.
-    print("Creating VLLMRolloutRequester (waiting for JAX controller setup)...")
-    requester = VLLMRolloutRequester(gateway_url=gateway_url)
+    print("Creating VLLMRolloutRequester...")
+    print(f"Using response topic: {response_topic}")
+    requester = VLLMRolloutRequester(
+        gateway_url=gateway_url,
+        response_topic=response_topic,
+    )
     print("VLLMRolloutRequester ready.")
 
     # --- Create inference config ---

--- a/jax-inference-offloading/examples/decoupled_synchronous/jax_controller.py
+++ b/jax-inference-offloading/examples/decoupled_synchronous/jax_controller.py
@@ -68,7 +68,7 @@ transfer_mode = os.environ.get("TRANSFER_MODE", "grouped")
 num_iterations = int(os.environ.get("NUM_ITERATIONS", "3"))
 
 # Shared topic IDs for cross-process coordination
-RESULTS_TOPIC = "inference/results/shared"
+RESULTS_TOPIC = os.environ.get("JIO_RESPONSE_TOPIC", "inference/results/shared")
 SYNC_TOPIC = "sync/weights_ready"
 
 # Validate required environment variables

--- a/jax-inference-offloading/examples/decoupled_synchronous/prompt_dispatcher.py
+++ b/jax-inference-offloading/examples/decoupled_synchronous/prompt_dispatcher.py
@@ -50,6 +50,7 @@ from jax_inference_offloading.controller.utils import create_topic
 # --- Configuration ---
 gateway_url = os.environ.get("GATEWAY_URL", "localhost:50051")
 num_iterations = int(os.environ.get("NUM_ITERATIONS", "3"))
+response_topic = os.environ.get("JIO_RESPONSE_TOPIC", "inference/results/shared")
 
 # Shared topic ID for synchronization
 SYNC_TOPIC = "sync/weights_ready"
@@ -73,10 +74,12 @@ def main():
     print(f"Gateway URL: {gateway_url}")
 
     # --- Create VLLMRolloutRequester ---
-    # This will automatically wait for the JAX controller to complete setup
-    # by polling the gateway KV store for the response topic.
-    print("Creating VLLMRolloutRequester (waiting for JAX controller setup)...")
-    requester = VLLMRolloutRequester(gateway_url=gateway_url)
+    print("Creating VLLMRolloutRequester...")
+    print(f"Using response topic: {response_topic}")
+    requester = VLLMRolloutRequester(
+        gateway_url=gateway_url,
+        response_topic=response_topic,
+    )
     print("VLLMRolloutRequester ready.")
 
     # --- Setup gRPC connection for sync subscription ---

--- a/jax-inference-offloading/examples/mappings/llama3_8b_param_mapping.json
+++ b/jax-inference-offloading/examples/mappings/llama3_8b_param_mapping.json
@@ -1,0 +1,157 @@
+{
+  "mesh_axes": ["fsdp", "tp"],
+  "num_layers": 32,
+  "mappings": [
+    {
+      "jax_param": {
+        "name": "embedder.input_embedding"
+      },
+      "vllm_param": {
+        "name": "model.embed_tokens.weight",
+        "shape": [128256, 4096]
+      }
+    },
+    {
+      "jax_param": {
+        "name": "final_norm.w"
+      },
+      "vllm_param": {
+        "name": "model.norm.weight",
+        "shape": [4096]
+      }
+    },
+    {
+      "jax_param": {
+        "name": "layers.{layer}.input_layernorm.w"
+      },
+      "vllm_param": {
+        "name": "model.layers.{layer}.input_layernorm.weight",
+        "shape": [4096]
+      }
+    },
+    {
+      "jax_param": {
+        "name": "layers.{layer}.post_attention_layernorm.w"
+      },
+      "vllm_param": {
+        "name": "model.layers.{layer}.post_attention_layernorm.weight",
+        "shape": [4096]
+      }
+    },
+    {
+      "jax_param": {
+        "name": "layers.{layer}.mlp.gate_proj.kernel",
+        "transform": {
+          "transpose": [1, 0]
+        }
+      },
+      "vllm_param": {
+        "name": "model.layers.{layer}.mlp.gate_proj.weight",
+        "shape": [14336, 4096],
+        "transform": {
+          "transpose": [1, 0]
+        }
+      }
+    },
+    {
+      "jax_param": {
+        "name": "layers.{layer}.mlp.up_proj.kernel",
+        "transform": {
+          "transpose": [1, 0]
+        }
+      },
+      "vllm_param": {
+        "name": "model.layers.{layer}.mlp.up_proj.weight",
+        "shape": [14336, 4096],
+        "transform": {
+          "transpose": [1, 0]
+        }
+      }
+    },
+    {
+      "jax_param": {
+        "name": "layers.{layer}.mlp.down_proj.kernel",
+        "transform": {
+          "transpose": [1, 0]
+        }
+      },
+      "vllm_param": {
+        "name": "model.layers.{layer}.mlp.down_proj.weight",
+        "shape": [4096, 14336],
+        "transform": {
+          "transpose": [1, 0]
+        }
+      }
+    },
+    {
+      "jax_param": {
+        "name": "layers.{layer}.attn.q_proj.w",
+        "transform": {
+          "transpose": [1, 2, 0],
+          "reshape": [-1, 4096]
+        }
+      },
+      "vllm_param": {
+        "name": "model.layers.{layer}.self_attn.q_proj.weight",
+        "shape": [4096, 4096],
+        "transform": {
+          "transpose": [1, 0],
+          "reshape": [4096, 32, 128]
+        }
+      }
+    },
+    {
+      "jax_param": {
+        "name": "layers.{layer}.attn.k_proj.w",
+        "transform": {
+          "transpose": [1, 2, 0],
+          "reshape": [-1, 4096],
+          "replication_axis": 2
+        }
+      },
+      "vllm_param": {
+        "name": "model.layers.{layer}.self_attn.k_proj.weight",
+        "shape": [1024, 4096],
+        "transform": {
+          "transpose": [1, 0],
+          "reshape": [4096, 8, 128]
+        }
+      }
+    },
+    {
+      "jax_param": {
+        "name": "layers.{layer}.attn.v_proj.w",
+        "transform": {
+          "transpose": [1, 2, 0],
+          "reshape": [-1, 4096],
+          "replication_axis": 2
+        }
+      },
+      "vllm_param": {
+        "name": "model.layers.{layer}.self_attn.v_proj.weight",
+        "shape": [1024, 4096],
+        "transform": {
+          "transpose": [1, 0],
+          "reshape": [4096, 8, 128]
+        }
+      }
+    },
+    {
+      "jax_param": {
+        "name": "layers.{layer}.attn.o_proj.w",
+        "transform": {
+          "transpose": [2, 0, 1],
+          "reshape": [4096, -1]
+        }
+      },
+      "vllm_param": {
+        "name": "model.layers.{layer}.self_attn.o_proj.weight",
+        "shape": [4096, 4096],
+        "transform": {
+          "transpose": [1, 0],
+          "reshape": [32, 128, 4096]
+        }
+      }
+    }
+  ]
+}

--- a/jax-inference-offloading/examples/single_controller/prompt_source.py
+++ b/jax-inference-offloading/examples/single_controller/prompt_source.py
@@ -119,7 +119,13 @@ def main():
     raise ValueError("SC_MODE must be either 'sync' or 'async'.")
 
   print(f"Starting prompt source: mode={mode} gateway={gateway_url}")
-  requester = VLLMRolloutRequester(gateway_url=gateway_url)
+  response_topic = os.environ.get("SC_JAX_RESULTS_TOPIC")
+  if response_topic:
+    print(f"Using response topic: {response_topic}")
+  requester = VLLMRolloutRequester(
+    gateway_url=gateway_url,
+    response_topic=response_topic,
+  )
 
   try:
     if mode == "sync":


### PR DESCRIPTION
## Summary
- Add the Llama 3.1 8B JIO parameter mapping used by the current examples.
- Let the current single-controller and decoupled examples use an explicit response topic instead of relying only on KV discovery.
- Add a GKE smoke job for the validated 8B decoupled synchronous example.

## Base and retargeting
This PR targets `jio-update-vllm-0.22` while #2141 is open, because the 8B smoke builds on that JIO/vLLM stack update. Once #2141 has merged, this PR shall be retargeted to `main`.

## Validation
- Ptyche allocation, image `gitlab-master.nvidia.com:5005/yuhangt/containers:20260603-jio-update-vllm-0.22`: `decoupled_synchronous/decoupled_sync.sh` completed one 8B iteration with 2 vLLM GPUs + 2 JAX GPUs, transferred weights, and returned 3 outputs.
- Confirmed the old legacy multihost entrypoints referenced by the disabled transfer/GRPO/EKS jobs are absent from the current image, so this reincarnates only the current supported example path.
- Did not add async CI: the async 8B probe dispatched a batch but did not receive rollout results before the 900s timeout.
- Local checks: `python3 -m py_compile` for touched example Python files, `python3 -m json.tool` for the 8B mapping, workflow YAML parse, and `git diff --check`.
