### PR TITLE
Fix coordinator discovery for MaxText EKS workloads

### DIFF
--- a/.github/actions/eks-jobset/action.yml
+++ b/.github/actions/eks-jobset/action.yml
@@ -151,8 +151,8 @@ runs:
           | .spec.replicatedJobs[0].template.spec.template.spec.containers[0].image = "${{ inputs.IMAGE }}"
           | .spec.replicatedJobs[0].template.spec.template.spec.containers[0].resources.limits."nvidia.com/gpu" = ${{ inputs.NUM_GPUS }}
           | .spec.replicatedJobs[0].template.spec.template.spec.containers[0].resources.limits."vpc.amazonaws.com/efa" = env(NUM_EFA)
-          | .spec.replicatedJobs[0].template.spec.template.spec.containers[0].env[4].value = "${{ inputs.NUM_NODES }}"
-          | .spec.replicatedJobs[0].template.spec.template.spec.containers[0].env[6].value = "${{ inputs.NUM_GPUS }}"
+          | .spec.replicatedJobs[0].template.spec.template.spec.containers[0].env[5].value = "${{ inputs.NUM_NODES }}"
+          | .spec.replicatedJobs[0].template.spec.template.spec.containers[0].env[7].value = "${{ inputs.NUM_GPUS }}"
           | .spec.replicatedJobs[0].template.spec.template.spec.containers[0].command[2] = strenv(CMD)' \
         > ${JOBSET_YAML}
 

--- a/.github/eks-workflow-files/jobset.yml
+++ b/.github/eks-workflow-files/jobset.yml
@@ -55,16 +55,18 @@ spec:
                   env:
                   - name: JAX_COORDINATOR_PORT
                     value: '3389'
+                  - name: POD_NAMESPACE
+                    valueFrom:
+                      fieldRef:
+                        fieldPath: metadata.namespace
                   - name: JAX_COORDINATOR_HOST
                     valueFrom:
                       fieldRef:
                         fieldPath: metadata.labels['jobset.sigs.k8s.io/coordinator']
                   - name: JAX_COORDINATOR_IP
-                    valueFrom:
-                      fieldRef:
-                        fieldPath: metadata.labels['jobset.sigs.k8s.io/coordinator']
+                    value: "$(JAX_COORDINATOR_HOST).$(POD_NAMESPACE).svc.cluster.local"
                   - name: JAX_COORDINATOR_ADDRESS
-                    value: "$(JAX_COORDINATOR_HOST):$(JAX_COORDINATOR_PORT)"
+                    value: "$(JAX_COORDINATOR_IP):$(JAX_COORDINATOR_PORT)"
                   - name: NNODES
                     value: "1"
                   - name: NODE_RANK

--- a/.github/workflows/_ci.yaml
+++ b/.github/workflows/_ci.yaml
@@ -639,6 +639,8 @@ jobs:
             envs: |-
               NCCL_NET_PLUGIN=none
               NCCL_NET=Socket
+            maxtext-args: |-
+              skip_jax_distributed_system=true
           - test: multi-node
             nodes: 2
             gpus: 8
@@ -648,6 +650,8 @@ jobs:
             tensor-parallel: 2
             envs: |-
               OFI_NCCL_PROTOCOL=SENDRECV
+            maxtext-args: |-
+              jax_distributed_initialization_timeout=60
     runs-on: eks
     steps:
       - uses: actions/checkout@v4
@@ -677,7 +681,9 @@ jobs:
                   max_target_length=1024
                   use_iota_embed=true
                   logits_dot_in_fp32=false
-                  max_segments_per_seq=32'
+                  max_segments_per_seq=32
+                  ${{ matrix.maxtext-args }}
+                  '
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NVCR_TOKEN: ${{ secrets.NVCR_TOKEN }}
 


### PR DESCRIPTION
Addresses some flakiness when running MaxText on EKS e.g [single-node](https://github.com/NVIDIA/JAX-Toolbox/actions/runs/27189839581/job/80277887354#step:3:822), [multi-node](https://github.com/NVIDIA/JAX-Toolbox/actions/runs/27189839581/job/80277887360#step:3:1215)

Passing workloads with fix:
- [Single-node](https://github.com/NVIDIA/JAX-Toolbox/actions/runs/27268509213/job/80541639238#step:3:1704)
- [Multi-node](https://github.com/NVIDIA/JAX-Toolbox/actions/runs/27268509213/job/80541639242#step:3:2837)