### PR TITLE
Enforce constant core.abbrev value in TransformerEngine wheel build

### DIFF
--- a/.github/container/build-te.sh
+++ b/.github/container/build-te.sh
@@ -160,6 +160,10 @@ fi
 
 # The wheel filename includes the TE commit; if this has changed since the last
 # incremental build then we would end up with multiple wheels.
+
+# ensure TE uses a consistent short sha length
+git -C "${SRC_PATH_TE}" config --local core.abbrev 9
+
 rm -fv dist/*.whl
 python setup.py bdist_wheel
 ls dist/


### PR DESCRIPTION
TransformerEngine can build wheels with differing short commit SHAs which can cause issues with commit version-pinned pip installs.

https://github.com/NVIDIA/TransformerEngine/blob/main/build_tools/te_version.py#L26

https://git-scm.com/docs/git-rev-parse#Documentation/git-rev-parse.txt---shortlength