### PR TITLE
[jax-inference-offloading] add 8B decoupled sync smoke

### DIFF
--- a/.github/actions/gke-xpk/action.yml
+++ b/.github/actions/gke-xpk/action.yml
@@ -205,7 +205,7 @@ runs:
           mkdir -p ${{ inputs.CONTAINER_OUTPUT_PATH }};"
 
       PRELUDE+="
-          export LD_LIBRARY_PATH=/opt/nvidia/nccl/lib:\${NCCL_LIB_DIR}:\${LD_LIBRARY_PATH};
+          export LD_LIBRARY_PATH=\${NCCL_LIB_DIR}:\${LD_LIBRARY_PATH};
       "
 
       # gsutil command to export logs from container's /opt/output to bucket

--- a/.github/actions/gke-xpk/action.yml
+++ b/.github/actions/gke-xpk/action.yml
@@ -205,7 +205,7 @@ runs:
           mkdir -p ${{ inputs.CONTAINER_OUTPUT_PATH }};"
 
       PRELUDE+="
-          export LD_LIBRARY_PATH=\${NCCL_LIB_DIR}:\${LD_LIBRARY_PATH};
+          export LD_LIBRARY_PATH=/opt/nvidia/nccl/lib:\${NCCL_LIB_DIR}:\${LD_LIBRARY_PATH};
       "
 
       # gsutil command to export logs from container's /opt/output to bucket

--- a/.github/workflows/jax-vllm-offloading.yml
+++ b/.github/workflows/jax-vllm-offloading.yml
@@ -230,39 +230,6 @@ jobs:
       PUBLISH_BADGE: ${{ needs.metadata.outputs.PUBLISH == 'true' }}
     secrets: inherit
 
-  jio-single-controller-gke-smoke:
-    needs: amd64
-    runs-on: gke-a3mega
-    steps:
-    - uses: actions/checkout@v6
-
-    - name: Run JIO single-controller smoke
-      uses: ./.github/actions/gke-xpk
-      with:
-        NAME: jio-sc-smoke
-        IMAGE: ${{ needs.amd64.outputs.DOCKER_TAG_FINAL }}
-        NUM_NODES: 1
-        ENVS: |
-          CUDA_VISIBLE_DEVICES=0,1,2,3;
-          MODEL_NAME=meta-llama/Llama-3.2-1B-Instruct;
-          NCCL_CUMEM_ENABLE=0;
-        COMMAND: |
-          set -x;
-          cd /opt/jtbx/jax-inference-offloading/examples/single_controller;
-          timeout --kill-after=10s 120s bash ./run_single_controller.sh \
-            --mode=sync \
-            --model-path=meta-llama/Llama-3.2-1B-Instruct \
-            --param-mapping-path=../mappings/llama3_1b_param_mapping.json \
-            --num-iterations=1 \
-            --transfer-mode=grouped \
-            --n-gpus-vllm=2 \
-            --n-gpus-jax=2 \
-            --vllm-enforce-eager \
-            --vllm-gpu-memory-utilization=0.7 \
-            --output-dir=/opt/output/jio-single-controller;
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        NVCR_TOKEN: ${{ secrets.NVCR_TOKEN }}
-
   jio-decoupled-sync-8b-gke-smoke:
     needs: amd64
     runs-on: gke-a3mega
@@ -282,9 +249,10 @@ jobs:
           NCCL_CUMEM_ENABLE=0;
         COMMAND: |
           set -x;
+          MODEL_PATH=\$(python -c 'import os; from huggingface_hub import snapshot_download; print(snapshot_download(os.environ["MODEL_NAME"]))');
           cd /opt/jtbx/jax-inference-offloading/examples/decoupled_synchronous;
           timeout --kill-after=30s 900s bash ./decoupled_sync.sh \
-            --model-path=/Llama-3.1-8B-Instruct \
+            --model-path=\${MODEL_PATH} \
             --param-mapping-path=../mappings/llama3_8b_param_mapping.json \
             --num-iterations=1 \
             --transfer-mode=grouped \
@@ -293,7 +261,7 @@ jobs:
             --vllm-enforce-eager \
             --vllm-gpu-memory-utilization=0.7 \
             --output-dir=/opt/output/jio-decoupled-sync-8b;
-          EXIT_CODE=$?;
+          EXIT_CODE=\$?;
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         NVCR_TOKEN: ${{ secrets.NVCR_TOKEN }}
 

