### PR TITLE
triage: build plugins and metric-based triage

### DIFF
--- a/.github/triage/jax_toolbox_triage/args.py
+++ b/.github/triage/jax_toolbox_triage/args.py
@@ -98,6 +98,16 @@ def parse_args(args=None) -> argparse.Namespace:
             `date` will be substituted, e.g. ghcr.io/nvidia/jax:{container}-{date} for
             the JAX-Toolbox public nightlies.""",
     )
+    parser.add_argument("--metric-name", type=str, help="Example: tflops_per_sec")
+    parser.add_argument(
+        "--passing-metric",
+        action="append",
+        type=float,
+        help="Good value for the metric",
+    )
+    parser.add_argument(
+        "--failing-metric", action="append", type=float, help="Bad value for the metric"
+    )
     parser.add_argument(
         "--output-prefix",
         default=None,
@@ -316,6 +326,14 @@ def parse_args(args=None) -> argparse.Namespace:
         default="main",
         help="The name of the main branch (e.g. main) to derive cherry-picks from",
     )
+    parser.add_argument(
+        "--container-registry",
+        type=str,
+        help="""
+            Remote registry for use with the plugin backend. This can optionally
+            include a tag prefix, i.e. gitlab.com/USER/containers and
+            gitlab.com/USER/containers:PREFIX- are both valid.""",
+    )
     args = parser.parse_args(args=args)
     if args.restart:
         if args.output_prefix is None:
@@ -331,12 +349,28 @@ def parse_args(args=None) -> argparse.Namespace:
             args.output_prefix = pathlib.Path(
                 datetime.datetime.now().strftime("triage-%Y-%m-%d-%H-%M-%S")
             )
-
+    args.optional_software = optional_software.copy()
+    if args.exclude_transformer_engine:
+        args.optional_software.remove("transformer-engine")
     assert args.container_runtime in {
         "docker",
         "pyxis",
         "local",
+        "plugin",
     }, args.container_runtime
+
+    # Metric-based triage checks
+    container_search_options_passed = (
+        args.container is not None
+        or args.start_date is not None
+        or args.end_date is not None
+    )
+    if args.metric_name is not None:
+        if container_search_options_passed:
+            raise Exception(
+                "--metric-name is only supported in version-level search; use --{passing,failing}-{container,versions}."
+            )
+
     args.workaround_buggy_container = set(args.workaround_buggy_container)
     # --{passing,failing}-commits are deprecated aliases for --{passing,failing}-versions.
     for prefix in ["passing", "failing"]:
@@ -393,9 +427,7 @@ def parse_args(args=None) -> argparse.Namespace:
         # If the container-level search is being skipped, because a valid combination
         # of --{passing,failing}-{versions,container} is passed, then no container-level
         # search options should be passed.
-        assert (
-            args.container is None and args.start_date is None and args.end_date is None
-        ), (
+        assert not container_search_options_passed, (
             "No container-level search options should be passed if the passing/failing"
             " containers/versions have been passed explicitly."
         )
@@ -417,12 +449,7 @@ def parse_args(args=None) -> argparse.Namespace:
     else:
         # None of --{passing,failing}-{versions,container} were passed, make sure the
         # compulsory arguments for the container-level search were passed
-        assert (
-            args.container is not None
-        ), "--container must be passed for the container-level search"
-
-    args.optional_software = optional_software.copy()
-    if args.exclude_transformer_engine:
-        args.optional_software.remove("transformer-engine")
-
+        assert args.container is not None, (
+            "--container must be passed for the container-level search"
+        )
     return args

--- a/.github/triage/jax_toolbox_triage/args.py
+++ b/.github/triage/jax_toolbox_triage/args.py
@@ -368,8 +368,18 @@ def parse_args(args=None) -> argparse.Namespace:
     if args.metric_name is not None:
         if container_search_options_passed:
             raise Exception(
-                "--metric-name is only supported in version-level search; use --{passing,failing}-{container,versions}."
+                "--metric-name is only supported in version-level search; use "
+                "--{passing,failing}-{container,versions}."
             )
+        if not args.passing_metric or not args.failing_metric:
+            raise Exception(
+                "You should pass seed metric values via --passing-metric and "
+                "--failing-metric if --metric-name is passed."
+            )
+    if (args.passing_metric or args.failing_metric) and args.metric_name is None:
+        raise Exception(
+            "--metric-name must be passed if --passing-metric or --failing-metric is."
+        )
 
     args.workaround_buggy_container = set(args.workaround_buggy_container)
     # --{passing,failing}-commits are deprecated aliases for --{passing,failing}-versions.

--- a/.github/triage/jax_toolbox_triage/data_files/Dockerfile.triage-tool
+++ b/.github/triage/jax_toolbox_triage/data_files/Dockerfile.triage-tool
@@ -1,0 +1,9 @@
+# syntax=docker/dockerfile:1
+ARG BASE_IMAGE
+ARG BUILD_CMD
+ARG GIT_CMD
+FROM ${BASE_IMAGE}
+ARG BUILD_CMD
+ARG GIT_CMD
+RUN sh -c "${GIT_CMD}"
+RUN --mount=type=cache,target=/root/.cache sh -c "${BUILD_CMD}"

--- a/.github/triage/jax_toolbox_triage/docker.py
+++ b/.github/triage/jax_toolbox_triage/docker.py
@@ -24,10 +24,15 @@ class DockerContainer(Container):
 
     def __enter__(self):
         self._logger.debug(f"Launching {self}")
-        have_gpus = shutil.which("nvidia-smi") is not None
+        have_gpus = (
+            shutil.which("nvidia-smi") is not None
+            and subprocess.run(["nvidia-smi"]).returncode == 0
+        )
         if not have_gpus:
             self._logger.warning("No GPUs detected!")
-        gpu_args = ["--gpus=all"] if have_gpus else []
+        gpu_args = (
+            ["--gpus=all"] if have_gpus else ["-e", "NVIDIA_VISIBLE_DEVICES=void"]
+        )
         result = run_and_log(
             [
                 "docker",
@@ -93,6 +98,7 @@ class DockerContainer(Container):
         """
         Check if the given container exists.
         """
+        # TODO: check without pulling; docker manifest inspect
         result = run_and_log(
             ["docker", "pull", self._url],
             logger=self._logger,

--- a/.github/triage/jax_toolbox_triage/logic.py
+++ b/.github/triage/jax_toolbox_triage/logic.py
@@ -25,18 +25,22 @@ class TestExecutionOutcome(Enum):
 
     __test__ = False  # stop pytest gathering this
     BUILD_FAILURE = auto()
-    TEST_FAILURE = auto()
-    TEST_SUCCESS = auto()
+    TEST_ERROR = auto()  # test could not be run, no results
+    TEST_YIELDED_RESULTS = auto()  # ran, yielded results
+
+
+_EXIT_CODE_METRIC = "exit_code"
 
 
 @dataclass
 class TestResult:
     """
-    Hold the pass/fail result and the interleaved stdout/stderr of a test run.
+    Hold the outcome and the interleaved stdout/stderr of a test run.
 
     `build_stdouterr` can be None if there was no build, e.g. running the test case in
     an existing container.
     `stdouterr` can be None if the build did not succeed, so the test was not run.
+    `metrics` is empty unless `result` is `TestExecutionOutcome.TEST_YIELDED_RESULTS`
     """
 
     __test__ = False  # stop pytest gathering this
@@ -44,6 +48,84 @@ class TestResult:
     host_output_directory: pathlib.Path
     result: TestExecutionOutcome
     stdouterr: typing.Optional[str]
+    time: typing.Optional[float]
+    metrics: typing.Dict[str, typing.Any]
+
+    def exit_code_based_pass(self):
+        exit_code = self.metrics.get(_EXIT_CODE_METRIC)
+        return (
+            self.result == TestExecutionOutcome.TEST_YIELDED_RESULTS
+            and isinstance(exit_code, int)
+            and exit_code == 0
+        )
+
+    def exit_code_based_fail(self):
+        exit_code = self.metrics.get(_EXIT_CODE_METRIC)
+        return (
+            self.result == TestExecutionOutcome.TEST_YIELDED_RESULTS
+            and isinstance(exit_code, int)
+            and exit_code != 0
+        )
+
+
+class ClassifiedTestOutcome(Enum):
+    """
+    Enumerate the possible outcomes of a build + test run (+ possible re-runs)
+    followed by classification of its results.
+    """
+
+    __test__ = False  # stop pytest gathering this
+    AMBIGUOUS = auto()
+    ERROR = auto()
+    FAIL = auto()
+    PASS = auto()
+
+
+class ExecutionClassifier(typing.Protocol):
+    def __call__(
+        self, test_results: typing.Sequence[TestResult]
+    ) -> ClassifiedTestOutcome:
+        """
+        Classify the given results. If the classifier returns that the results are
+        ambiguous, it should not update its internal state and should expect to be
+        called again with a longer `test_results` list.
+        """
+        ...
+
+    def add_data_with_label(
+        self, results: typing.Sequence[TestResult], label: ClassifiedTestOutcome
+    ):
+        """
+        Add the given data to the internal state of the classifier. This can be used to
+        add more samples from a known population after initialisation.
+        """
+        ...
+
+    def text_summary(
+        self, *, columns: int = 120, rows: int = 3
+    ) -> typing.Sequence[str]:
+        """
+        Return some lines of text summarising the state of the classifier.
+        """
+        ...
+
+
+class ExitCodeClassifier(ExecutionClassifier):
+    """
+    A simple classifier with no fuzziness and no retries.
+    """
+
+    def __call__(
+        self, test_results: typing.Sequence[TestResult]
+    ) -> ClassifiedTestOutcome:
+        if all(r.exit_code_based_pass() for r in test_results):
+            return ClassifiedTestOutcome.PASS
+        elif all(r.exit_code_based_fail() for r in test_results):
+            return ClassifiedTestOutcome.FAIL
+        return ClassifiedTestOutcome.ERROR
+
+    def text_summary(self, *, columns: int = 120, rows: int = 3) -> typing.List[str]:
+        return []
 
 
 def as_datetime(date: datetime.date) -> datetime.datetime:
@@ -144,7 +226,7 @@ def container_search(
         logger.info(f"Checking end-of-range failure in {end_date}")
         # Print context for the IMPORTANT .info(...) to the console
         test_end_date = container_passes(end_date, test_output_log_level=logging.INFO)
-        if test_end_date.result != TestExecutionOutcome.TEST_FAILURE:
+        if not test_end_date.exit_code_based_fail():
             raise Exception(f"Could not reproduce failure in {end_date}")
         logger.info(
             "IMPORTANT: you should check that the test output above shows the "
@@ -185,11 +267,12 @@ def container_search(
                 f"Starting coarse search with {search_date} based on --start-date"
             )
 
+    classifier = ExitCodeClassifier()
     if skip_first_phase:
         logger.info(f"Skipping check that the test passes on start_date={start_date}")
     else:
         # While condition prints an info message
-        while container_passes(search_date).result != TestExecutionOutcome.TEST_SUCCESS:
+        while classifier([container_passes(search_date)]) != ClassifiedTestOutcome.PASS:
             # Test failed on `search_date`, go further into the past
             earliest_failure = search_date
             new_search_date = adjust(
@@ -217,9 +300,11 @@ def container_search(
         if range_mid is None:
             # It wasn't possible to refine further.
             break
-        if container_passes(range_mid).result == TestExecutionOutcome.TEST_SUCCESS:
+        outcome = classifier([container_passes(range_mid)])
+        if outcome == ClassifiedTestOutcome.PASS:
             range_start = range_mid
         else:
+            assert outcome == ClassifiedTestOutcome.FAIL
             range_end = range_mid
         logger.info(f"Refined container-level range to [{range_start}, {range_end}]")
     return range_start, range_end
@@ -318,7 +403,15 @@ def _strip_build_failures(versions: typing.Dict[str, str]) -> typing.Dict[str, s
     return {k: remove_build_failures(v) for k, v in versions.items()}
 
 
+# Fake version key used to distinguish between intentional repeated measurements of the
+# same thing
 _REPETITION_KEY = "#rep"
+
+# Special version key used to denote versions of the test command itself. This has
+# special treatment because, while it is included in the multi-project triage along
+# with the various software versions, it is passed to the test command rather than
+# being checked out/built/baked into the test container.
+_WORKLOAD_VERSION_KEY = "WORKLOAD"
 
 
 def version_cache_key(
@@ -342,7 +435,9 @@ def version_search(
     skip_precondition_checks: bool,
     check_success_before_failure: bool = True,
     confirmation_iterations: int = 1,
+    max_repetitions: typing.Optional[int] = None,
     result_cache: typing.Optional[typing.Dict[FlatVersionDict, TestResult]] = None,
+    classifier: ExecutionClassifier = ExitCodeClassifier(),
 ) -> typing.Tuple[typing.Dict[str, str], TestResult, typing.Optional[TestResult]]:
     """
     Bisect a failure back to a single version of a single component.
