### PR TITLE
Temporary fix for nsys-jax 26.07 release

### DIFF
--- a/.github/container/nsys_jax/nsys_jax/utils.py
+++ b/.github/container/nsys_jax/nsys_jax/utils.py
@@ -85,9 +85,11 @@ def remove_autotuning_detail(
         data.compile.loc[mask, "Name"] = "XlaAutotunerMeasurement"
         data.compile = remove_child_ranges(data.compile, mask)
     if compilation and data.compile is not None and len(data.compile):
-        # Remove the detail of the constituent parts (EmitLlvmIr etc.) of autotuner
-        # compilation
-        data.compile = remove_child_ranges(
-            data.compile, data.compile["Name"] == "XlaAutotunerCompilation"
+        # Remove the EmitLlvmIr part, as GEMM-fusion autotuner wraps this in a
+        # single "XlaAutotunerCompilation" since openxla/xla ecf19f5
+        autotuner = data.compile["Name"].str.match(
+            r"XlaAutotunerCompilation|XlaPass:#name=autotuner[,#]"
         )
+        data.compile.loc[autotuner, "Name"] = "XlaAutotunerCompilation"
+        data.compile = remove_child_ranges(data.compile, autotuner)
     return data


### PR DESCRIPTION
Given [ecf19](https://github.com/openxla/xla/commit/ecf19f597af8708d793ac6291c3677f50e304187#diff-e0dfa2ff7db6994eff593a7c359abc88577165e429c84a6e436ad60b0ea63a18L1066) and [43343](https://github.com/openxla/xla/pull/43343), the `XlaAutotunerCompilation` and `XlaAutotunerMeasurement` are gone, so the `remove_autotuning_detail` in nsys-jax cannot collapse autotuner's candidates correctly. 

This is a temporary fix, for re-introducing these annotations and make nsys-jax work on 26.07 release