--- a/.github/workflows/jax-vllm-offloading.yml
+++ b/.github/workflows/jax-vllm-offloading.yml
@@ -263,6 +263,40 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         NVCR_TOKEN: ${{ secrets.NVCR_TOKEN }}
 
+  jio-decoupled-sync-8b-gke-smoke:
+    needs: amd64
+    runs-on: gke-a3mega
+    steps:
+    - uses: actions/checkout@v6
+
+    - name: Run JIO decoupled sync 8B smoke
+      uses: ./.github/actions/gke-xpk
+      with:
+        NAME: jio-dec-sync-8b
+        IMAGE: ${{ needs.amd64.outputs.DOCKER_TAG_FINAL }}
+        NUM_NODES: 1
+        ENVS: |
+          CUDA_VISIBLE_DEVICES=0,1,2,3;
+          JIO_RESPONSE_TOPIC=inference/results/shared;
+          MODEL_NAME=meta-llama/Llama-3.1-8B-Instruct;
+          NCCL_CUMEM_ENABLE=0;
+        COMMAND: |
+          set -x;
+          cd /opt/jtbx/jax-inference-offloading/examples/decoupled_synchronous;
+          timeout --kill-after=30s 900s bash ./decoupled_sync.sh \
+            --model-path=/Llama-3.1-8B-Instruct \
+            --param-mapping-path=../mappings/llama3_8b_param_mapping.json \
+            --num-iterations=1 \
+            --transfer-mode=grouped \
+            --n-gpus-vllm=2 \
+            --n-gpus-jax=2 \
+            --vllm-enforce-eager \
+            --vllm-gpu-memory-utilization=0.7 \
+            --output-dir=/opt/output/jio-decoupled-sync-8b;
+          EXIT_CODE=$?;
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        NVCR_TOKEN: ${{ secrets.NVCR_TOKEN }}
+
   # TODO: Port these legacy 8B/70B transfer, GRPO, and EKS checks to the
   # current JIO example structure before re-enabling them.
   #

--- a/.github/workflows/jax-vllm-offloading.yml
+++ b/.github/workflows/jax-vllm-offloading.yml
@@ -249,7 +249,8 @@ jobs:
           NCCL_CUMEM_ENABLE=0;
         COMMAND: |
           set -x;
-          MODEL_PATH=\$(python -c 'import os; from huggingface_hub import snapshot_download; print(snapshot_download(os.environ["MODEL_NAME"]))');
+          python -m pip install --upgrade huggingface_hub==0.34.4;
+          MODEL_PATH=\$(hf download \${MODEL_NAME} --quiet);
           cd /opt/jtbx/jax-inference-offloading/examples/decoupled_synchronous;
           timeout --kill-after=30s 900s bash ./decoupled_sync.sh \
             --model-path=\${MODEL_PATH} \

--- a/.github/workflows/jax-vllm-offloading.yml
+++ b/.github/workflows/jax-vllm-offloading.yml
@@ -249,7 +249,7 @@ jobs:
           NCCL_CUMEM_ENABLE=0;
         COMMAND: |
           set -x;
-          python -m pip install --upgrade huggingface_hub==0.34.4;
+          python -m pip install --upgrade huggingface-hub==1.17.0;
           MODEL_PATH=\$(hf download \${MODEL_NAME} --quiet);
           cd /opt/jtbx/jax-inference-offloading/examples/decoupled_synchronous;
           timeout --kill-after=30s 900s bash ./decoupled_sync.sh \

--- a/jax-inference-offloading/examples/decoupled_synchronous/decoupled_sync.sh
+++ b/jax-inference-offloading/examples/decoupled_synchronous/decoupled_sync.sh
@@ -293,4 +293,14 @@ echo "All processes started. Waiting for completion..."
 echo "Check logs in: ${OUTPUT_DIR}"
 echo ""
 
-wait "${PIDS[@]}"
+EXIT_STATUS=0
+for pid in "${PIDS[@]}"; do
+  if wait "${pid}"; then
+    continue
+  else
+    child_status=$?
+    EXIT_STATUS=${child_status}
+  fi
+done
+
+exit "${EXIT_STATUS}"