@@ -357,8 +452,12 @@ def version_search(
     skip_precondition_checks: if True, some tests that should pass/fail by
         construction are skipped
     check_success_before_failure: choose the order of precondition checks
-    confirmation_iterations: after convergence, re-run the first-known-bad and
-        last-known-good versions this many extra times to build confidence
+    confirmation_iterations: check the known-bad/known-good inputs and the
+        first-known-bad/last-known-good output at least this many *extra* times
+    max_repetitions: if the classifier returns an ambiguous result and requests more
+        data, this is the maximum number of extra runs, i.e. the maximum total number
+        of times any given set of versions will be executed is `max_repetitions + 1`.
+        Defaults to be `confirmation_iterations + 2`.
     result_cache: previously completed build/test results to reuse
 
     Returns a 3-tuple of (summary_dict, last_known_good, first_known_bad),
@@ -367,6 +466,12 @@ def version_search(
     False, but the other fields can be used to obtain stdout+stderr and
     output files from those test invocations.
     """
+    if max_repetitions is None:
+        max_repetitions = confirmation_iterations + 2
+    assert max_repetitions >= confirmation_iterations, (
+        max_repetitions,
+        confirmation_iterations,
+    )
     if result_cache is None:
         result_cache = {}
 
@@ -388,63 +493,98 @@ def version_search(
         cache_key = version_cache_key(bisect_versions, repetition=repetition)
         bisect_result = result_cache.get(cache_key)
         if bisect_result is not None:
-            logger.info(f"Reusing cached result for {dict(cache_key)}")
+            logger.info(
+                f"Reusing cached result for {dict(cache_key)}: "
+                f"{bisect_result.result}: {bisect_result.metrics}"
+            )
             return bisect_result
         bisect_result = build_and_test(
             versions=_strip_build_failures(bisect_versions),
             test_output_log_level=test_output_log_level,
             test_repetition=repetition,
         )
+        logger.info(
+            f"New result for {dict(cache_key)}: {bisect_result.result}: "
+            f"{bisect_result.metrics}"
+        )
         result_cache[cache_key] = bisect_result
         return bisect_result
 
-    def _check_success():
-        # Verify that we can build successfully and that the test succeeds as expected.
+    def _check(
+        good_or_bad, check_versions, desired_outcome, CouldNotReproduceDesiredOutcome
+    ):
+        # Verify that we can build successfully and that the test gives the expected results.
         logger.info(
-            f"Verifying test success using 'good' versions {confirmation_iterations + 1} times"
+            f"Verifying test success using {good_or_bad} versions "
+            f"{confirmation_iterations + 1} times"
         )
+        # Run `confirmation_iterations + 1` runs to confirm non-flakiness (boolean
+        # triage) and/or seed the classifier state (metric-based triage)
         for n in range(confirmation_iterations + 1):
-            check_pass = build_cached(
-                _earliest_versions(versions),
-                repetition=-n,
+            test_output_log_level = (
+                logging.INFO
+                if n == 0 and desired_outcome == ClassifiedTestOutcome.FAIL
+                else logging.DEBUG
             )
-            if check_pass.result == TestExecutionOutcome.TEST_SUCCESS:
-                logger.info("Verified test passes using 'good' versions")
-            else:
-                err = f"Could not reproduce success with 'good' versions ({check_pass.result}, attempt {n})"
+            check = build_cached(
+                check_versions,
+                repetition=n,
+                test_output_log_level=test_output_log_level,
+            )
+            if check.result == TestExecutionOutcome.BUILD_FAILURE:
+                err = f"Build failure attempting to reproduce result with {good_or_bad} versions"
                 logger.fatal(err)
-                if check_pass.result == TestExecutionOutcome.BUILD_FAILURE:
-                    logger.fatal(check_pass.build_stdouterr)
+                logger.fatal(check.build_stdouterr)
+                raise CouldNotReproduceDesiredOutcome(err)
+            outcome = classifier([check])
+            assert outcome != ClassifiedTestOutcome.ERROR
+            if outcome == ClassifiedTestOutcome.AMBIGUOUS:
+                # For metric-based triage, these up-front checking loops are important
+                # to help initialise the classifier state. Rather than spending a long
+                # time looping, force ambiguous results to resolve in the direction of
+                # our expectations
+                logger.info(
+                    f"Ambiguous result when attempting {good_or_bad} version "
+                    "verification, forcing it into the classifier as labelled data..."
+                )
+                classifier.add_data_with_label([check], desired_outcome)
+            classifier_status = classifier.text_summary()
+            if len(classifier_status):
+                logger.info("Updated classifier status:")
+                for row in classifier_status:
+                    logger.info(row)
+            if outcome == desired_outcome:
+                if desired_outcome == ClassifiedTestOutcome.FAIL:
+                    logger.log(
+                        test_output_log_level,
+                        "Verified test failure using 'bad' versions. IMPORTANT: you should "
+                        "check that the test output above shows the *expected* failure of your "
+                        "test case. It is very easy to accidentally provide a test case that "
+                        "fails for the wrong reason, which will not triage the correct issue!",
+                    )
                 else:
-                    logger.fatal(check_pass.stdouterr)
-                raise CouldNotReproduceSuccess(err)
+                    logger.info(f"Verified test result using {good_or_bad} versions.")
+            elif outcome in {ClassifiedTestOutcome.PASS, ClassifiedTestOutcome.FAIL}:
+                err = f"Could not reproduce results with {good_or_bad} versions ({outcome}, iteration {n})"
+                logger.fatal(err)
+                logger.fatal(check.stdouterr)
+                raise CouldNotReproduceDesiredOutcome(err)
+
+    def _check_success():
+        _check(
+            "'good'",
+            _earliest_versions(versions),
+            ClassifiedTestOutcome.PASS,
+            CouldNotReproduceSuccess,
+        )
 
     def _check_failure():
-        # Verify we can build successfully and that the test fails as expected.
-        logger.info(
-            f"Verifying test failure using 'bad' versions {confirmation_iterations + 1} times"
+        _check(
+            "'bad'",
+            _latest_versions(versions),
+            ClassifiedTestOutcome.FAIL,
+            CouldNotReproduceFailure,
         )
-        for n in range(confirmation_iterations + 1):
-            check_fail = build_cached(
-                _latest_versions(versions),
-                repetition=-n,
-                test_output_log_level=logging.INFO if n == 0 else logging.DEBUG,
-            )
-            if check_fail.result == TestExecutionOutcome.TEST_FAILURE:
-                logger.info(
-                    "Verified test failure using 'bad' versions. IMPORTANT: you should "
-                    "check that the test output above shows the *expected* failure of your "
-                    "test case. It is very easy to accidentally provide a test case that "
-                    "fails for the wrong reason, which will not triage the correct issue!"
-                )
-            else:
-                err = f"Could not reproduce failure with 'bad' versions ({check_fail.result}, attempt {n})"
-                logger.fatal(err)
-                if check_fail.result == TestExecutionOutcome.BUILD_FAILURE:
-                    logger.fatal(check_fail.build_stdouterr)
-                else:
-                    logger.fatal(check_fail.stdouterr)
-                raise CouldNotReproduceFailure(err)
 
     if skip_precondition_checks:
         logger.info("Skipping check that 'good' and 'bad' versions reproduce success")
@@ -478,7 +618,7 @@ def version_search(
             return bisect_result, bisect_versions
         logger.info(
             f"Encountered build failure using index={indices[primary]} of "
-            f"the remaining {primary} versions"
+            f"the remaining {len(versions[primary])} {primary} versions"
         )
         # Versions based on the middle of the remaining `primary` commits led to a
         # build failure (n), but the endpoints build OK (y).
@@ -500,9 +640,9 @@ def version_search(
         # succeeds so we can do the same. The somewhat arbitrary logic here is to take
         # the shorter y??????n run and refine it in the hope one of the ? is a y.
         assert (
-            result_cache.get(version_cache_key(_earliest_versions(versions))).result
-            == TestExecutionOutcome.TEST_SUCCESS
-        )
+            result_cache[version_cache_key(_earliest_versions(versions))].result
+            != TestExecutionOutcome.BUILD_FAILURE
+        ), result_cache[version_cache_key(_earliest_versions(versions))].result
         build_statuses = [(True, {p: 0 for p in versions})]
         for n in range(1, len(versions[primary]) - 1):
             versions_n, indices_n = get_versions(primary_index=n, versions=versions)
@@ -513,9 +653,9 @@ def version_search(
             )
             build_statuses.append((None if result_n is None else False, indices_n))
         assert (
-            result_cache.get(version_cache_key(_latest_versions(versions))).result
-            == TestExecutionOutcome.TEST_FAILURE
-        )
+            result_cache[version_cache_key(_latest_versions(versions))].result
+            != TestExecutionOutcome.BUILD_FAILURE
+        ), result_cache.get(version_cache_key(_latest_versions(versions))).result
         build_statuses.append((True, {p: len(vs) - 1 for p, vs in versions.items()}))
         assert len(build_statuses) == len(versions[primary])
         # build_statuses is something like [True, None, False, None, True]; identify
@@ -568,6 +708,25 @@ def version_search(
                 }
         return bisect_result, bisect_versions
 
+    def _outcome_with_retries(test_versions, *, min_runs, max_runs):
+        results = [build_cached(test_versions, repetition=n) for n in range(min_runs)]
+        outcome = classifier(results)
+        if outcome == ClassifiedTestOutcome.AMBIGUOUS:
+            logger.info(
+                f"Ambiguous result from {len(results)} measurements, running "
+                f"up to {max_runs - min_runs} extra measurements to disambiguate."
+            )
+            for n in range(min_runs, max_runs):
+                results.append(build_cached(test_versions, repetition=n))
+                outcome = classifier(results)
+                if outcome != ClassifiedTestOutcome.AMBIGUOUS:
+                    logger.info(
+                        f"Got non-ambiguous outcome {outcome} from {len(results)} "
+                        "measurements."
+                    )
+                    break
+        return outcome, results
+
     while len(versions[primary]) > 2:
         bisect_result, bisect_versions = find_successful_build(versions=versions)
 
@@ -579,21 +738,31 @@ def version_search(
             assert False
 
         indices = {pkg: _index(pkg, ver) for pkg, ver in bisect_versions.items()}
-        if bisect_result.result == TestExecutionOutcome.TEST_SUCCESS:
+        outcome, _ = _outcome_with_retries(
+            bisect_versions, min_runs=1, max_runs=max_repetitions + 1
+        )
+        classifier_status = classifier.text_summary()
+        if len(classifier_status):
+            logger.info("Updated classifier status:")
+            for row in classifier_status:
+                logger.info(row)
+        if outcome == ClassifiedTestOutcome.PASS:
             # Test passed, continue searching in the second half
             for package, index in indices.items():
                 versions[package] = versions[package][index:]
-        elif bisect_result.result == TestExecutionOutcome.TEST_FAILURE:
+        elif outcome == ClassifiedTestOutcome.FAIL:
             # Test failed, continue searching in the first half
             for package, index in indices.items():
                 versions[package] = versions[package][: index + 1]
+        elif outcome == ClassifiedTestOutcome.AMBIGUOUS:
+            err = f"Could not reach an unambiguous result with {max_repetitions + 1} measurements."
+            logger.fatal(err)
+            raise Exception(err)
         else:
-            assert (
-                bisect_result.result == TestExecutionOutcome.BUILD_FAILURE
-            ), bisect_result
-            # Did not succeed in finding a version of `primary` that builds. This does
-            # not quite mean that all versions fail, as the algorithm will not try all
-            # versions in ranges with failures at both ends
+            assert outcome == ClassifiedTestOutcome.ERROR, outcome
+            # Did not succeed in finding a version of `primary` that gives results.
+            # This does not quite mean that all versions fail, as the algorithm will
+            # not try all versions in ranges with failures at both ends
             #
             #       might
             #          \
@@ -604,16 +773,15 @@ def version_search(
             # as given middle=fail, and Q1=fail the points between Q1 and middle will
             # not be checked.
             n_primary = len(versions[primary])
-            logger.info(n_primary)
             build_fail_commits = []
             for n in range(1, n_primary - 1):
                 versions_n, _ = get_versions(primary_index=n, versions=versions)
                 # Should have been a build failure if tested.
                 result_n = result_cache.get(version_cache_key(versions_n))
                 if result_n is not None:
-                    assert (
-                        result_n.result == TestExecutionOutcome.BUILD_FAILURE
-                    ), result_n
+                    assert result_n.result == TestExecutionOutcome.BUILD_FAILURE, (
+                        result_n
+                    )
                 build_fail_commits.append(versions_n[primary])
             logger.warning(
                 f"Could not triage {primary} to a single version due to build "
@@ -651,9 +819,13 @@ def version_search(
         f"Two {primary} versions remain, checking if {versions[primary][-1][0]} is the "
         "culprit"
     )
-    # It's possible that this combination has already been tested at this point
-    blame = build_cached(blame_versions)
-    if blame.result == TestExecutionOutcome.TEST_SUCCESS:
+    # FIXME: It's possible that this combination has already been tested at this point,
+    # so the classifier may have seen some values before and they may, therefore, get
+    # double counted in its internal state.
+    blame_outcome, _ = _outcome_with_retries(
+        blame_versions, min_runs=1, max_runs=max_repetitions + 1
+    )
+    if blame_outcome == ClassifiedTestOutcome.PASS:
         # Test passed with {pX, sZ, tZ, ...} but was known to fail with
         # {pZ, sZ, tZ, ...}. Therefore pZ is the culprit version.
         log_str = f"Bisected failure to {primary} {bad_version} with"
@@ -687,18 +859,29 @@ def version_search(
         # Run the test case a few more times as a final line of defence against flakiness.
         # `blame_versions` are last-known-good, `first_known_bad` are what they say.
         # We just tested `blame_versions`, so start with `first_known_bad`.
-        for n in range(confirmation_iterations):
-            confirm_bad = build_cached(first_known_bad, repetition=n + 1)
-            assert confirm_bad.result == TestExecutionOutcome.TEST_FAILURE
-            confirm_good = build_cached(blame_versions, repetition=n + 1)
-            assert confirm_good.result == TestExecutionOutcome.TEST_SUCCESS
-        return ret, blame, first_known_bad_result
-    else:
+        # FIXME: as above this may double-count in the classifier state.
+        bad_outcome, confirm_bad = _outcome_with_retries(
+            first_known_bad,
+            min_runs=1 + confirmation_iterations,
+            max_runs=1 + max_repetitions,
+        )
+        for row in classifier.text_summary():
+            logger.info(row)
+        assert bad_outcome == ClassifiedTestOutcome.FAIL, (bad_outcome, confirm_bad)
+        good_outcome, confirm_good = _outcome_with_retries(
+            blame_versions,
+            min_runs=1 + confirmation_iterations,
+            max_runs=1 + max_repetitions,
+        )
+        for row in classifier.text_summary():
+            logger.info(row)
+        assert good_outcome == ClassifiedTestOutcome.PASS, (good_outcome, confirm_good)
+        return ret, confirm_good, confirm_bad
+    elif blame_outcome == ClassifiedTestOutcome.FAIL:
         # Test failed with both {pX, sZ, tZ, ...} and {pZ, sZ, tZ, ...}, so
         # we can fix the primary package to pX and recurse with the old
         # secondary package (s) as the new primary, and the old primary
         # package (p) moved to the end.
-        assert blame.result == TestExecutionOutcome.TEST_FAILURE, blame.result
         versions[primary] = [versions.pop(primary)[0]]
         return version_search(
             build_and_test=build_and_test,
@@ -707,4 +890,9 @@ def version_search(
             skip_precondition_checks=True,
             result_cache=result_cache,
             confirmation_iterations=confirmation_iterations,
+            classifier=classifier,
         )
+    else:
+        err = f"Could not handle blame outcome {blame_outcome}"
+        logger.fatal(err)
+        raise Exception(err)

--- a/.github/triage/jax_toolbox_triage/logic.py
+++ b/.github/triage/jax_toolbox_triage/logic.py
@@ -124,6 +124,15 @@ class ExitCodeClassifier(ExecutionClassifier):
             return ClassifiedTestOutcome.FAIL
         return ClassifiedTestOutcome.ERROR
 
+    def add_data_with_label(
+        self, results: typing.Sequence[TestResult], label: ClassifiedTestOutcome
+    ):
+        if label == ClassifiedTestOutcome.PASS:
+            assert all(r.exit_code_based_pass() for r in results), results
+        else:
+            assert label == ClassifiedTestOutcome.FAIL, label
+            assert all(r.exit_code_based_fail() for r in results)
+
     def text_summary(self, *, columns: int = 120, rows: int = 3) -> typing.List[str]:
         return []
 
@@ -438,7 +447,9 @@ def version_search(
     max_repetitions: typing.Optional[int] = None,
     result_cache: typing.Optional[typing.Dict[FlatVersionDict, TestResult]] = None,
     classifier: ExecutionClassifier = ExitCodeClassifier(),
-) -> typing.Tuple[typing.Dict[str, str], TestResult, typing.Optional[TestResult]]:
+) -> typing.Tuple[
+    typing.Dict[str, str], typing.Sequence[TestResult], typing.Sequence[TestResult]
+]:
     """
     Bisect a failure back to a single version of a single component.
 
@@ -515,7 +526,7 @@ def version_search(
     ):
         # Verify that we can build successfully and that the test gives the expected results.
         logger.info(
-            f"Verifying test success using {good_or_bad} versions "
+            f"Verifying test outcome using {good_or_bad} versions "
             f"{confirmation_iterations + 1} times"
         )
         # Run `confirmation_iterations + 1` runs to confirm non-flakiness (boolean

--- a/.github/triage/jax_toolbox_triage/metric_classifier.py
+++ b/.github/triage/jax_toolbox_triage/metric_classifier.py
@@ -16,8 +16,8 @@ class MetricClassifier(ExecutionClassifier):
         self,
         *,
         metric_name: str,
-        passing_values: typing.Sequence[float],
-        failing_values: typing.Sequence[float],
+        passing_values: typing.List[float],
+        failing_values: typing.List[float],
         threshold: float = 0.997,
         common_variance: bool = True,
     ):
@@ -58,13 +58,13 @@ class MetricClassifier(ExecutionClassifier):
             "b": 0.5 * ss,
         }
 
