### PR TITLE
Update runner tag

### DIFF
--- a/.github/workflows/_build_base.yaml
+++ b/.github/workflows/_build_base.yaml
@@ -58,7 +58,7 @@ permissions:
 jobs:
 
   build-base:
-    runs-on: [self-hosted, "${{ inputs.ARCHITECTURE }}", small]
+    runs-on: ["linux-${{ inputs.ARCHITECTURE }}-cpu32"]
     env:
       BADGE_FILENAME_FULL: ${{ inputs.BADGE_FILENAME }}-${{ inputs.ARCHITECTURE }}.json
     outputs:

--- a/.github/workflows/_ci.yaml
+++ b/.github/workflows/_ci.yaml
@@ -310,7 +310,7 @@ jobs:
 
   build-alphafold:
     needs: build-jax
-    runs-on: [self-hosted, "${{ inputs.ARCHITECTURE }}", "large"]
+    runs-on: ${{ inputs.ARCHITECTURE == 'amd64' && 'linux-amd64-cpu16m' || 'linux-arm64-cpu16m' }}
     outputs:
       DOCKER_TAG_MEALKIT: ${{ steps.build-alphafold.outputs.DOCKER_TAG_MEALKIT }}
       DOCKER_TAG_FINAL:  ${{ steps.build-alphafold.outputs.DOCKER_TAG_FINAL }}

--- a/.github/workflows/_test_nccl.yaml
+++ b/.github/workflows/_test_nccl.yaml
@@ -21,7 +21,7 @@ jobs:
     secrets: inherit
 
   build-mpi-operator-compatible-base:
-    runs-on: [self-hosted, "amd64", "large"]
+    runs-on: ["linux-amd64-cpu32"]
     steps:
       - name: Login to nvcr.io Container Registry
         uses: docker/login-action@v4

--- a/.github/workflows/_test_nccl_gke.yaml
+++ b/.github/workflows/_test_nccl_gke.yaml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   build-nccl-gke:
-    runs-on: [self-hosted, "amd64", "large"]
+    runs-on: ["linux-amd64-cpu32"]
     steps:
       - uses: actions/checkout@v6
       - name: Login to nvcr.io Container Registry


### PR DESCRIPTION
Fix for GHA self-hosted runner rename causing builds scheduled on non-existent tags ([e.g](https://github.com/NVIDIA/JAX-Toolbox/actions/runs/30073254274/job/89457577176)) to hang indefinitely

c.f working build at https://github.com/NVIDIA/JAX-Toolbox/actions/runs/30094731541