### PR TITLE
NCCL test mpirun compat for Open MPI 5.0

### DIFF
--- a/.github/eks-workflow-files/mpi-nccl-test.yml
+++ b/.github/eks-workflow-files/mpi-nccl-test.yml
@@ -50,6 +50,11 @@ spec:
                     -c 1 \
                     -n 100
                 - PLACEHOLDER
+              env:
+                - name: PRTE_MCA_prte_default_hostfile
+                  value: /etc/mpi/hostfile
+                - name: OMPI_MCA_orte_default_hostfile
+                  value: /etc/mpi/hostfile
               resources:
                 limits:
                   cpu: 1

--- a/.github/gke-workflow/nccl/scripts/test.sh
+++ b/.github/gke-workflow/nccl/scripts/test.sh
@@ -17,7 +17,6 @@ NCCL_NVLSTREE_MAX_CHUNKSIZE="${NCCL_NVLSTREE_MAX_CHUNKSIZE:-131072}"
 run_nccl() {
   mpirun --mca btl tcp,self \
          --mca btl_tcp_if_include eth0 \
-         --mca orte_keep_fqdn_hostnames 1 \
          --allow-run-as-root \
          -np $(( GPUS_PER_NODE * "${NHOSTS}" )) \
          --hostfile "${SCRIPT_DIR}/hostfiles${NHOSTS}/hostfile${GPUS_PER_NODE}"     \

--- a/.github/workflows/_test_nccl_gke.yaml
+++ b/.github/workflows/_test_nccl_gke.yaml
@@ -55,6 +55,7 @@ jobs:
       TEST_NAME: ${{ matrix.test }}
       NAME: nccl-gke
       NHOSTS: 2
+      NUM_GPUS: 8
       NCCL_MINBYTES: 8
       NCCL_MAXBYTES: 16G
       NCCL_STEPFACTOR: 2
@@ -79,6 +80,8 @@ jobs:
         ENVS: |
           OMPI_MCA_orte_keep_fqdn_hostnames=1;
           PRTE_MCA_prte_keep_fqdn_hostnames=1;
+          MPI_MCA_orte_default_hostfile=/scripts/hostfiles${{ env.NHOSTS }}/hostfile${{ env.NUM_GPUS }};
+          PRTE_MCA_prte_default_hostfile=/scripts/hostfiles${{ env.NHOSTS }}/hostfile${{ env.NUM_GPUS }};
           NCCL_MINBYTES=${{ env.NCCL_MINBYTES }};
           NCCL_MAXBYTES=${{ env.NCCL_MAXBYTES }};
           NCCL_STEPFACTOR=${{ env.NCCL_STEPFACTOR }};

--- a/.github/workflows/_test_nccl_gke.yaml
+++ b/.github/workflows/_test_nccl_gke.yaml
@@ -77,11 +77,16 @@ jobs:
         IMAGE: ${{ env.BASE_IMAGE }}
         NAME: ${{ steps.workload-name.outputs.JOBSET_PREFIX }}
         ENVS: |
+          OMPI_MCA_orte_keep_fqdn_hostnames=1;
+          PRTE_MCA_prte_keep_fqdn_hostnames=1;
           NCCL_MINBYTES=${{ env.NCCL_MINBYTES }};
           NCCL_MAXBYTES=${{ env.NCCL_MAXBYTES }};
           NCCL_STEPFACTOR=${{ env.NCCL_STEPFACTOR }};
           NCCL_ITERS=${{ env.NCCL_ITERS }};
         COMMAND: |
+          mpirun --version;
+          ompi_info --version;
+
           service ssh restart;
           declare -a hosts=(\${JOBSET_NAME}-\${REPLICATED_JOB_NAME}-0-0.\${JOBSET_NAME} \${JOBSET_NAME}-\${REPLICATED_JOB_NAME}-0-1.\${JOBSET_NAME});
 


### PR DESCRIPTION
Add compatibility for Open MPI 5.0 for NCCL tests using mpirun due to upcoming CUDA 13.3 base (NGC 26.06). Retain backward compatibility for ORTE runtime mpirun.

- [GKE OMPI `v5.0.10rc2`](https://github.com/NVIDIA/JAX-Toolbox/actions/runs/27210146457/job/80341724297#step:4:1853)
- [EKS OMPI `v5.0.10rc2`](https://github.com/NVIDIA/JAX-Toolbox/actions/runs/27210146457/job/80341758904#step:9:137)
- [GKE OMPI `v4.1.9a1`](https://github.com/NVIDIA/JAX-Toolbox/actions/runs/27210128814/job/80338619984#step:4:1849)
- [EKS OMPI `v4.1.9a1`](https://github.com/NVIDIA/JAX-Toolbox/actions/runs/27210151310/job/80339183988#step:9:156)