-    def _scale(self, s):
+    def _scale(self, s) -> float:
         a = s.get("a", self._shared.get("a"))
         b = s.get("b", self._shared.get("b"))
         assert a is not None and b is not None
         return math.sqrt(b * (s["k"] + 1) / (a * s["k"]))
 
-    def _log_evidence(self, s, xs):
+    def _log_evidence(self, s, xs) -> float:
         n = len(xs)
         xb = sum(xs) / n
         ss = sum((x - xb) ** 2 for x in xs)
@@ -84,7 +84,7 @@ class MetricClassifier(ExecutionClassifier):
             - n / 2 * math.log(math.pi)
         )
 
-    def _log_ratio(self, xs) -> ClassifiedTestOutcome:
+    def _log_ratio(self, xs) -> float:
         return self._log_evidence(self._pass, xs) - self._log_evidence(self._fail, xs)
 
     def _update(self, s, xs):
@@ -107,7 +107,9 @@ class MetricClassifier(ExecutionClassifier):
         s["k"] = k
         _add_to("a", n / 2)
 
-    def __call__(self, test_results: typing.Sequence[TestResult]):
+    def __call__(
+        self, test_results: typing.Sequence[TestResult]
+    ) -> ClassifiedTestOutcome:
         assert len(test_results)
 
         if any(
@@ -181,6 +183,7 @@ class MetricClassifier(ExecutionClassifier):
                 output.append(sep.join(chars))
 
         low_edges, high_edges = bin_edges[:-1], bin_edges[1:]
+
         def _print_label(*, low, mean, high, char):
             row = np.asarray([" "] * columns)
             row[(low_edges > low) & (high_edges < high)] = char
@@ -197,7 +200,7 @@ class MetricClassifier(ExecutionClassifier):
             f"fail={fail_uf} (n={len(self._fail_history)})"
         )
         _print_hist(fail_hist)
-        _print_label(low=fail_lo, high=fail_hi, mean=fail_mean, char='F')
+        _print_label(low=fail_lo, high=fail_hi, mean=fail_mean, char="F")
         _print_hist(pass_hist)
         _print_label(low=pass_lo, high=pass_hi, mean=pass_mean, char="P")
         return output

