### PR TITLE
Fix data loaders error for HLO and async in analysis

### DIFF
--- a/.github/container/nsys_jax/nsys_jax/analysis.py
+++ b/.github/container/nsys_jax/nsys_jax/analysis.py
@@ -28,9 +28,9 @@ def align_profiler_data_timestamps(
     # Error if the communication frame doesn't exist at all, but not if it is empty.
     # Calling this on a profile that does not contain any communication should
     # gracefully yield empty results.
-    assert frames.communication is not None, (
-        "align_profiler_data_timestamps requires a communication frame"
-    )
+    assert (
+        frames.communication is not None
+    ), "align_profiler_data_timestamps requires a communication frame"
     if not len(frames.communication):
         # Nothing to be done, return an empty result
         return frames, {}
@@ -43,9 +43,9 @@ def align_profiler_data_timestamps(
             f"WARNING: cannot align {num_profiled_devices} devices because max collective size is 1"
         )
         return frames, {}
-    assert num_profiled_devices == max_collective_size, (
-        f"Aligning {num_profiled_devices} using collectives of size {max_collective_size} is not implemented"
-    )
+    assert (
+        num_profiled_devices == max_collective_size
+    ), f"Aligning {num_profiled_devices} using collectives of size {max_collective_size} is not implemented"
     # Find the collectives that will be used
     align_df = comm_df[comm_df["CollectiveSize"] == max_collective_size]
     # Calculate the collectives' end times
@@ -189,18 +189,22 @@ def _get_message_size(
 ) -> tuple[int, str, int, float, float]:
     _, inst = module_proto.find_instruction(instruction)
     comm_inst = inst.communication_proto()
-    assert comm_inst.opcode in {
-        "all-gather-start",
-        "all-reduce-start",
-        "all-to-all",
-        "collective-broadcast",
-        "collective-permute-start",
-        "dynamic-slice",
-        "dynamic-update-slice",
-        "reduce-scatter",
-    }, (
-        f"{instruction}: message size calculation for {comm_inst.opcode} has not yet been validated"
-    )
+    assert (
+        comm_inst.opcode
+        in {
+            "all-gather",
+            "all-gather-start",
+            "all-reduce",
+            "all-reduce-start",
+            "all-to-all",
+            "collective-broadcast",
+            "collective-permute",
+            "collective-permute-start",
+            "dynamic-slice",
+            "dynamic-update-slice",
+            "reduce-scatter",
+        }
+    ), f"{instruction}: message size calculation for {comm_inst.opcode} has not yet been validated"
 
     def _byte_size(inst) -> int:
         size_bits = math.prod(
@@ -211,7 +215,7 @@ def _get_message_size(
         assert rem == 0
         return size_bytes
 
-    if comm_inst.opcode == "collective-permute-start":
+    if comm_inst.opcode in {"collective-permute-start", "collective-permute"}:
         # See https://openxla.org/xla/operation_semantics#collectivepermute, which
         # generates pair-wise send+recv between devices
         collective_size = 2
@@ -262,21 +266,21 @@ def _get_message_size(
                 mesh = comm_inst.mesh_axes_replica_group_list.mesh
                 axes = comm_inst.mesh_axes_replica_group_list.axes
                 assert len(axes), axes
-                assert not any(ax.HasField("sub_axis_info") for ax in axes), (
-                    f"sub_axis_info not supported: {axes}"
-                )
+                assert not any(
+                    ax.HasField("sub_axis_info") for ax in axes
+                ), f"sub_axis_info not supported: {axes}"
                 collective_size = np.prod(
                     [mesh.axes[ax.mesh_axis_index].size for ax in axes]
                 )
         else:
             collective_sizes = set(len(group.replica_ids) for group in replica_groups)
-            assert len(collective_sizes) == 1, (
-                f"Heterogeneous collective {comm_inst} could not be interpreted"
-            )
+            assert (
+                len(collective_sizes) == 1
+            ), f"Heterogeneous collective {comm_inst} could not be interpreted"
             collective_size = next(iter(collective_sizes))
-        assert collective_size > 0, (
-            f"Could not extract collective size from: {comm_inst}"
-        )
+        assert (
+            collective_size > 0
+        ), f"Could not extract collective size from: {comm_inst}"
     total_msg_size = 0
     for operand_id in comm_inst.operand_ids:
         _, operand = module_proto.find_instruction_by_id(operand_id)

--- a/.github/container/nsys_jax/nsys_jax/data_loaders.py
+++ b/.github/container/nsys_jax/nsys_jax/data_loaders.py
@@ -435,7 +435,7 @@ def _load_nvtx_gpu_proj_trace_single(
         # thunks + the protobuf data, and we can further clean up the data.
         thunk_df = clean_data_frame(df[all_thunks])
         thunk_df["Name"] = thunk_df["Name"].str.replace(
-            pat=f"^{tsl_prefix}Thunk:#(?:name=.*?,|)hlo_op=([a-z0-9._-]+)#$",
+            pat=f"^{tsl_prefix}Thunk:#(?:name=.*?,|)hlo_op=([a-z0-9._-]+)(?:,[^#]*)?#$",
             n=1,
             repl=lambda m: m.group(1),
             regex=True,


### PR DESCRIPTION
1.  Fixing the error `AssertionError: psum_invariant.7.1: message size calculation for all-reduce has not yet been validated`

This was mainly due  because collectives have now an asynchronous representation: 
```
async-start
      └── all-reduce
async-done
```

Therror is that `_get_message_size()` didn't allow to have `all-gather`/`all-reduce`/`collective-permute`.


2. Trying also to fix this error:
```
KeyError: 'TSL:Thunk:#hlo_op=copy.1,unique_hlo_op_id=4294967297#'
```
here nsys-jax is supposed to convert the full annotation into just `copy.1` gbut we have a new additional bit added to the thunk. Thus, i'm modifying the regex we're using for parsing it.
