### PR TITLE
Document scheduler memory fencing flags

### DIFF
--- a/docs/GPU_performance.md
+++ b/docs/GPU_performance.md
@@ -47,6 +47,7 @@ Please note that some of these flags are experimental. All combinations of flags
 
 - The `xla_gpu_memory_limit_slop_factor` flag controls the memory used by XLA for determining its default heuristics for scheduling, and rematerialization. Default is recommended.
 
+- The experimental `xla_gpu_experimental_scheduler_memory_fencing_threshold_bytes` flag enables scheduler memory fencing, which limits peak memory when the latency-hiding scheduler would otherwise defer users of large buffers and keep those buffers live too long. `-1` disables the feature (default), `0` fences buffers at least 1% of the scheduler memory limit, and a positive value specifies the threshold in bytes. The optional `xla_gpu_experimental_scheduler_memory_fencing_slack_windows` flag controls how many asynchronous-operation windows fenced buffer users may be deferred (default: `1`).
 
 ## General CUDA/NCCL flags 
 


### PR DESCRIPTION
## What changed

- Document the experimental scheduler memory-fencing threshold flag.
- Explain the threshold values and the optional slack-windows control.

## Why

OpenXLA commit https://github.com/openxla/xla/commit/26d66344828ee6aad95ae3306b5eb1a2c20a9eab introduced scheduler memory fencing to limit peak memory when the latency-hiding scheduler keeps large buffers live by deferring their users.

## Impact

JAX/XLA users can discover how to enable and tune the feature when latency-hiding scheduling causes excessive peak GPU memory use or OOMs.

## Validation

- Reviewed the rendered Markdown structure.
- Ran `git diff --check`.