--- a/.github/triage/jax_toolbox_triage/metric_classifier.py
+++ b/.github/triage/jax_toolbox_triage/metric_classifier.py
@@ -1,0 +1,203 @@
+import math
+import numpy as np
+import typing
+from uncertainties import ufloat
+
+from .logic import (
+    ClassifiedTestOutcome,
+    ExecutionClassifier,
+    TestExecutionOutcome,
+    TestResult,
+)
+
+
+class MetricClassifier(ExecutionClassifier):
+    def __init__(
+        self,
+        *,
+        metric_name: str,
+        passing_values: typing.Sequence[float],
+        failing_values: typing.Sequence[float],
+        threshold: float = 0.997,
+        common_variance: bool = True,
+    ):
+        """
+        The classifier models the metric as two Gaussian distributions (pass/fail),
+        optionally constrained to have the same variance as one another. The parameters
+        of the two distributions are seeded by the values passed to this constructor
+        for each population, and are optionally updated with additional labelled values
+        using `add_data_with_label`. If new values can be assigned to one of the two
+        populations with confidence greater than `threshold`, they are also used to
+        update the estimated parameters of the distributions.
+        """
+        self._metric_name = metric_name
+        self._threshold = threshold
+        self._log_threshold_odds = math.log(threshold / (1 - threshold))
+        self._pass = self._fit(passing_values)
+        self._fail = self._fit(failing_values)
+        # Make sure neither of the widths is excessively low w.r.t. the spread between
+        # the seed mean values of the two populations.
+        self._min_b = 1e-4 * ((self._pass["m"] - self._fail["m"]) ** 2)
+        self._pass["b"] = max(self._min_b, self._pass["b"])
+        self._fail["b"] = max(self._min_b, self._fail["b"])
+        self._shared = {}
+        if common_variance:
+            self._shared["a"] = self._pass.pop("a") + self._fail.pop("a")
+            self._shared["b"] = self._pass.pop("b") + self._fail.pop("b")
+        self._pass_history = passing_values.copy()
+        self._fail_history = failing_values.copy()
+
+    def _fit(self, xs):
+        n = len(xs)
+        m = sum(xs) / n
+        ss = sum((x - m) ** 2 for x in xs)
+        return {
+            "m": m,
+            "k": n,
+            "a": n / 2,
+            "b": 0.5 * ss,
+        }
+
+    def _scale(self, s):
+        a = s.get("a", self._shared.get("a"))
+        b = s.get("b", self._shared.get("b"))
+        assert a is not None and b is not None
+        return math.sqrt(b * (s["k"] + 1) / (a * s["k"]))
+
+    def _log_evidence(self, s, xs):
+        n = len(xs)
+        xb = sum(xs) / n
+        ss = sum((x - xb) ** 2 for x in xs)
+
+        a_input = s.get("a", self._shared.get("a"))
+        b_input = s.get("b", self._shared.get("b"))
+
+        k = s["k"] + n
+        a = a_input + n / 2
+        b = b_input + 0.5 * ss + s["k"] * n * (xb - s["m"]) ** 2 / (2 * k)
+        return (
+            math.lgamma(a)
+            - math.lgamma(a_input)
+            + 0.5 * (math.log(s["k"]) - math.log(k))
+            + a_input * math.log(b_input)
+            - a * math.log(b)
+            - n / 2 * math.log(math.pi)
+        )
+
+    def _log_ratio(self, xs) -> ClassifiedTestOutcome:
+        return self._log_evidence(self._pass, xs) - self._log_evidence(self._fail, xs)
+
+    def _update(self, s, xs):
+        n = len(xs)
+        xb = sum(xs) / n
+        k = s["k"] + n
+
+        def _add_to(key, v):
+            if key in s:
+                s[key] += v
+            else:
+                self._shared[key] += v
+
+        _add_to(
+            "b",
+            0.5 * sum((x - xb) ** 2 for x in xs)
+            + s["k"] * n * (xb - s["m"]) ** 2 / (2 * k),
+        )
+        s["m"] = (s["k"] * s["m"] + n * xb) / k
+        s["k"] = k
+        _add_to("a", n / 2)
+
+    def __call__(self, test_results: typing.Sequence[TestResult]):
+        assert len(test_results)
+
+        if any(
+            r.result != TestExecutionOutcome.TEST_YIELDED_RESULTS for r in test_results
+        ):
+            return ClassifiedTestOutcome.ERROR
+
+        # FIXME: what if some of `test_results` have been seen before?
+        xs = [r.metrics[self._metric_name] for r in test_results]
+        log_ratio = self._log_ratio(xs)
+        if log_ratio > self._log_threshold_odds:
+            self._pass_history += xs
+            self._update(self._pass, xs)
+            return ClassifiedTestOutcome.PASS
+        elif log_ratio < -self._log_threshold_odds:
+            self._fail_history += xs
+            self._update(self._fail, xs)
+            return ClassifiedTestOutcome.FAIL
+        return ClassifiedTestOutcome.AMBIGUOUS
+
+    def add_data_with_label(
+        self, results: typing.Sequence[TestResult], label: ClassifiedTestOutcome
+    ):
+        xs = [r.metrics[self._metric_name] for r in results]
+        if label == ClassifiedTestOutcome.PASS:
+            self._pass_history += xs
+            self._update(self._pass, xs)
+        else:
+            assert label == ClassifiedTestOutcome.FAIL, label
+            self._fail_history += xs
+            self._update(self._fail, xs)
+
+    def text_summary(self, *, columns: int = 120, rows: int = 3) -> typing.List[str]:
+        fail_mean, pass_mean = self._fail["m"], self._pass["m"]
+        fail_width, pass_width = self._scale(self._fail), self._scale(self._pass)
+        fail_lo, fail_hi = fail_mean - fail_width, fail_mean + fail_width
+        pass_lo, pass_hi = pass_mean - pass_width, pass_mean + pass_width
+        min_x = min(min(self._fail_history), min(self._pass_history), fail_lo, pass_lo)
+        max_x = max(max(self._fail_history), max(self._pass_history), fail_hi, pass_hi)
+
+        def _hist(data, *, edges=False):
+            data, bin_data = np.histogram(data, bins=columns, range=(min_x, max_x))
+            return (data, bin_data) if edges else data
+
+        fail_hist, bin_edges = _hist(self._fail_history, edges=True)
+        pass_hist = _hist(self._pass_history)
+        max_bin_value = int(max(fail_hist.max(), pass_hist.max()))
+        sep = ""  # narrow space tempting, but not with monospace font
+        output = []
+
+        def _print_hist(hist):
+            dots = {
+                0: " ",
+                1: "\N{LOWER ONE EIGHTH BLOCK}",
+                2: "\N{LOWER ONE QUARTER BLOCK}",
+                3: "\N{LOWER THREE EIGHTHS BLOCK}",
+                4: "\N{LOWER HALF BLOCK}",
+                5: "\N{LOWER FIVE EIGHTHS BLOCK}",
+                6: "\N{LOWER THREE QUARTERS BLOCK}",
+                7: "\N{LOWER SEVEN EIGHTHS BLOCK}",
+                8: "\N{FULL BLOCK}",
+            }
+            max_dots = max(dots.keys())
+            for row in range(rows)[::-1]:
+                chars = []
+                for col in range(columns):
+                    # ceil to avoid rounding non-zero bins to zero
+                    height = int(math.ceil(rows * max_dots * hist[col] / max_bin_value))
+                    chars.append(dots[min(max_dots, max(0, height - max_dots * row))])
+                assert len(chars) == columns
+                output.append(sep.join(chars))
+
+        low_edges, high_edges = bin_edges[:-1], bin_edges[1:]
+        def _print_label(*, low, mean, high, char):
+            row = np.asarray([" "] * columns)
+            row[(low_edges > low) & (high_edges < high)] = char
+            row[_hist([low]).astype(bool)] = "\\"
+            row[_hist([high]).astype(bool)] = "/"
+            row[_hist([mean]).astype(bool)] = "|"
+            output.append(sep.join(row))
+
+        pass_uf = ufloat(pass_mean, pass_width)
+        fail_uf = ufloat(fail_mean, fail_width)
+        output.append(
+            f"x=[{min_x:.2f}, {max_x:.2f}] "
+            f"pass={pass_uf} (n={len(self._pass_history)}) "
+            f"fail={fail_uf} (n={len(self._fail_history)})"
+        )
+        _print_hist(fail_hist)
+        _print_label(low=fail_lo, high=fail_hi, mean=fail_mean, char='F')
+        _print_hist(pass_hist)
+        _print_label(low=pass_lo, high=pass_hi, mean=pass_mean, char="P")
+        return output