--- a/jax-inference-offloading/examples/decoupled_synchronous/decoupled_sync.sh
+++ b/jax-inference-offloading/examples/decoupled_synchronous/decoupled_sync.sh
@@ -164,7 +164,7 @@ MODEL_NAME=${MODEL_NAME:-"meta-llama/Llama-3.2-1B-Instruct"}
 # ------------------------------------------------------------------------------
 # Kill all processes when done.
 # ------------------------------------------------------------------------------
-trap "trap - SIGTERM && kill -- -$$" SIGINT SIGTERM EXIT
+trap "trap - SIGTERM && kill -- -$$ 2>/dev/null || true" SIGINT SIGTERM EXIT
 
 # ------------------------------------------------------------------------------
 # load environment variables from .env file
@@ -294,12 +294,14 @@ echo "Check logs in: ${OUTPUT_DIR}"
 echo ""
 
 EXIT_STATUS=0
-for pid in "${PIDS[@]}"; do
-  if wait "${pid}"; then
+for _ in "${PIDS[@]}"; do
+  if wait -n; then
     continue
   else
     child_status=$?
+    echo "A component exited with status ${child_status}; terminating remaining processes."
     EXIT_STATUS=${child_status}
+    exit "${EXIT_STATUS}"
   fi
 done
 

--- a/jax-inference-offloading/examples/decoupled_synchronous/prompt_dispatcher.py
+++ b/jax-inference-offloading/examples/decoupled_synchronous/prompt_dispatcher.py
@@ -50,6 +50,7 @@ from jax_inference_offloading.controller.utils import create_topic
 # --- Configuration ---
 gateway_url = os.environ.get("GATEWAY_URL", "localhost:50051")
 num_iterations = int(os.environ.get("NUM_ITERATIONS", "3"))
+response_topic = os.environ.get("JIO_RESPONSE_TOPIC", "inference/results/shared")
 
 # Shared topic ID for synchronization
 SYNC_TOPIC = "sync/weights_ready"
@@ -73,10 +74,12 @@ def main():
     print(f"Gateway URL: {gateway_url}")
 
     # --- Create VLLMRolloutRequester ---
-    # This will automatically wait for the JAX controller to complete setup
-    # by polling the gateway KV store for the response topic.
-    print("Creating VLLMRolloutRequester (waiting for JAX controller setup)...")
-    requester = VLLMRolloutRequester(gateway_url=gateway_url)
+    print("Creating VLLMRolloutRequester...")
+    print(f"Using response topic: {response_topic}")
+    requester = VLLMRolloutRequester(
+        gateway_url=gateway_url,
+        response_topic=response_topic,
+    )
     print("VLLMRolloutRequester ready.")
 
     # --- Setup gRPC connection for sync subscription ---

