### PR TITLE
Fix nsys-jax hangs on zombie Nsight processes

### DIFF
--- a/.github/container/nsys_jax/nsys_jax/analysis.py
+++ b/.github/container/nsys_jax/nsys_jax/analysis.py
@@ -254,14 +254,19 @@ def _get_message_size(
             replica_groups = comm_inst.replica_groups
         if len(replica_groups) == 0:
             # perhaps we have the newer format
+            collective_size = 0
             try:
                 collective_size = comm_inst.collective_device_list.iota_replica_group_list.num_devices_per_group
             except AttributeError:
-                # Or the even-newer format
-                collective_size = (
-                    comm_inst.iota_collective_device_list.num_devices_per_group
-                )
-            if len(replica_groups) == 0:
+                pass
+            if collective_size == 0:
+                try:
+                    collective_size = (
+                        comm_inst.iota_collective_device_list.num_devices_per_group
+                    )
+                except AttributeError:
+                    pass
+            if collective_size == 0:
                 # Or the EVEN-newer format. It seems that process_allgather emits this. The default print(axes) is unhelpful, beware.
                 mesh = comm_inst.mesh_axes_replica_group_list.mesh
                 axes = comm_inst.mesh_axes_replica_group_list.axes

--- a/.github/container/nsys_jax/tests/nsys_jax_test_helpers/__init__.py
+++ b/.github/container/nsys_jax/tests/nsys_jax_test_helpers/__init__.py
@@ -6,6 +6,7 @@ import re
 import shutil
 import subprocess
 import tempfile
+import time
 import typing
 import zipfile
 
@@ -35,11 +36,16 @@ def nsys_jax_with_result(command, *, out_dir):
 
         def _not_dead(child: psutil.Process) -> bool:
             try:
-                return child.status() != "dead"
+                return child.status() not in {
+                    psutil.STATUS_DEAD,
+                    psutil.STATUS_ZOMBIE,
+                }
             except psutil.NoSuchProcess:
                 return False
 
         descendants = list(filter(_not_dead, descendants))
+        if descendants:
+            time.sleep(0.1)
     return output, subprocess.CompletedProcess(
         args=proc.args, returncode=proc.returncode
     )


### PR DESCRIPTION
We're fixing: 
- Test helpers could wait forever for defunct nsight processes
- HLO collective-size analysis could incorrectly fall through from an iota device-list representation to the mesh-axis representation.

The former is becuase `psutil` reports these defunct processes as zombie, so they remained in the descendant list forever. The loop also had no delay, causing pytest to consume an entire CPU core while making no progress. So now we can treat `psutil.STATUS_DEAD` and `STATUS_ZOMBIE`