--- a/.github/triage/jax_toolbox_triage/summary.py
+++ b/.github/triage/jax_toolbox_triage/summary.py
@@ -14,6 +14,7 @@ VERSION_CACHE_SECTION = "versions"
 VERSION_RECORD_METADATA = {
     "build_time",
     "container",
+    "metrics",
     "output_directory",
     "result",
     "test_repetition",
@@ -101,51 +102,51 @@ def result_cache_from_summary(
         if not {"container", "result", "output_directory"} <= record.keys():
             logging.warning("Ignoring incomplete restart container record: %s", record)
             continue
-        result = (
-            TestExecutionOutcome.TEST_SUCCESS
-            if record["result"]
-            else TestExecutionOutcome.TEST_FAILURE
+        result_name = record["result"].rsplit(".", 1)[-1]
+        result_enum = TestExecutionOutcome[result_name]
+        assert (
+            "metrics" in record
+            or result_enum != TestExecutionOutcome.TEST_YIELDED_RESULTS
         )
         cache[(CONTAINER_CACHE_SECTION, record["container"])] = TestResult(
             build_stdouterr=None,
             host_output_directory=_record_output_directory(output_prefix, record),
-            result=result,
+            result=result_enum,
             stdouterr=None,
+            metrics=record.get("metrics", {}),
+            time=record.get("test_time"),  # Might not exist for build failures
         )
 
     for record in summary.get("versions", []):
-        if not isinstance(record, dict):
-            continue
-        if "result" not in record or "output_directory" not in record:
-            logging.warning("Ignoring incomplete restart summary record: %s", record)
-            continue
         versions = {
             key: value
             for key, value in record.items()
             if key not in VERSION_RECORD_METADATA
         }
-        if not versions:
-            logging.warning(
-                "Ignoring restart summary record that is missing package keys: %s",
-                record,
-            )
-            continue
         repetition = int(record.get("test_repetition", 0))
         key = version_cache_key(versions, repetition=repetition)
         result_name = record["result"].rsplit(".", 1)[-1]
+        result_enum = TestExecutionOutcome[result_name]
+        assert (
+            "metrics" in record
+            or result_enum != TestExecutionOutcome.TEST_YIELDED_RESULTS
+        )
+        out_dir = _record_output_directory(output_prefix, record)
         cache[(VERSION_CACHE_SECTION, key)] = TestResult(
             build_stdouterr=None,
-            host_output_directory=_record_output_directory(output_prefix, record),
-            result=TestExecutionOutcome[result_name],
+            host_output_directory=out_dir,
+            result=result_enum,
             stdouterr=None,
+            metrics=record.get("metrics", {}),
+            time=record.get("test_time"),  # Might not exist for build failures
         )
     return cache
 
 
 def create_output_symlinks(
     output_prefix: pathlib.Path,
-    last_known_good: typing.Optional[TestResult],
-    first_known_bad: typing.Optional[TestResult],
+    last_known_good: typing.Sequence[TestResult],
+    first_known_bad: typing.Sequence[TestResult],
 ):
     """
     Create symlinks to the last-good and first-bad output directories.
@@ -153,16 +154,14 @@ def create_output_symlinks(
 
     Args:
         output_prefix (pathlib.Path): The prefix for the output directory.
-        last_known_good (TestResult): The last known good test result.
-        first_known_bad (TestResult): The first known bad test result.
+        last_known_good (TestResult): The last known good test result(s).
+        first_known_bad (TestResult): The first known bad test result(s).
 
     Returns:
         None
     """
 
-    def symlink(result: typing.Optional[TestResult], symlink_name: str) -> None:
-        if result is None:
-            return
+    def symlink(result: TestResult, symlink_name: str) -> None:
         symlink_path = (output_prefix / symlink_name).resolve()
         assert not symlink_path.exists(), symlink_path
         assert symlink_path.parent == result.host_output_directory.parent, (
@@ -171,5 +170,7 @@ def create_output_symlinks(
         )
         symlink_path.symlink_to(result.host_output_directory)
 
-    symlink(last_known_good, "last-known-good")
-    symlink(first_known_bad, "first-known-bad")
+    for n, result in enumerate(last_known_good):
+        symlink(result, f"last-known-good-{n}")
+    for n, result in enumerate(first_known_bad):
+        symlink(result, f"first-known-bad-{n}")

--- a/.github/triage/jax_toolbox_triage/triage_tool.py
+++ b/.github/triage/jax_toolbox_triage/triage_tool.py
@@ -17,6 +17,7 @@ from .logic import (
     _WORKLOAD_VERSION_KEY,
     ClassifiedTestOutcome,
     container_search,
+    ExecutionClassifier,
     ExitCodeClassifier,
     TestExecutionOutcome,
     TestResult,
@@ -602,12 +603,17 @@ class TriageTool:
             summary = {}
             if push_intermediate_containers:
                 # Build a new layer on top of `bisection_url` that includes running `build_cmds` as a new layer.
-                tag_suffix = self._version_slug(
-                    self.bisection_url,
-                    versions={
-                        k: v for k, v in brief_versions.items() if k != _REPETITION_KEY
-                    },
-                ) + f"-{platform.machine()}"
+                tag_suffix = (
+                    self._version_slug(
+                        self.bisection_url,
+                        versions={
+                            k: v
+                            for k, v in brief_versions.items()
+                            if k != _REPETITION_KEY
+                        },
+                    )
+                    + f"-{platform.machine()}"
+                )
                 if self.args.container_registry is None:
                     # Do not push, everything local.
                     container_name = tag_suffix
@@ -710,6 +716,7 @@ class TriageTool:
         summary = {
             "build_time": build_time,
             "container": container_name,
+            "metrics": test_result.metrics,
             "output_directory": out_dir.as_posix(),
             "result": str(test_result.result),
             "test_repetition": test_repetition,
@@ -877,6 +884,7 @@ class TriageTool:
         Returns:
             Tuple[dict, TestResult]: The final versions and the test result.
         """
+        classifier: ExecutionClassifier
         if self.args.metric_name:
             classifier = MetricClassifier(
                 metric_name=self.args.metric_name,

--- a/.github/triage/jax_toolbox_triage/triage_tool.py
+++ b/.github/triage/jax_toolbox_triage/triage_tool.py
@@ -1,22 +1,30 @@
 import collections
+import contextlib
 import datetime
 import functools
 import hashlib
+import json
 import logging
 import pathlib
+import platform
 import time
 from typing import Dict, Tuple, Union, Any, Optional, Set
 
 from .container import Container
 from .logic import (
+    _EXIT_CODE_METRIC,
     _REPETITION_KEY,
+    _WORKLOAD_VERSION_KEY,
+    ClassifiedTestOutcome,
     container_search,
+    ExitCodeClassifier,
     TestExecutionOutcome,
     TestResult,
     version_search,
     CouldNotReproduceFailure,
     CouldNotReproduceSuccess,
 )
+from .metric_classifier import MetricClassifier
 from .versions import get_versions_dirs_env
 from .summary import (
     add_summary_record,
@@ -27,9 +35,11 @@ from .summary import (
     VERSION_CACHE_SECTION,
 )
 from .bisect import get_commit_history
+from .docker import DockerContainer
 from .utils import (
     container_url as container_url_base,
     prepare_bazel_cache_mounts,
+    run_and_log,
 )
 from .container_factory import make_container
 
@@ -74,6 +84,12 @@ class TriageTool:
             f"to {(self.args.output_prefix / 'debug.log').resolve()}"
         )
 
+    def _version_slug(self, url: str, versions: Dict[str, str]) -> str:
+        hash_chars = 8
+        components = {"container": hashlib.sha1(url.encode()).hexdigest()}
+        components.update(versions)
+        return "-".join(f"{k}-{v[:hash_chars]}" for k, v in components.items())
+
     def _test_output_directory(
         self, url: str, versions: Union[Dict[str, str], None]
     ) -> pathlib.Path:
@@ -86,13 +102,7 @@ class TriageTool:
         Returns:
             pathlib.Path: The path to the output directory.
         """
-        hash_chars = 8
-        urlhash = f"container-{hashlib.sha1(url.encode()).hexdigest()[:hash_chars]}"
-        out_dirname = "-".join(
-            [urlhash]
-            + [f"{k}-{v[:hash_chars]}" for k, v in sorted((versions or {}).items())]
-        )
-
+        out_dirname = self._version_slug(url=url, versions=versions or {})
         out_dir = self.args.output_prefix / out_dirname
         if out_dir.exists() and self.args.restart:
             base_out_dir = out_dir
@@ -100,7 +110,9 @@ class TriageTool:
             while out_dir.exists():
                 out_dir = base_out_dir.with_name(f"{base_out_dir.name}-restart-{n}")
                 n += 1
-        assert not out_dir.exists(), f"{out_dir} should not already exist, maybe you are re-using {self.args.output_prefix}?"
+        assert not out_dir.exists(), (
+            f"{out_dir} should not already exist, maybe you are re-using {self.args.output_prefix}?"
+        )
         out_dir.mkdir(mode=0o755)
         return out_dir.resolve()
 
@@ -120,8 +132,10 @@ class TriageTool:
         mounts = self.bazel_cache_mounts + self.args.container_mount
         if test_output_directory is not None:
             mounts.append((test_output_directory, "/triage-tool-output"))
-
-        return make_container(self.args.container_runtime, url, mounts, self.logger)
+        runtime = self.args.container_runtime
+        if runtime == "plugin":
+            runtime = "docker"
+        return make_container(runtime, url, mounts, self.logger)
 
     def _get_versions(
         self,
@@ -144,9 +158,9 @@ class TriageTool:
         """
         if explicit_versions is not None and container_url is None:
             return explicit_versions, None, None, None
-        assert (
-            container_url is not None
-        ), "Container URL must be provided if explicit versions are not set."
+        assert container_url is not None, (
+            "Container URL must be provided if explicit versions are not set."
+        )
 
         with self._make_container(container_url) as worker:
             url_versions, dirs, env = get_versions_dirs_env(
@@ -271,7 +285,6 @@ class TriageTool:
         Returns:
             TestResult: The result of the test, including whether it passed and the output.
         """
-        before = time.monotonic()
         cached_result = self.restart_cache.get((CONTAINER_CACHE_SECTION, container_url))
         if cached_result is not None:
             self.logger.info(f"Reusing cached container result for {container_url}")
@@ -287,14 +300,49 @@ class TriageTool:
                 versions_from_env=self.args.build_scripts_path is not None,
                 optional_software=self.args.optional_software,
             )
-            result = worker.exec(
-                self.args.test_command, log_level=test_output_log_level
-            )
-            test_time = time.monotonic() - before
-            test_pass = result.returncode == 0
-            self.logger.info(
-                f"Ran test case in {worker} in {test_time:.1f}s, pass={test_pass}"
-            )
+            if self.args.container_runtime == "plugin":
+                workload_version = None
+                if self.args.passing_container == container_url:
+                    workload_version = (self.args.passing_versions or {}).get(
+                        _WORKLOAD_VERSION_KEY
+                    )
+                elif self.args.failing_container == container_url:
+                    workload_version = (self.args.failing_versions or {}).get(
+                        _WORKLOAD_VERSION_KEY
+                    )
+                elif (
+                    _WORKLOAD_VERSION_KEY
+                    in (self.args.passing_versions or {}).keys()
+                    | (self.args.failing_versions or {}).keys()
+                ):
+                    self.logger.warning(
+                        f"{_WORKLOAD_VERSION_KEY} was passed explicitly for some "
+                        f"containers but not {container_url}"
+                    )
+
+                def _test():
+                    return (
+                        self._run_plugin(
+                            container_url=container_url,
+                            output_prefix=out_dir,
+                            log_level=test_output_log_level,
+                            workload_version=workload_version,
+                        ),
+                        out_dir,
+                        container_url,
+                    )
+            else:
+
+                def _test():
+                    return (
+                        worker.exec(
+                            self.args.test_command, log_level=test_output_log_level
+                        ),
+                        out_dir,
+                        container_url,
+                    )
+
+            test_result = self._run_test(_test)
 
         add_summary_record(
             self.args.output_prefix,
@@ -302,21 +350,15 @@ class TriageTool:
             {
                 **{
                     "container": container_url,
-                    "output_directory": out_dir.as_posix(),
-                    "result": test_pass,
-                    "test_time": test_time,
+                    "output_directory": test_result.host_output_directory.as_posix(),
+                    "result": str(test_result.result),
+                    "test_time": test_result.time,
+                    "metrics": test_result.metrics,
                 },
                 **versions,
             },
         )
-        return TestResult(
-            build_stdouterr=None,
-            host_output_directory=out_dir,
-            result=TestExecutionOutcome.TEST_SUCCESS
-            if test_pass
-            else TestExecutionOutcome.TEST_FAILURE,
-            stdouterr=result.stdout,
-        )
+        return test_result
 
     def _check_container_by_date(
         self, date: datetime.date, *, test_output_log_level: int = logging.DEBUG
@@ -390,6 +432,61 @@ class TriageTool:
         packages_missing_scripts = packages_needing_scripts - self.packages_with_scripts
         return packages_missing_scripts
 
+    def _run_plugin(
+        self,
+        container_url: str,
+        output_prefix: pathlib.Path,
+        log_level: int,
+        workload_version: Optional[str] = None,
+    ):
+        assert self.args.container_runtime == "plugin"
+        test_cmd = self.args.test_command + [
+            "--container",
+            container_url,
+            "--output-prefix",
+            str(output_prefix),
+        ]
+        if workload_version is not None:
+            test_cmd += ["--workload-version", workload_version]
+        return run_and_log(
+            test_cmd,
+            log_level=log_level,
+            logger=self.logger,
+            stderr="interleaved",
+        )
+
+    def _run_test(self, kernel):
+        before = time.monotonic()
+        result, out_dir, container_url = kernel()
+        duration = time.monotonic() - before
+        with open(out_dir / "test.log", "w") as log:
+            log.write(result.stdout)
+        metrics = {_EXIT_CODE_METRIC: result.returncode}
+        if self.args.metric_name is None:
+            # For non-metric triage there is always a result: the exit code
+            result_enum = TestExecutionOutcome.TEST_YIELDED_RESULTS
+        else:
+            # metric-based triage
+            metrics_file = out_dir / "metrics.json"
+            try:
+                with open(metrics_file) as ifile:
+                    metrics.update(json.load(ifile))
+                result_enum = TestExecutionOutcome.TEST_YIELDED_RESULTS
+            except Exception as e:
+                result_enum = TestExecutionOutcome.TEST_ERROR
+                self.logger.fatal(f"Failed to extract metrics: {e}")
+        self.logger.info(
+            f"Test completed in {duration:.1f}s with metric values {metrics} in {container_url}"
+        )
+        return TestResult(
+            build_stdouterr=None,  # May be filled in by the caller
+            host_output_directory=out_dir,
+            result=result_enum,
+            stdouterr=result.stdout,
+            metrics=metrics,
+            time=duration,
+        )
+
     def _build_and_test(
         self,
         *,
@@ -426,10 +523,9 @@ class TriageTool:
             #   worker.exec(cat /bar) # prints foo
             #
             # but now each new context manager is a fresh instance of `blah`, which was
-            # how the docker backend already worked. This is also how the intended
-            # build-a-container-and-push-it-to-registry-before-pulling-it-when-testing
-            # backend will want to work. It does mean that e.g. bazel repository caching
-            # does not work as well as it otherwise would out of the box.
+            # how the docker backend already worked. This is also how the "plugin"
+            # backend works. It does mean that e.g. bazel repository caching does not
+            # work as well as it otherwise would out of the box.
             changed.append(f"{package}@{version}")
             if package in self.package_dirs:
                 git_commands.append(
@@ -442,8 +538,9 @@ class TriageTool:
                     git_commands.append(
                         f"(git cherry-pick {cherry_pick_range} || git cherry-pick --abort)"
                     )
-
             else:
+                if package == _WORKLOAD_VERSION_KEY:
+                    continue
                 # Another software package, `version` is probably a version number.
                 # Installation of this version is delegated to an installPACKAGE.sh
                 # script that is assumed to be available in `args.build_scripts_path`.
@@ -462,35 +559,39 @@ class TriageTool:
         # Keep the pathnames shorter by only including packages that actually have
         # multiple versions in the bisection range.
         brief_versions = {
-            p: ver for p, ver in versions.items() if p in self.dynamic_packages
+            p: ver
+            for p, ver in versions.items()
+            if p in self.dynamic_packages and p != _WORKLOAD_VERSION_KEY
         }
         brief_versions[_REPETITION_KEY] = str(test_repetition)
         out_dir = self._test_output_directory(
             self.bisection_url,
             versions=brief_versions,
         )
-
-        with self._make_container(
-            self.bisection_url, test_output_directory=out_dir
+        change_str = " ".join(changed) if len(changed) else "<nothing>"
+        info_str = f"Checking out {change_str}"
+        if len(skipped):
+            info_str += f", leaving {' '.join(skipped)} unchanged"
+        push_intermediate_containers = self.args.container_runtime == "plugin"
+        with (
+            contextlib.nullcontext()
+            if push_intermediate_containers
+            else self._make_container(self.bisection_url, test_output_directory=out_dir)
         ) as worker:
-            change_str = " ".join(changed) if len(changed) else "<nothing>"
-            info_str = f"Checking out {change_str} in {worker}"
-            if len(skipped):
-                info_str += f", leaving {' '.join(skipped)} unchanged"
-            self.logger.info(info_str)
-            worker.check_exec(
-                ["sh", "-c", " && ".join(git_commands)],
-                policy="once_per_container",
-            )
+            self.logger.info(f"{info_str}")
             # Build JAX
-            # TODO: do not build JAX/XLA/TransformerEngine if we know their versions did not change?
-            before = time.monotonic()
-            # Unfortunately the build system does not always seem to handle incremental
-            # rebuilds correctly, so clean the local cache and rely on the remote one.
-            build_cmds = [
-                "bazel clean --expunge",
-                f"build-jax.sh --bazel-cache={self.args.bazel_cache}",
-            ]
+            # TODO: include a dependency graph and do not re-build components if they and their dependencies did not change
+            build_cmds = []
+            if not push_intermediate_containers:
+                # Unfortunately the build system does not always seem to handle incremental
+                # rebuilds correctly, so clean the local cache and rely on the remote one.
+                # Not needed if we are pushing a container, because the local cache is not
+                # included in it.
+                build_cmds.append("bazel clean --expunge")
+            if self.args.bazel_cache:
+                build_cmds.append(f"build-jax.sh --bazel-cache={self.args.bazel_cache}")
+            else:
+                build_cmds.append("build-jax.sh")
             if not self.args.exclude_transformer_engine:
                 if len(self.args.transformer_engine_ccache_env):
                     build_cmds.append(
@@ -498,56 +599,125 @@ class TriageTool:
                     )
                 else:
                     build_cmds.append("build-te.sh")
-            build_result = worker.exec(
-                ["sh", "-c", " && ".join(build_cmds)],
-                policy="once_per_container",
-                workdir=self.package_dirs["jax"],
-            )
+            summary = {}
+            if push_intermediate_containers:
+                # Build a new layer on top of `bisection_url` that includes running `build_cmds` as a new layer.
+                tag_suffix = self._version_slug(
+                    self.bisection_url,
+                    versions={
+                        k: v for k, v in brief_versions.items() if k != _REPETITION_KEY
+                    },
+                ) + f"-{platform.machine()}"
+                if self.args.container_registry is None:
+                    # Do not push, everything local.
+                    container_name = tag_suffix
+                elif ":" in self.args.container_registry:
+                    # gitlab.com/USER/containers:PREFIX-
+                    container_name = f"{self.args.container_registry}{tag_suffix}"
+                else:
+                    # gitlab.com/USER/containers
+                    container_name = f"{self.args.container_registry}:{tag_suffix}"
+                data_files_dir = pathlib.Path(__file__).parent / "data_files"
+
+                def _build():
+                    if DockerContainer(
+                        container_name, logger=self.logger, mounts=[]
+                    ).exists():
+                        command = [
+                            "echo",
+                            f"Skipping building {container_name} because it already exists",
+                        ]
+                    else:
+                        # TODO: organise this better to encourage layer sharing
+                        command = [
+                            "docker",
+                            "buildx",
+                            "build",
+                            f"--build-arg=BASE_IMAGE={self.bisection_url}",
+                            f"--build-arg=GIT_CMD={' && '.join(git_commands)}",
+                            f"--build-arg=BUILD_CMD={' && '.join(build_cmds)}",
+                            "--tag",
+                            container_name,
+                            "--file",
+                            str(data_files_dir / "Dockerfile.triage-tool"),
+                            str(data_files_dir),
+                        ]
+                        if self.args.container_registry is not None:
+                            command.append("--push")
+                    return run_and_log(
+                        command,
+                        logger=self.logger,
+                        stderr="interleaved",
+                    )
+
+                def _test():
+                    return (
+                        self._run_plugin(
+                            container_url=container_name,
+                            output_prefix=out_dir,
+                            log_level=test_output_log_level,
+                            workload_version=versions.get(_WORKLOAD_VERSION_KEY),
+                        ),
+                        out_dir,
+                        container_name,
+                    )
+            else:
+                container_name = self.bisection_url
+
+                def _build():
+                    worker.check_exec(
+                        ["sh", "-c", " && ".join(git_commands)],
+                        policy="once_per_container",
+                    )
+                    return worker.exec(
+                        ["sh", "-c", " && ".join(build_cmds)],
+                        policy="once_per_container",
+                        workdir=self.package_dirs["jax"],
+                    )
+
+                def _test():
+                    return (
+                        worker.exec(
+                            self.args.test_command, log_level=test_output_log_level
+                        ),
+                        out_dir,
+                        container_name,
+                    )
+
+            before = time.monotonic()
+            build_result = _build()
             build_pass = build_result.returncode == 0
+            middle = time.monotonic()
             with open(out_dir / "build.log", "w") as log:
                 log.write(build_result.stdout)
-            middle = time.monotonic()
             build_time = middle - before
             self.logger.info(
-                f"Build {'succeeded' if build_pass else 'failed'} in {build_time:.1f}s"
+                f"Container {container_name} build {'succeeded' if build_pass else 'failed'} in {build_time:.1f}s"
             )
-            summary = {
-                "build_time": build_time,
-                "container": self.bisection_url,
-                "output_directory": out_dir.as_posix(),
-                "test_repetition": test_repetition,
-            }
-            summary.update(versions)
             if build_pass:
-                # Run the test
-                test_result = worker.exec(
-                    self.args.test_command, log_level=test_output_log_level
-                )
-                test_output = test_result.stdout
-                test_time = time.monotonic() - middle
-                with open(out_dir / "test.log", "w") as log:
-                    log.write(test_output)
-                test_result_enum = (
-                    TestExecutionOutcome.TEST_SUCCESS
-                    if test_result.returncode == 0
-                    else TestExecutionOutcome.TEST_FAILURE
-                )
-                summary["output_directory"] = out_dir.as_posix()
-                summary["test_time"] = test_time
-                self.logger.info(
-                    f"Test completed in {test_time:.1f}s ({test_result_enum})"
-                )
+                # Time and run the test, extract metrics
+                test_result = self._run_test(_test)
+                test_result.build_stdouterr = build_result.stdout
             else:
-                test_output = None
-                test_result_enum = TestExecutionOutcome.BUILD_FAILURE
-        summary["result"] = str(test_result_enum)
+                test_result = TestResult(
+                    build_stdouterr=build_result.stdout,
+                    host_output_directory=out_dir,
+                    result=TestExecutionOutcome.BUILD_FAILURE,
+                    stdouterr=None,
+                    time=None,
+                    metrics={},
+                )
+        summary = {
+            "build_time": build_time,
+            "container": container_name,
+            "output_directory": out_dir.as_posix(),
+            "result": str(test_result.result),
+            "test_repetition": test_repetition,
+            "test_time": test_result.time,
+        }
+        summary.update(versions)
         add_summary_record(self.args.output_prefix, "versions", summary)
-        return TestResult(
-            build_stdouterr=build_result.stdout,
-            host_output_directory=out_dir,
-            result=test_result_enum,
-            stdouterr=test_output,
-        )
+        return test_result
 
     def find_container_range(self) -> Tuple[str, str]:
         """
@@ -666,7 +836,11 @@ class TriageTool:
         unknown_initial_packages = (
             passing_versions.keys() - self.bisection_versions.keys()
         )
-        assert len(unknown_initial_packages) == 0, (
+        # With a build+test plugin, we can allow the plugin to handle this case.
+        assert (
+            len(unknown_initial_packages) == 0
+            or self.args.container_runtime == "plugin"
+        ), (
             passing_versions.keys(),
             self.bisection_versions.keys(),
         )
@@ -703,6 +877,14 @@ class TriageTool:
         Returns:
             Tuple[dict, TestResult]: The final versions and the test result.
         """
+        if self.args.metric_name:
+            classifier = MetricClassifier(
+                metric_name=self.args.metric_name,
+                passing_values=self.args.passing_metric,
+                failing_values=self.args.failing_metric,
+            )
+        else:
+            classifier = ExitCodeClassifier()
         # Prepare the container for the bisection
         with self._make_container(self.bisection_url) as worker:
             package_versions = self._gather_histories(
@@ -741,6 +923,7 @@ class TriageTool:
                 check_success_before_failure=self.check_success_before_failure,
                 confirmation_iterations=self.args.confirmation_iterations,
                 result_cache=result_cache,
+                classifier=classifier,
             )
         except CouldNotReproduceFailure as e:
             if (
@@ -756,7 +939,8 @@ class TriageTool:
                 check_fail = self._check_container_by_url(
                     self.args.failing_container, test_output_log_level=logging.INFO
                 )
-                if check_fail.result == TestExecutionOutcome.TEST_FAILURE:
+                check_fail_outcome = classifier([check_fail])
+                if check_fail_outcome == ClassifiedTestOutcome.FAIL:
                     self.logger.fatal(
                         f"Reproduced failure in {self.args.failing_container} after failing to "
                         f"reproduce in {self.bisection_url}. This may mean the failure is due to "
@@ -766,6 +950,9 @@ class TriageTool:
                         f"Reproduced failure in {self.args.failing_container} but not {self.bisection_url}"
                     ) from e
                 else:
+                    assert check_fail_outcome == ClassifiedTestOutcome.PASS, (
+                        check_fail_outcome
+                    )
                     raise CouldNotReproduceFailure(
                         f"Could not reproduce failure with 'bad' container ({self.args.failing_container}, {check_fail.result})"
                     ) from e
@@ -785,7 +972,8 @@ class TriageTool:
                 check_pass = self._check_container_by_url(
                     self.args.passing_container, test_output_log_level=logging.INFO
                 )
-                if check_pass.result == TestExecutionOutcome.TEST_SUCCESS:
+                check_pass_outcome = classifier([check_pass])
+                if check_pass_outcome == ClassifiedTestOutcome.PASS:
                     self.logger.fatal(
                         f"Reproduced success in {self.args.passing_container} after failing to "
                         f"reproduce in {self.bisection_url}. This may mean the failure is due to "
@@ -795,6 +983,9 @@ class TriageTool:
                         f"Reproduced success in {self.args.passing_container} but not {self.bisection_url}"
                     ) from e
                 else:
+                    assert check_pass_outcome == ClassifiedTestOutcome.FAIL, (
+                        check_pass_outcome
+                    )
                     raise CouldNotReproduceSuccess(
                         f"Could not reproduce success with 'good' container ({self.args.passing_container}, {check_pass.result})"
                     ) from e

--- a/.github/triage/pyproject.toml
+++ b/.github/triage/pyproject.toml
@@ -2,7 +2,9 @@
 name = "jax-toolbox-triage"
 dynamic = ["version"]
 dependencies = [
+    "numpy",
     "psutil",
+    "uncertainties",
 ]
 # Because this script needs to run on compute clusters *outside* the containers that it
 # orchestrates, it tries to tolerate old Python versions

--- a/.github/triage/pyproject.toml
+++ b/.github/triage/pyproject.toml
@@ -19,3 +19,7 @@ dev = [
     "ruff>=0.15.8",
     "types-psutil>=6.1.0.20241221",
 ]
+
+[[tool.mypy.overrides]]
+module = ["uncertainties.*"]
+follow_untyped_imports = true

--- a/.github/triage/tests/mock_scripts/Dockerfile
+++ b/.github/triage/tests/mock_scripts/Dockerfile
@@ -1,0 +1,33 @@
+ARG BASE_IMAGE=ubuntu:24.04
+FROM ${BASE_IMAGE} AS passing
+RUN <<"EOF" bash -exuo pipefail
+export DEBIAN_FRONTEND=noninteractive
+export TZ=America/Los_Angeles
+apt-get update
+apt-get install --no-install-recommends --no-install-suggests -y git
+apt-get clean
+rm -rf /var/lib/apt/lists/*
+EOF
+ADD build-jax.sh build-te.sh /usr/local/bin
+RUN <<"EOF" bash -exuo pipefail
+git config --global user.name "Test User"
+git config --global user.email "test@example.com"
+for package in jax xla; do
+  mkdir -p /opt/${package}
+  cd /opt/${package}
+  git init -b main
+  touch pass.txt
+  git add pass.txt
+  git commit -m C0
+  git commit --allow-empty -m C1
+done
+EOF
+WORKDIR /opt/jax
+RUN touch feature_file.txt # for the mock build-jax.sh
+FROM passing AS failing
+RUN git rm pass.txt && git commit -m C2
+FROM passing AS passing_with_later_version
+RUN git commit --allow-empty -m C2
+RUN git commit --allow-empty -m C3
+FROM failing AS failing_with_later_version
+RUN git commit --allow-empty -m C3

--- a/.github/triage/tests/mock_scripts/build-jax.sh
+++ b/.github/triage/tests/mock_scripts/build-jax.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-
+cd /opt/jax
 if [ ! -f "feature_file.txt" ]; then
     echo "Build FAILED: The feature commit was not applied (feature_file.txt is missing)."
     exit 1

--- a/.github/triage/tests/mock_scripts/mock_plugin.py
+++ b/.github/triage/tests/mock_scripts/mock_plugin.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python
+import argparse
+import json
+import pathlib
+import subprocess
+import sys
+
+parser = argparse.ArgumentParser()
+# This is the interface expected by the triage tool
+parser.add_argument("--container", required=True, type=str, help="Container to test.")
+parser.add_argument(
+    "--output-prefix",
+    required=True,
+    type=pathlib.Path,
+    help="Directory to download output to.",
+)
+# These are for use in test cases
+parser.add_argument("--exit-code", type=int)
+args = parser.parse_args()
+result = subprocess.run(
+    ["docker", "run", args.container, "cat", "/opt/jax/pass.txt"],
+    stdout=subprocess.PIPE,
+    stderr=subprocess.PIPE,
+)
+with open(args.output_prefix / "stdout.txt", "wb") as ofile:
+    ofile.write(result.stdout)
+with open(args.output_prefix / "stderr.txt", "wb") as ofile:
+    ofile.write(result.stderr)
+if result.returncode == 0:
+    metric_value = 1.0
+else:
+    metric_value = 0.0
+with open(args.output_prefix / "metrics.json", "w") as ofile:
+    json.dump({"test_metric": metric_value}, ofile)
+if args.exit_code is None:
+    result.check_returncode()
+else:
+    sys.exit(args.exit_code)

--- a/.github/triage/tests/test_arg_parsing.py
+++ b/.github/triage/tests/test_arg_parsing.py
@@ -215,3 +215,25 @@ def test_container_search_with_metric():
         Exception, match="--metric-name is only supported in version-level search"
     ):
         parse_args(["--container=jax", "--metric-name=sumptiousness"] + test_command)
+
+
+def test_metric_triage_without_seed_values():
+    with pytest.raises(
+        Exception,
+        match="You should pass seed metric values",
+    ):
+        parse_args(
+            valid_start_end_container + ["--metric-name=sumptiousness"] + test_command
+        )
+
+
+def test_metric_seed_values_without_metric_name():
+    with pytest.raises(
+        Exception,
+        match="--metric-name must be passed if --passing-metric or --failing-metric is",
+    ):
+        parse_args(
+            valid_start_end_container
+            + ["--passing-metric=42", "--failing-metric=24"]
+            + test_command
+        )

--- a/.github/triage/tests/test_arg_parsing.py
+++ b/.github/triage/tests/test_arg_parsing.py
@@ -204,3 +204,14 @@ def test_combining_deprecated_args_with_their_replacements(args):
 def test_warning_on_deprecated_args(args):
     with pytest.deprecated_call():
         parse_args(args + test_command)
+
+
+def test_container_search_with_metric():
+    # Trying to do a metric-based container-level search could easily be supported for
+    # closed ranges, but it isn't yet. Attempting it should fail. Container-level
+    # search with an open range (i.e. backwards from today) would be harder and would
+    # lean more on externally provided pass/fail metric values.
+    with pytest.raises(
+        Exception, match="--metric-name is only supported in version-level search"
+    ):
+        parse_args(["--container=jax", "--metric-name=sumptiousness"] + test_command)

--- a/.github/triage/tests/test_container_runtimes.py
+++ b/.github/triage/tests/test_container_runtimes.py
@@ -1,12 +1,23 @@
+from jax_toolbox_triage.args import parse_args
 from jax_toolbox_triage.container_factory import make_container
+from jax_toolbox_triage.logic import CouldNotReproduceFailure, CouldNotReproduceSuccess
+from jax_toolbox_triage.triage_tool import TriageTool
 import logging
 import os
+import pathlib
 import pytest
 import shutil
+import subprocess
 import uuid
 
 srun_available = shutil.which("srun") is not None and "SLURM_JOBID" in os.environ
 docker_available = shutil.which("docker") is not None
+skip_if_no_docker = pytest.mark.skipif(
+    not docker_available, reason="Plugin backend needs docker"
+)
+mock_scripts_path = pathlib.Path(__file__).parent / "mock_scripts"
+
+_BASE_CONTAINER = "ubuntu:24.04"
 
 
 @pytest.fixture(scope="module")
@@ -25,8 +36,9 @@ def test_container_semantics(logger, runtime):
         pytest.skip("Docker is not available")
     elif runtime == "pyxis" and not srun_available:
         pytest.skip("Pyxis is not available")
-    url = "ubuntu:24.04"
-    with make_container(runtime=runtime, url=url, mounts=[], logger=logger) as worker:
+    with make_container(
+        runtime=runtime, url=_BASE_CONTAINER, mounts=[], logger=logger
+    ) as worker:
         # The file should not exist in the container image we pulled
         assert worker.exec(["cat", "/root/token"]).returncode != 0
         token = uuid.uuid1().hex
@@ -34,6 +46,184 @@ def test_container_semantics(logger, runtime):
         read_token = worker.check_exec(["cat", "/root/token"], stderr="separate").stdout
         # While the context manager is active, there is a single container instance
         assert token == read_token, (token, read_token)
-    with make_container(runtime=runtime, url=url, mounts=[], logger=logger) as worker:
+    with make_container(
+        runtime=runtime, url=_BASE_CONTAINER, mounts=[], logger=logger
+    ) as worker:
         # We should not be able to see the old token
         assert worker.exec(["cat", "/root/token"]).returncode != 0
+
+
+def build_container(logger, target):
+    tag = uuid.uuid1().hex
+    subprocess.run(
+        [
+            "docker",
+            "buildx",
+            "build",
+            "--build-arg",
+            f"BASE_IMAGE={_BASE_CONTAINER}",
+            "--target",
+            target,
+            "--tag",
+            tag,
+            str(mock_scripts_path),
+        ],
+        check=True,
+    )
+    with make_container(runtime="docker", url=tag, mounts=[], logger=logger) as worker:
+        jax_commit = worker.check_exec(
+            ["git", "rev-parse", "HEAD"], workdir="/opt/jax"
+        ).stdout.strip()
+    return tag, jax_commit
+
+
+@pytest.fixture(scope="module")
+def passing_container(logger):
+    return build_container(logger, "passing")
+
+
+@pytest.fixture(scope="module")
+def passing_container_with_later_version(logger):
+    return build_container(logger, "passing_with_later_version")
+
+
+@pytest.fixture(scope="module")
+def failing_container(logger):
+    return build_container(logger, "failing")
+
+
+@pytest.fixture(scope="module")
+def failing_container_with_later_version(logger):
+    return build_container(logger, "failing_with_later_version")
+
+
+@pytest.fixture
+def run_with_plugin_backend(logger, tmp_path):
+    def wrapped(*, tool=[], plugin=[]):
+        arg_list = (
+            [
+                "--output-prefix",
+                str(tmp_path),
+                "--container-runtime",
+                "plugin",
+            ]
+            + tool
+            + ["--", str(mock_scripts_path / "mock_plugin.py")]
+            + plugin
+        )
+        args = parse_args(arg_list)
+        triage_tool = TriageTool(args, logger)
+        passing_versions, failing_versions = triage_tool.gather_version_info(
+            args.passing_container, args.failing_container
+        )
+        return triage_tool.run_version_bisection(passing_versions, failing_versions)
+
+    return wrapped
+
+
+@skip_if_no_docker
+def test_plugin_backend_exit_code(
+    run_with_plugin_backend,
+    passing_container,
+    failing_container,
+):
+    passing_container_url, good_jax_commit = passing_container
+    failing_container_url, bad_jax_commit = failing_container
+    result = run_with_plugin_backend(
+        tool=[
+            "--passing-container",
+            passing_container_url,
+            "--failing-container",
+            failing_container_url,
+        ],
+    )
+    assert result["result"]["jax_bad"] == bad_jax_commit
+    assert result["result"]["jax_good"] == good_jax_commit
+    assert "xla_ref" in result["result"]
+
+
+metric_args = [
+    "--metric-name",
+    "test_metric",
+    "--passing-metric",
+    "1.0",
+    "--failing-metric",
+    "0.0",
+]
+
+
+@skip_if_no_docker
+@pytest.mark.parametrize("exit_code", [0, 1])
+def test_plugin_backend_metric(
+    run_with_plugin_backend,
+    passing_container,
+    failing_container,
+    exit_code,
+):
+    passing_container_url, good_jax_commit = passing_container
+    failing_container_url, bad_jax_commit = failing_container
+    result = run_with_plugin_backend(
+        tool=[
+            "--passing-container",
+            passing_container_url,
+            "--failing-container",
+            failing_container_url,
+        ]
+        + metric_args,
+        plugin=[
+            # Tell mock_plugin.py what code to exit with
+            "--exit-code",
+            str(exit_code),
+        ],
+    )
+    assert result["result"]["jax_bad"] == bad_jax_commit
+    assert result["result"]["jax_good"] == good_jax_commit
+    assert "xla_ref" in result["result"]
+
+
+@skip_if_no_docker
+def test_plugin_backend_metric_always_good(
+    run_with_plugin_backend,
+    passing_container,
+    passing_container_with_later_version,
+):
+    """
+    Passing container URLs that are different but where the returned metric value is
+    always 'good' should yield an error.
+    """
+    passing_container_url, _ = passing_container
+    failing_container_url, _ = passing_container_with_later_version
+    with pytest.raises(CouldNotReproduceFailure):
+        run_with_plugin_backend(
+            tool=[
+                "--passing-container",
+                passing_container_url,
+                "--failing-container",
+                failing_container_url,
+            ]
+            + metric_args,
+        )
+
+
+@skip_if_no_docker
+def test_plugin_backend_metric_always_bad(
+    run_with_plugin_backend,
+    failing_container,
+    failing_container_with_later_version,
+):
+    """
+    Passing container URLs that are different but where the returned metric value is
+    always 'bad' should yield an error.
+    """
+    passing_container_url, _ = failing_container
+    failing_container_url, _ = failing_container_with_later_version
+    with pytest.raises(CouldNotReproduceSuccess):
+        run_with_plugin_backend(
+            tool=[
+                "--passing-container",
+                passing_container_url,
+                "--failing-container",
+                failing_container_url,
+            ]
+            + metric_args,
+        )

--- a/.github/triage/tests/test_metric_classifier.py
+++ b/.github/triage/tests/test_metric_classifier.py
@@ -1,0 +1,146 @@
+from collections import defaultdict
+from functools import partial
+import pathlib
+import pytest
+import random
+
+from jax_toolbox_triage.logic import (
+    ClassifiedTestOutcome,
+    TestExecutionOutcome,
+    TestResult,
+)
+from jax_toolbox_triage.metric_classifier import MetricClassifier
+
+_PASS_MU = 1
+_FAIL_MU = 0
+_METRIC_NAME = "metric"
+_MAX_RETRIES = 10
+_SAMPLES_TO_TEST = 1000
+_OUTCOME_MAP = {
+    True: ClassifiedTestOutcome.PASS,
+    False: ClassifiedTestOutcome.FAIL,
+}
+
+
+def wrap(metric_value: float) -> TestResult:
+    return TestResult(
+        build_stdouterr=None,
+        host_output_directory=pathlib.Path(),
+        metrics={_METRIC_NAME: metric_value},
+        result=TestExecutionOutcome.TEST_YIELDED_RESULTS,
+        stdouterr=None,
+        time=0.0,
+    )
+
+
+@pytest.mark.parametrize("random_seed", range(4))
+# How many labelled values to seed the classifier with.
+@pytest.mark.parametrize("seed_values", [2, 4])
+# Noise level in the good measurements.
+@pytest.mark.parametrize("pass_sigma", [1e-4, 0.1, 0.2])
+# Noise level in the bad measurements.
+@pytest.mark.parametrize("fail_sigma", [1e-4, 0.1, 0.2])
+# Effectively whether the culprit is early or late in the search range. This is
+# symmetric, so no need to cover 0.75 and 1.0
+@pytest.mark.parametrize("pass_probability", [0.0, 0.25, 0.5])
+# Whether the pass/fail distributions should be assumed to have the same width
+@pytest.mark.parametrize("common_variance", [True, False])
+# How tolerant of failures to be
+@pytest.mark.parametrize("threshold", [0.954, 0.997])
+def test_random_data(
+    random_seed,
+    seed_values,
+    pass_sigma,
+    fail_sigma,
+    pass_probability,
+    common_variance,
+    threshold,
+):
+    if pass_sigma != fail_sigma and common_variance:
+        pytest.skip(
+            "Expect failures when assuming common variance if the true variances "
+            "differ too much."
+        )
+    rng = random.Random(random_seed)
+    draw_pass = partial(rng.gauss, mu=_PASS_MU, sigma=pass_sigma)
+    draw_fail = partial(rng.gauss, mu=_FAIL_MU, sigma=fail_sigma)
+    classifier = MetricClassifier(
+        metric_name=_METRIC_NAME,
+        threshold=threshold,
+        common_variance=common_variance,
+        passing_values=[draw_pass() for _ in range(seed_values)],
+        failing_values=[draw_fail() for _ in range(seed_values)],
+    )
+    test_stats = defaultdict(int)
+    for _ in range(_SAMPLES_TO_TEST):
+        is_pass = rng.random() <= pass_probability
+        values = []
+        for _ in range(_MAX_RETRIES):
+            values.append(wrap(draw_pass() if is_pass else draw_fail()))
+            outcome = classifier(values)
+            if outcome != ClassifiedTestOutcome.AMBIGUOUS:
+                break
+        for row in classifier.text_summary():
+            print(row)
+        if outcome == ClassifiedTestOutcome.AMBIGUOUS:
+            test_stats["ambiguous"] += 1
+        elif outcome == ClassifiedTestOutcome.ERROR:
+            test_stats["errors"] += 1
+        elif outcome == _OUTCOME_MAP[is_pass]:
+            test_stats["correct"] += 1
+        else:
+            assert outcome == _OUTCOME_MAP[not is_pass], outcome
+            test_stats["incorrect"] += 1
+    assert sum(test_stats.values()) == _SAMPLES_TO_TEST
+    assert test_stats["errors"] == 0, test_stats
+    hit_rate = test_stats["correct"] / (
+        test_stats["incorrect"] + test_stats["correct"] + test_stats["ambiguous"]
+    )
+    # The misclassification rate should not significantly exceed the
+    # configured threshold. If the pass/fail populations are very distinct, it's hard
+    # to get wrong and the hit rate will be ~100% regardless of the threshold.
+    assert hit_rate > threshold * 0.9, (hit_rate, threshold)
+
+
+def test_progress_reporting():
+    rng = random.Random(0)
+    draw_pass = partial(rng.gauss, mu=_PASS_MU, sigma=0.1)
+    draw_fail = partial(rng.gauss, mu=_FAIL_MU, sigma=0.15)
+    seed_values = 2
+    classifier = MetricClassifier(
+        metric_name=_METRIC_NAME,
+        threshold=0.954,
+        common_variance=False,
+        passing_values=[draw_pass() for _ in range(seed_values)],
+        failing_values=[draw_fail() for _ in range(seed_values)],
+    )
+    initial_summary = classifier.text_summary(columns=60, rows=2)
+    initial_reference = [
+        "x=[-0.12, 1.12] pass=0.98+/-0.14 (n=2) fail=-0.02+/-0.10 (n=2)",
+        "█       █                                                   ",
+        "█       █                                                   ",
+        "\\FFF|FFFF/                                                  ",
+        "                                               █          █ ",
+        "                                               █          █ ",
+        "                                              \\PPPPPP|PPPPP/",
+    ]
+    assert initial_summary == initial_reference
+    for _ in range(100):
+        is_pass = rng.random() <= 0.25
+        values = []
+        for _ in range(_MAX_RETRIES):
+            values.append(wrap(draw_pass() if is_pass else draw_fail()))
+            outcome = classifier(values)
+            if outcome != ClassifiedTestOutcome.AMBIGUOUS:
+                break
+    final_summary = classifier.text_summary(columns=60, rows=2)
+    final_reference = [
+        "x=[-0.35, 1.24] pass=1.00+/-0.13 (n=26) fail=-0.01+/-0.15 (n=81)",
+        "        ▅  ▅    █                                           ",
+        "▂▄▅ ▄▂▂▇██▇█▇██▇█▄▄▂▅ ▄▂ ▄ ▂                                ",
+        "      \\FFFFF|FFFFF/                                         ",
+        "                                                            ",
+        "                                          ▄  ▄▄▇▂ ▅▂▂▄▄▄ ▄▂▂",
+        "                                             \\PPPP|PPPP/    ",
+    ]
+    assert final_summary == final_reference

--- a/.github/triage/tests/test_restart.py
+++ b/.github/triage/tests/test_restart.py
@@ -7,7 +7,9 @@ import pytest
 
 from jax_toolbox_triage.args import parse_args
 from jax_toolbox_triage.logic import (
-    TestExecutionOutcome,
+    _EXIT_CODE_METRIC,
+    ClassifiedTestOutcome,
+    ExitCodeClassifier,
     version_search,
 )
 from jax_toolbox_triage.summary import (
@@ -99,14 +101,16 @@ def test_version_search_reuses_preloaded_restart_cache(tmp_path):
                 "xla": "xla-good",
                 "jax": "jax-good",
                 "output_directory": str(good_dir),
-                "result": "TestExecutionOutcome.TEST_SUCCESS",
+                "result": "TestExecutionOutcome.TEST_YIELDED_RESULTS",
+                "metrics": {_EXIT_CODE_METRIC: 0},
             },
             {
                 "container": "container-url",
                 "xla": "xla-good",
                 "jax": "jax-bad",
                 "output_directory": str(bad_dir),
-                "result": "TestExecutionOutcome.TEST_FAILURE",
+                "result": "TestExecutionOutcome.TEST_YIELDED_RESULTS",
+                "metrics": {_EXIT_CODE_METRIC: 1},
             },
         ]
     }
@@ -135,8 +139,9 @@ def test_version_search_reuses_preloaded_restart_cache(tmp_path):
         "jax_good": "jax-good",
         "xla_ref": "xla-good",
     }
-    assert last_known_good.result == TestExecutionOutcome.TEST_SUCCESS
-    assert first_known_bad.result == TestExecutionOutcome.TEST_FAILURE
+    classifier = ExitCodeClassifier()
+    assert classifier(last_known_good) == ClassifiedTestOutcome.PASS
+    assert classifier(first_known_bad) == ClassifiedTestOutcome.FAIL
 
 
 def test_summary_cache_loads_container_records(tmp_path):
@@ -147,7 +152,8 @@ def test_summary_cache_loads_container_records(tmp_path):
             {
                 "container": "container-url",
                 "output_directory": str(out_dir),
-                "result": True,
+                "result": "TestExecutionOutcome.TEST_YIELDED_RESULTS",
+                "metrics": {_EXIT_CODE_METRIC: 0},
             }
         ]
     }
@@ -156,7 +162,7 @@ def test_summary_cache_loads_container_records(tmp_path):
     summary_cache = result_cache_from_summary(tmp_path)
 
     cached_result = summary_cache[(CONTAINER_CACHE_SECTION, "container-url")]
-    assert cached_result.result == TestExecutionOutcome.TEST_SUCCESS
+    assert cached_result.exit_code_based_pass()
     assert cached_result.host_output_directory == out_dir
 
 
@@ -196,14 +202,16 @@ def test_triage_tool_loads_restart_cache(tmp_path):
                 "xla": "xla-good",
                 "jax": "jax-good",
                 "output_directory": str(good_dir),
-                "result": "TestExecutionOutcome.TEST_SUCCESS",
+                "result": "TestExecutionOutcome.TEST_YIELDED_RESULTS",
+                "metrics": {_EXIT_CODE_METRIC: 0},
             },
             {
                 "container": "local",
                 "xla": "xla-good",
                 "jax": "jax-bad",
                 "output_directory": str(bad_dir),
-                "result": "TestExecutionOutcome.TEST_FAILURE",
+                "result": "TestExecutionOutcome.TEST_YIELDED_RESULTS",
+                "metrics": {_EXIT_CODE_METRIC: 1},
             },
         ]
     }

--- a/.github/triage/tests/test_triage_logic.py
+++ b/.github/triage/tests/test_triage_logic.py
@@ -5,25 +5,33 @@ import logging
 import pytest
 import random
 from jax_toolbox_triage.logic import (
+    _EXIT_CODE_METRIC,
+    ClassifiedTestOutcome,
     container_search,
+    ExitCodeClassifier,
     TestExecutionOutcome,
     TestResult,
     version_search,
 )
+from jax_toolbox_triage.metric_classifier import MetricClassifier
+
+_METRIC_NAME = "metric"
 
 
-def wrap(b, versions={}, build_failure=False):
+def wrap(b, versions={}, build_failure=False, metrics=None):
+    # TODO: return TestExecutionOutcome.TEST_ERROR sometimes
+    if metrics is None:
+        metrics = {}
+    metrics[_EXIT_CODE_METRIC] = 0 if b else 1
     return TestResult(
         build_stdouterr="",
         host_output_directory="-".join(map("-".join, sorted(versions.items()))),
         result=TestExecutionOutcome.BUILD_FAILURE
         if build_failure
-        else (
-            TestExecutionOutcome.TEST_SUCCESS
-            if b
-            else TestExecutionOutcome.TEST_FAILURE
-        ),
+        else TestExecutionOutcome.TEST_YIELDED_RESULTS,
         stdouterr="",
+        metrics=metrics,
+        time=None if build_failure else 0.0,
     )
 
 
@@ -31,9 +39,6 @@ def wrap(b, versions={}, build_failure=False):
 def logger():
     logger = logging.getLogger("triage-tests")
     logger.setLevel(logging.DEBUG)
-    console = logging.StreamHandler()
-    console.setLevel(logging.INFO)
-    logger.addHandler(console)
     return logger
 
 
@@ -93,21 +98,24 @@ def test_version_search_explicit(
         skip_precondition_checks=False,
     )
     assert algorithm_result == expected
-    assert last_known_good.result == TestExecutionOutcome.TEST_SUCCESS
-    assert first_known_bad.result == TestExecutionOutcome.TEST_FAILURE
-    assert last_known_good.host_output_directory == last_known_good_dir
-    assert first_known_bad.host_output_directory == first_known_bad_dir
+    assert ExitCodeClassifier()(last_known_good) == ClassifiedTestOutcome.PASS
+    assert ExitCodeClassifier()(first_known_bad) == ClassifiedTestOutcome.FAIL
+    assert last_known_good[0].host_output_directory == last_known_good_dir
+    assert first_known_bad[0].host_output_directory == first_known_bad_dir
 
 
 start_date = datetime.datetime(2024, 10, 1)
 step_size = datetime.timedelta(days=1)
 
 
-@pytest.mark.parametrize("seed", range(10))
+@pytest.mark.parametrize("seed", range(5))
 @pytest.mark.parametrize("packages", [2, 3, 100])
 @pytest.mark.parametrize("extra_commits", [0, 2, 7, 100])
+@pytest.mark.parametrize("metric_std", [0.01, 0.2])
 @pytest.mark.parametrize("build_pass_probability", [0.0, 0.9, 1.0])
-def test_version_search(logger, build_pass_probability, extra_commits, packages, seed):
+def test_version_search(
+    logger, build_pass_probability, extra_commits, packages, seed, metric_std
+):
     """
     Generate random sequences of commits for `packages` different packages and test
     that the version-level search algorithm yields the expected results.
@@ -118,8 +126,12 @@ def test_version_search(logger, build_pass_probability, extra_commits, packages,
 
     Around `extra_commits` extra commits will be added across the 2+ packages.
 
-    If `build_failures` is true, some commits within the generated range will result in
-    [simulated] build failures.
+    If `build_pass_probability` is non-zero, some commits within the generated range
+    will result in [simulated] build failures.
+
+    If `metric_std` is non-zero, the triage will use floating point metrics drawn from
+    a normal distribution with that width and mean value 0 (fail) or 1 (pass). If the
+    width is zero, this will be flattened into a pass/fail boolean.
     """
     rng = random.Random(seed)
 
@@ -166,18 +178,41 @@ def test_version_search(logger, build_pass_probability, extra_commits, packages,
     for commit_list in commits.values():
         build_failure_commits.discard(commit_list[-1][0])
 
+    def dummy_test_truth(*, versions, **kwargs) -> bool:
+        return culprit_dates[versions[culprit]] < bad_date
+
+    def sample_metric_value(is_pass):
+        return rng.gauss(0 if is_pass else 1, metric_std)
+
     def dummy_test(*, versions, **kwargs):
+        metrics = {}
+        test_pass = dummy_test_truth(versions=versions)
+        if metric_std > 0:
+            metrics[_METRIC_NAME] = sample_metric_value(test_pass)
+            test_pass = True  # exit code is always 0/success for metric-based triage
         return wrap(
-            culprit_dates[versions[culprit]] < bad_date,
+            test_pass,
             versions,
             build_failure=any(v in build_failure_commits for v in versions.values()),
+            metrics=metrics,
         )
+
+    if metric_std > 0:
+        classifier = MetricClassifier(
+            metric_name=_METRIC_NAME,
+            passing_values=[sample_metric_value(True)],
+            failing_values=[sample_metric_value(False)],
+        )
+    else:
+        classifier = ExitCodeClassifier()
 
     algorithm_result, last_known_good, first_known_bad = version_search(
         build_and_test=dummy_test,
         versions=commits,
         logger=logger,
         skip_precondition_checks=False,
+        classifier=classifier,
+        confirmation_iterations=2,
     )
     # Do not check the reference versions, it's a bit underspecified quite what they
     # mean, other than that the dummy_test assertions below should pass
@@ -199,24 +234,24 @@ def test_version_search(logger, build_pass_probability, extra_commits, packages,
         ","
     )[0]
     commits[culprit] = passing_version_before_build_failures
-    assert dummy_test(versions=commits).result == TestExecutionOutcome.TEST_SUCCESS
+    assert dummy_test_truth(versions=commits)
     # The last listed 'bad' commit should be one where the test runs + fails
     failing_version_after_build_failures = algorithm_result[f"{culprit}_bad"].split(
         ","
     )[-1]
     commits[culprit] = failing_version_after_build_failures
-    assert dummy_test(versions=commits).result == TestExecutionOutcome.TEST_FAILURE
+    assert not dummy_test_truth(versions=commits)
     # The returned results should have the correct outcomes
-    assert last_known_good.result == TestExecutionOutcome.TEST_SUCCESS
-    assert first_known_bad.result == TestExecutionOutcome.TEST_FAILURE
+    assert classifier(last_known_good) == ClassifiedTestOutcome.PASS
+    assert classifier(first_known_bad) == ClassifiedTestOutcome.FAIL
     # Not sure if this is worth testing...
-    assert (
-        f"{culprit}-{passing_version_before_build_failures}"
-        in last_known_good.host_output_directory
+    assert all(
+        f"{culprit}-{passing_version_before_build_failures}" in r.host_output_directory
+        for r in last_known_good
     )
     assert (
-        f"{culprit}-{failing_version_after_build_failures}"
-        in first_known_bad.host_output_directory
+        f"{culprit}-{failing_version_after_build_failures}" in r.host_output_directory
+        for r in first_known_bad
     )
 
 
@@ -341,9 +376,9 @@ def test_version_search_exhaustive(logger, commits):
         if proj != bad_project
     }
     commits[bad_project] = bad_commit
-    assert dummy_test(versions=commits).result == TestExecutionOutcome.TEST_FAILURE
+    assert dummy_test(versions=commits).exit_code_based_fail()
     commits[bad_project] = good_commit
-    assert dummy_test(versions=commits).result == TestExecutionOutcome.TEST_SUCCESS
+    assert dummy_test(versions=commits).exit_code_based_pass()
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
- Add `plugin` backend that receives a container to test.
- Add metric-based triage, where a numeric value is extracted from each test and classified as belonging to a 'pass' or 'fail' population.