--- a/jax-inference-offloading/examples/mappings/llama3_8b_param_mapping.json
+++ b/jax-inference-offloading/examples/mappings/llama3_8b_param_mapping.json
@@ -1,0 +1,157 @@
+{
+  "mesh_axes": ["fsdp", "tp"],
+  "num_layers": 32,
+  "mappings": [
+    {
+      "jax_param": {
+        "name": "embedder.input_embedding"
+      },
+      "vllm_param": {
+        "name": "model.embed_tokens.weight",
+        "shape": [128256, 4096]
+      }
+    },
+    {
+      "jax_param": {
+        "name": "final_norm.w"
+      },
+      "vllm_param": {
+        "name": "model.norm.weight",
+        "shape": [4096]
+      }
+    },
+    {
+      "jax_param": {
+        "name": "layers.{layer}.input_layernorm.w"
+      },
+      "vllm_param": {
+        "name": "model.layers.{layer}.input_layernorm.weight",
+        "shape": [4096]
+      }
+    },
+    {
+      "jax_param": {
+        "name": "layers.{layer}.post_attention_layernorm.w"
+      },
+      "vllm_param": {
+        "name": "model.layers.{layer}.post_attention_layernorm.weight",
+        "shape": [4096]
+      }
+    },
+    {
+      "jax_param": {
+        "name": "layers.{layer}.mlp.gate_proj.kernel",
+        "transform": {
+          "transpose": [1, 0]
+        }
+      },
+      "vllm_param": {
+        "name": "model.layers.{layer}.mlp.gate_proj.weight",
+        "shape": [14336, 4096],
+        "transform": {
+          "transpose": [1, 0]
+        }
+      }
+    },
+    {
+      "jax_param": {
+        "name": "layers.{layer}.mlp.up_proj.kernel",
+        "transform": {
+          "transpose": [1, 0]
+        }
+      },
+      "vllm_param": {
+        "name": "model.layers.{layer}.mlp.up_proj.weight",
+        "shape": [14336, 4096],
+        "transform": {
+          "transpose": [1, 0]
+        }
+      }
+    },
+    {
+      "jax_param": {
+        "name": "layers.{layer}.mlp.down_proj.kernel",
+        "transform": {
+          "transpose": [1, 0]
+        }
+      },
+      "vllm_param": {
+        "name": "model.layers.{layer}.mlp.down_proj.weight",
+        "shape": [4096, 14336],
+        "transform": {
+          "transpose": [1, 0]
+        }
+      }
+    },
+    {
+      "jax_param": {
+        "name": "layers.{layer}.attn.q_proj.w",
+        "transform": {
+          "transpose": [1, 2, 0],
+          "reshape": [-1, 4096]
+        }
+      },
+      "vllm_param": {
+        "name": "model.layers.{layer}.self_attn.q_proj.weight",
+        "shape": [4096, 4096],
+        "transform": {
+          "transpose": [1, 0],
+          "reshape": [4096, 32, 128]
+        }
+      }
+    },
+    {
+      "jax_param": {
+        "name": "layers.{layer}.attn.k_proj.w",
+        "transform": {
+          "transpose": [1, 2, 0],
+          "reshape": [-1, 4096],
+          "replication_axis": 2
+        }
+      },
+      "vllm_param": {
+        "name": "model.layers.{layer}.self_attn.k_proj.weight",
+        "shape": [1024, 4096],
+        "transform": {
+          "transpose": [1, 0],
+          "reshape": [4096, 8, 128]
+        }
+      }
+    },
+    {
+      "jax_param": {
+        "name": "layers.{layer}.attn.v_proj.w",
+        "transform": {
+          "transpose": [1, 2, 0],
+          "reshape": [-1, 4096],
+          "replication_axis": 2
+        }
+      },
+      "vllm_param": {
+        "name": "model.layers.{layer}.self_attn.v_proj.weight",
+        "shape": [1024, 4096],
+        "transform": {
+          "transpose": [1, 0],
+          "reshape": [4096, 8, 128]
+        }
+      }
+    },
+    {
+      "jax_param": {
+        "name": "layers.{layer}.attn.o_proj.w",
+        "transform": {
+          "transpose": [2, 0, 1],
+          "reshape": [4096, -1]
+        }
+      },
+      "vllm_param": {
+        "name": "model.layers.{layer}.self_attn.o_proj.weight",
+        "shape": [4096, 4096],
+        "transform": {
+          "transpose": [1, 0],
+          "reshape": [32, 128, 4096]
+        }
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- Add the Llama 3.1 8B JIO parameter mapping and dispatcher response-topic handling used by the decoupled synchronous smoke.
- Replace the active JIO smoke with the 8B decoupled synchronous GKE smoke. The 1B smoke is intentionally not enabled because the CI HF token only has access to the 8B model.
- Pin `huggingface-hub==1.17.0` and use `hf download --quiet` so the smoke passes a local model snapshot path without embedding a fragile Python one-liner in the generated XPK command.
- Keep CI failures visible: the GKE command records `EXIT_CODE` after the timed smoke, and `decoupled_sync.sh` returns failed child process status.

## Base
This PR is stacked on #2147 (`aybchan/jio-update-vllm-0.22`), which owns the Hugging Face/GKE setup this smoke depends on. It intentionally leaves #2147's GKE `LD_LIBRARY_PATH` prelude unchanged.

## Validation
- Ptyche allocation, image `gitlab-master.nvidia.com:5005/yuhangt/containers:20260603-jio-update-vllm-0.22`: `decoupled_synchronous/decoupled_sync.sh` completed one 8B iteration with 2 vLLM GPUs + 2 JAX GPUs, transferred weights, and returned 3 outputs.
- Did not add async CI: the async 8B probe dispatched a batch but did not receive rollout results before the 900s timeout.
- Local checks: workflow/action YAML parse, `bash -n` for `decoupled_sync.sh`, `python3 -m py_compile` for `prompt_dispatcher.py`, JSON parse for the 8B mapping, and `git diff --check`.
- Failure propagation check: a synthetic failed child process exited `7`, and the wait loop returned `7` instead of silently passing.
