### PR TITLE
fix versions for tf and tf-text to prevent bug

### DIFF
--- a/.github/container/Dockerfile.maxtext
+++ b/.github/container/Dockerfile.maxtext
@@ -28,16 +28,19 @@ grep -E '^google-jetstream' ${SRC_PATH_MAXTEXT}/src/dependencies/requirements/re
   >> /opt/pip-tools.d/requirements-maxtext.in
 EOF
 
-RUN <<"EOF" bash -exuo pipefail
-# Avoid old tensorboard constraint from google-cloud-aiplatform[tensorboard].
-sed -i "/^cloud-accelerator-diagnostics/d" \
-  ${SRC_PATH_MAXTEXT}/src/dependencies/requirements/base_requirements/requirements.txt
+RUN <<"EOF" bash -ex -o pipefail
+echo "-e file://${SRC_PATH_MAXTEXT}" >> /opt/pip-tools.d/requirements-maxtext.in
+echo "-r ${SRC_PATH_MAXTEXT}/src/dependencies/requirements/base_requirements/requirements.txt" \
+  >> /opt/pip-tools.d/requirements-maxtext.in
 
-# remove custom build hook that conflicts with our dependencies introduced in
-# https://github.com/AI-Hypercomputer/maxtext/commit/de886f9a918d17cfb025a353e7da2bc4d64c26b5
-sed -i -e '/^\[tool\.hatch\.build\.targets\.wheel\.hooks\.custom\]$/d' \
-       -e '/^path = "build_hooks\.py"$/d' \
-       ${SRC_PATH_MAXTEXT}/pyproject.toml
+grep -E '^google-jetstream' \
+  ${SRC_PATH_MAXTEXT}/src/dependencies/requirements/requirements.txt \
+  >> /opt/pip-tools.d/requirements-maxtext.in
+
+# Temporary workaround for the broken tensorflow-text 2.21.0 Linux wheel.
+# Keep "tensorflow" here: pip-finalize.sh converts it to tensorflow-cpu.
+echo "tensorflow==2.20.0" >> /opt/pip-tools.d/requirements-maxtext.in
+echo "tensorflow-text==2.20.1" >> /opt/pip-tools.d/requirements-maxtext.in
 EOF
 
 ###############################################################################


### PR DESCRIPTION
Next `tensorflow-text` version introduces [this bug](https://github.com/tensorflow/text/issues/1541). The issue was fixed in [1543](https://github.com/tensorflow/text/pull/1543), but it's not been released yet as a new version.