### PR TITLE
`--commit` feature to triage tool

### DIFF
--- a/.github/triage/jax_toolbox_triage/args.py
+++ b/.github/triage/jax_toolbox_triage/args.py
@@ -239,6 +239,18 @@ def parse_args(args=None) -> argparse.Namespace:
         type=parse_version_argument,
     )
     version_search_args.add_argument(
+        "--commit",
+        metavar="[PACKAGE:]REVISION",
+        help="""
+            Commit suspected of introducing the regression. The tool first rebuilds
+            and tests this commit and its first parent using the other package versions
+            from the failing endpoint. If the commit is not confirmed as the culprit,
+            its observed test result is used to narrow the normal version-level
+            bisection. A bare revision is auto-detected among the source repositories;
+            prefix it with a package name (for example jax:abc123) to disambiguate.
+        """,
+    )
+    version_search_args.add_argument(
         "--cherry-pick",
         default={},
         help="""
@@ -459,7 +471,7 @@ def parse_args(args=None) -> argparse.Namespace:
     else:
         # None of --{passing,failing}-{versions,container} were passed, make sure the
         # compulsory arguments for the container-level search were passed
-        assert args.container is not None, (
-            "--container must be passed for the container-level search"
-        )
+        assert (
+            args.container is not None
+        ), "--container must be passed for the container-level search"
     return args

--- a/.github/triage/jax_toolbox_triage/args.py
+++ b/.github/triage/jax_toolbox_triage/args.py
@@ -7,7 +7,6 @@ import os
 import pathlib
 import tempfile
 import warnings
-import typing
 
 # Software we know may exist in the containers that we might be able to triage
 # We know how to recompile JAX/XLA, so it's OK that they include C++ code
@@ -37,7 +36,7 @@ def parse_version_argument(s: str) -> dict[str, str]:
     return ret
 
 
-def parse_commit_argument(s: str) -> typing.Dict[str, str]:
+def parse_commit_argument(s: str) -> dict[str, str]:
     try:
         versions = parse_version_argument(s)
     except (AssertionError, ValueError) as error:
@@ -60,7 +59,7 @@ def parse_override_remotes(s: str) -> dict[str, str]:
         s: (str) e.g. https://<token>@host/repo.git
 
     Returns:
-        ret: (typing.Dict[str,str]) Dictionary with software as key and git-url as value.
+        ret: (dict[str, str]) Dictionary with software as key and git-url as value.
     """
     ret: dict[str, str] = {}
     for part in s.split(","):

--- a/.github/triage/jax_toolbox_triage/args.py
+++ b/.github/triage/jax_toolbox_triage/args.py
@@ -35,6 +35,26 @@ def parse_version_argument(s: str) -> typing.Dict[str, str]:
     return ret
 
 
+def parse_commit_argument(s: str) -> typing.Dict[str, str]:
+    # Most users of a bare --commit are triaging JAX itself. Keep that convenient,
+    # while reusing the existing package:version syntax for every other package.
+    try:
+        versions = parse_version_argument(s if ":" in s else f"jax:{s}")
+    except (AssertionError, ValueError) as error:
+        raise argparse.ArgumentTypeError("invalid --commit value") from error
+    if len(versions) != 1:
+        raise argparse.ArgumentTypeError("--commit accepts exactly one commit")
+    package, revision = next(iter(versions.items()))
+    if (
+        not package
+        or not revision
+        or revision.startswith("-")
+        or any(character.isspace() for character in s)
+    ):
+        raise argparse.ArgumentTypeError("invalid --commit value")
+    return versions
+
+
 def parse_override_remotes(s: str) -> typing.Dict[str, str]:
     """Function to parse the override remote
 
@@ -241,13 +261,15 @@ def parse_args(args=None) -> argparse.Namespace:
     version_search_args.add_argument(
         "--commit",
         metavar="[PACKAGE:]REVISION",
+        type=parse_commit_argument,
         help="""
             Commit suspected of introducing the regression. The tool first rebuilds
-            and tests this commit and its first parent using the other package versions
-            from the failing endpoint. If the commit is not confirmed as the culprit,
-            its observed test result is used to narrow the normal version-level
-            bisection. A bare revision is auto-detected among the source repositories;
-            prefix it with a package name (for example jax:abc123) to disambiguate.
+            and tests this commit, then its first parent if the failure reproduces,
+            using the other package versions from the failing endpoint. If the commit
+            is not confirmed as the culprit, its observed test result is used to narrow
+            the normal version-level bisection. A bare revision refers to JAX; prefix
+            revisions for other packages with their package name (for example
+            xla:abc123).
         """,
     )
     version_search_args.add_argument(

--- a/.github/triage/jax_toolbox_triage/args.py
+++ b/.github/triage/jax_toolbox_triage/args.py
@@ -7,6 +7,7 @@ import os
 import pathlib
 import tempfile
 import warnings
+import typing
 
 # Software we know may exist in the containers that we might be able to triage
 # We know how to recompile JAX/XLA, so it's OK that they include C++ code
@@ -52,7 +53,6 @@ def parse_commit_argument(s: str) -> typing.Dict[str, str]:
     return versions
 
 
-def parse_override_remotes(s: str) -> typing.Dict[str, str]:
 def parse_override_remotes(s: str) -> dict[str, str]:
     """Function to parse the override remote
 
@@ -468,9 +468,7 @@ def parse_args(args=None) -> argparse.Namespace:
     if args.container_runtime == "local":
         assert (
             args.passing_versions is not None and args.failing_versions is not None
-        ), (
-            "For local runtime, --passing-versions and --failing-versions must be provided."
-        )
+        ), "For local runtime, --passing-versions and --failing-versions must be provided."
         assert (
             args.container is None
             and args.start_date is None

--- a/.github/triage/jax_toolbox_triage/args.py
+++ b/.github/triage/jax_toolbox_triage/args.py
@@ -36,20 +36,16 @@ def parse_version_argument(s: str) -> typing.Dict[str, str]:
 
 
 def parse_commit_argument(s: str) -> typing.Dict[str, str]:
-    # Most users of a bare --commit are triaging JAX itself. Keep that convenient,
-    # while reusing the existing package:version syntax for every other package.
     try:
-        versions = parse_version_argument(s if ":" in s else f"jax:{s}")
+        versions = parse_version_argument(s)
     except (AssertionError, ValueError) as error:
         raise argparse.ArgumentTypeError("invalid --commit value") from error
-    if len(versions) != 1:
-        raise argparse.ArgumentTypeError("--commit accepts exactly one commit")
-    package, revision = next(iter(versions.items()))
-    if (
+    if any(character.isspace() for character in s) or any(
         not package
+        or package.startswith("-")
         or not revision
         or revision.startswith("-")
-        or any(character.isspace() for character in s)
+        for package, revision in versions.items()
     ):
         raise argparse.ArgumentTypeError("invalid --commit value")
     return versions
@@ -260,16 +256,18 @@ def parse_args(args=None) -> argparse.Namespace:
     )
     version_search_args.add_argument(
         "--commit",
-        metavar="[PACKAGE:]REVISION",
+        metavar="PACKAGE:REVISION[,PACKAGE:REFERENCE...]",
+        action="append",
         type=parse_commit_argument,
         help="""
-            Commit suspected of introducing the regression. The tool first rebuilds
-            and tests this commit, then its first parent if the failure reproduces,
-            using the other package versions from the failing endpoint. If the commit
-            is not confirmed as the culprit, its observed test result is used to narrow
-            the normal version-level bisection. A bare revision refers to JAX; prefix
-            revisions for other packages with their package name (for example
-            xla:abc123).
+            Version vector suspected of introducing the regression. The first package
+            is the suspected culprit and any remaining packages are reference versions;
+            for example, jax:abc123,xla:def456 tests JAX abc123 and its first
+            parent with XLA def456 fixed. References not supplied explicitly are chosen
+            from the bisection histories by timestamp. If an unconfirmed candidate
+            vector lies within those histories, its observed result narrows the normal
+            version-level bisection across all packages. May be passed multiple times
+            to provide multiple candidate vectors.
         """,
     )
     version_search_args.add_argument(

--- a/.github/triage/jax_toolbox_triage/args.py
+++ b/.github/triage/jax_toolbox_triage/args.py
@@ -36,22 +36,6 @@ def parse_version_argument(s: str) -> dict[str, str]:
     return ret
 
 
-def parse_commit_argument(s: str) -> dict[str, str]:
-    try:
-        versions = parse_version_argument(s)
-    except (AssertionError, ValueError) as error:
-        raise argparse.ArgumentTypeError("invalid --commit value") from error
-    if any(character.isspace() for character in s) or any(
-        not package
-        or package.startswith("-")
-        or not revision
-        or revision.startswith("-")
-        for package, revision in versions.items()
-    ):
-        raise argparse.ArgumentTypeError("invalid --commit value")
-    return versions
-
-
 def parse_override_remotes(s: str) -> dict[str, str]:
     """Function to parse the override remote
 
@@ -259,7 +243,7 @@ def parse_args(args=None) -> argparse.Namespace:
         "--commit",
         metavar="PACKAGE:REVISION[,PACKAGE:REFERENCE...]",
         action="append",
-        type=parse_commit_argument,
+        type=parse_version_argument,
         help="""
             Version vector suspected of introducing the regression. The first package
             is the suspected culprit and any remaining packages are reference versions;
@@ -467,7 +451,9 @@ def parse_args(args=None) -> argparse.Namespace:
     if args.container_runtime == "local":
         assert (
             args.passing_versions is not None and args.failing_versions is not None
-        ), "For local runtime, --passing-versions and --failing-versions must be provided."
+        ), (
+            "For local runtime, --passing-versions and --failing-versions must be provided."
+        )
         assert (
             args.container is None
             and args.start_date is None
@@ -510,7 +496,7 @@ def parse_args(args=None) -> argparse.Namespace:
     else:
         # None of --{passing,failing}-{versions,container} were passed, make sure the
         # compulsory arguments for the container-level search were passed
-        assert (
-            args.container is not None
-        ), "--container must be passed for the container-level search"
+        assert args.container is not None, (
+            "--container must be passed for the container-level search"
+        )
     return args

--- a/.github/triage/jax_toolbox_triage/bisect.py
+++ b/.github/triage/jax_toolbox_triage/bisect.py
@@ -2,139 +2,8 @@ import argparse
 import datetime
 import logging
 import typing
-from dataclasses import dataclass
 
 from .container import Container
-
-
-@dataclass(frozen=True)
-class CommitAndParent:
-    package: str
-    commit: str
-    parent: str
-    needs_fetch: bool
-
-
-def _parse_git_date(date: str) -> datetime.datetime:
-    # Python < 3.11 does not accept the trailing Z emitted by some Git versions.
-    if date.endswith("Z"):
-        date = date[:-1] + "+00:00"
-    return datetime.datetime.fromisoformat(date).astimezone(datetime.timezone.utc)
-
-
-def _commit_exists(worker: Container, revision: str, directory: str) -> bool:
-    return (
-        worker.exec(
-            ["git", "cat-file", "-e", f"{revision}^{{commit}}"],
-            policy="once",
-            stderr="separate",
-            workdir=directory,
-        ).returncode
-        == 0
-    )
-
-
-def resolve_commit_and_parent(
-    worker: Container,
-    commit_spec: str,
-    package_dirs: typing.Dict[str, str],
-    override_remotes: typing.Dict[str, str],
-) -> CommitAndParent:
-    """Resolve ``[PACKAGE:]REVISION`` and its first parent.
-
-    Bare revisions are located among the known source repositories. If the revision
-    is not already present, each repository's configured remote is tried. An explicit
-    package avoids those probes and gives clearer errors for abbreviated revisions.
-    """
-    if not commit_spec or any(c.isspace() for c in commit_spec):
-        raise ValueError("--commit must be a non-empty Git revision without whitespace")
-
-    package = None
-    revision = commit_spec
-    if ":" in commit_spec:
-        package, revision = commit_spec.split(":", 1)
-        if package not in package_dirs:
-            known_packages = ", ".join(sorted(package_dirs))
-            raise ValueError(
-                f"Unknown package {package!r} in --commit; expected one of: "
-                f"{known_packages}"
-            )
-    if not revision or revision.startswith("-"):
-        raise ValueError(f"Invalid Git revision in --commit: {revision!r}")
-
-    if package is not None:
-        directory = package_dirs[package]
-        needs_fetch = not _commit_exists(worker, revision, directory)
-        if needs_fetch:
-            worker.check_exec(
-                ["git", "fetch", override_remotes.get(package, "origin"), revision],
-                policy="once_per_container",
-                stderr="separate",
-                workdir=directory,
-            )
-        matching_packages = [package]
-    else:
-        matching_packages = [
-            candidate_package
-            for candidate_package, directory in package_dirs.items()
-            if _commit_exists(worker, revision, directory)
-        ]
-        needs_fetch = False
-        if not matching_packages:
-            # A candidate can be newer than the checkout embedded in the bisection
-            # container. Try each source repository's remote before giving up.
-            for candidate_package, directory in package_dirs.items():
-                fetch = worker.exec(
-                    [
-                        "git",
-                        "fetch",
-                        override_remotes.get(candidate_package, "origin"),
-                        revision,
-                    ],
-                    policy="once_per_container",
-                    stderr="separate",
-                    workdir=directory,
-                )
-                if fetch.returncode == 0 and _commit_exists(
-                    worker, revision, directory
-                ):
-                    matching_packages.append(candidate_package)
-                    needs_fetch = True
-                    break
-
-    if not matching_packages:
-        raise ValueError(
-            f"Could not find --commit {revision!r} in any known source repository"
-        )
-    if len(matching_packages) > 1:
-        packages = ", ".join(sorted(matching_packages))
-        raise ValueError(
-            f"--commit {revision!r} is ambiguous across {packages}; use "
-            "PACKAGE:REVISION"
-        )
-
-    package = matching_packages[0]
-    directory = package_dirs[package]
-    commit_line = worker.check_exec(
-        ["git", "rev-list", "--parents", "-n", "1", revision],
-        policy="once",
-        stderr="separate",
-        workdir=directory,
-    ).stdout.strip()
-    commit_and_parents = commit_line.split()
-    if len(commit_and_parents) == 1:
-        raise ValueError(
-            f"--commit {commit_and_parents[0]} is a root commit and has no parent to test"
-        )
-
-    commit, parent = commit_and_parents[:2]
-
-    return CommitAndParent(
-        package=package,
-        commit=commit,
-        parent=parent,
-        needs_fetch=needs_fetch,
-    )
 
 
 def get_commit_history(
@@ -276,6 +145,10 @@ def get_commit_history(
     data = []
     for line in result.stdout.splitlines():
         commit, date = line.split()
-        data.append((commit, _parse_git_date(date)))
+        # for python < 3.11 we need to fix:
+        if date.endswith("Z"):
+            date = date[:-1] + "+00:00"
+        date = datetime.datetime.fromisoformat(date).astimezone(datetime.timezone.utc)
+        data.append((commit, date))
 
     return data, cherry_pick_ranges

--- a/.github/triage/jax_toolbox_triage/bisect.py
+++ b/.github/triage/jax_toolbox_triage/bisect.py
@@ -2,8 +2,139 @@ import argparse
 import datetime
 import logging
 import typing
+from dataclasses import dataclass
 
 from .container import Container
+
+
+@dataclass(frozen=True)
+class CommitAndParent:
+    package: str
+    commit: str
+    parent: str
+    needs_fetch: bool
+
+
+def _parse_git_date(date: str) -> datetime.datetime:
+    # Python < 3.11 does not accept the trailing Z emitted by some Git versions.
+    if date.endswith("Z"):
+        date = date[:-1] + "+00:00"
+    return datetime.datetime.fromisoformat(date).astimezone(datetime.timezone.utc)
+
+
+def _commit_exists(worker: Container, revision: str, directory: str) -> bool:
+    return (
+        worker.exec(
+            ["git", "cat-file", "-e", f"{revision}^{{commit}}"],
+            policy="once",
+            stderr="separate",
+            workdir=directory,
+        ).returncode
+        == 0
+    )
+
+
+def resolve_commit_and_parent(
+    worker: Container,
+    commit_spec: str,
+    package_dirs: typing.Dict[str, str],
+    override_remotes: typing.Dict[str, str],
+) -> CommitAndParent:
+    """Resolve ``[PACKAGE:]REVISION`` and its first parent.
+
+    Bare revisions are located among the known source repositories. If the revision
+    is not already present, each repository's configured remote is tried. An explicit
+    package avoids those probes and gives clearer errors for abbreviated revisions.
+    """
+    if not commit_spec or any(c.isspace() for c in commit_spec):
+        raise ValueError("--commit must be a non-empty Git revision without whitespace")
+
+    package = None
+    revision = commit_spec
+    if ":" in commit_spec:
+        package, revision = commit_spec.split(":", 1)
+        if package not in package_dirs:
+            known_packages = ", ".join(sorted(package_dirs))
+            raise ValueError(
+                f"Unknown package {package!r} in --commit; expected one of: "
+                f"{known_packages}"
+            )
+    if not revision or revision.startswith("-"):
+        raise ValueError(f"Invalid Git revision in --commit: {revision!r}")
+
+    if package is not None:
+        directory = package_dirs[package]
+        needs_fetch = not _commit_exists(worker, revision, directory)
+        if needs_fetch:
+            worker.check_exec(
+                ["git", "fetch", override_remotes.get(package, "origin"), revision],
+                policy="once_per_container",
+                stderr="separate",
+                workdir=directory,
+            )
+        matching_packages = [package]
+    else:
+        matching_packages = [
+            candidate_package
+            for candidate_package, directory in package_dirs.items()
+            if _commit_exists(worker, revision, directory)
+        ]
+        needs_fetch = False
+        if not matching_packages:
+            # A candidate can be newer than the checkout embedded in the bisection
+            # container. Try each source repository's remote before giving up.
+            for candidate_package, directory in package_dirs.items():
+                fetch = worker.exec(
+                    [
+                        "git",
+                        "fetch",
+                        override_remotes.get(candidate_package, "origin"),
+                        revision,
+                    ],
+                    policy="once_per_container",
+                    stderr="separate",
+                    workdir=directory,
+                )
+                if fetch.returncode == 0 and _commit_exists(
+                    worker, revision, directory
+                ):
+                    matching_packages.append(candidate_package)
+                    needs_fetch = True
+                    break
+
+    if not matching_packages:
+        raise ValueError(
+            f"Could not find --commit {revision!r} in any known source repository"
+        )
+    if len(matching_packages) > 1:
+        packages = ", ".join(sorted(matching_packages))
+        raise ValueError(
+            f"--commit {revision!r} is ambiguous across {packages}; use "
+            "PACKAGE:REVISION"
+        )
+
+    package = matching_packages[0]
+    directory = package_dirs[package]
+    commit_line = worker.check_exec(
+        ["git", "rev-list", "--parents", "-n", "1", revision],
+        policy="once",
+        stderr="separate",
+        workdir=directory,
+    ).stdout.strip()
+    commit_and_parents = commit_line.split()
+    if len(commit_and_parents) == 1:
+        raise ValueError(
+            f"--commit {commit_and_parents[0]} is a root commit and has no parent to test"
+        )
+
+    commit, parent = commit_and_parents[:2]
+
+    return CommitAndParent(
+        package=package,
+        commit=commit,
+        parent=parent,
+        needs_fetch=needs_fetch,
+    )
 
 
 def get_commit_history(
@@ -145,10 +276,6 @@ def get_commit_history(
     data = []
     for line in result.stdout.splitlines():
         commit, date = line.split()
-        # for python < 3.11 we need to fix:
-        if date.endswith("Z"):
-            date = date[:-1] + "+00:00"
-        date = datetime.datetime.fromisoformat(date).astimezone(datetime.timezone.utc)
-        data.append((commit, date))
+        data.append((commit, _parse_git_date(date)))
 
     return data, cherry_pick_ranges

--- a/.github/triage/jax_toolbox_triage/logic.py
+++ b/.github/triage/jax_toolbox_triage/logic.py
@@ -461,7 +461,6 @@ def version_search(
     max_repetitions: typing.Optional[int] = None,
     result_cache: typing.Optional[typing.Dict[FlatVersionDict, TestResult]] = None,
     classifier: ExecutionClassifier = ExitCodeClassifier(),
-    precondition_failure_log_level: int = logging.FATAL,
 ) -> typing.Tuple[
     typing.Dict[str, str], typing.Sequence[TestResult], typing.Sequence[TestResult]
 ]:
@@ -485,7 +484,6 @@ def version_search(
         of times any given set of versions will be executed is `max_repetitions + 1`.
         Defaults to be `confirmation_iterations + 2`.
     result_cache: previously completed build/test results to reuse
-    precondition_failure_log_level: log level for endpoint verification failures
 
     Returns a 3-tuple of (summary_dict, last_known_good, first_known_bad),
     where the last element can be None if skip_precondition_checks=True. The
@@ -560,16 +558,16 @@ def version_search(
             )
             if check.result == TestExecutionOutcome.BUILD_FAILURE:
                 err = f"Build failure attempting to reproduce result with {good_or_bad} versions"
-                logger.log(precondition_failure_log_level, err)
-                logger.log(precondition_failure_log_level, check.build_stdouterr)
+                logger.fatal(err)
+                logger.fatal(check.build_stdouterr)
                 raise CouldNotReproduceDesiredOutcome(
                     err, outcome=ClassifiedTestOutcome.ERROR
                 )
             outcome = classifier([check])
             if outcome == ClassifiedTestOutcome.ERROR:
                 err = f"Test error attempting to reproduce result with {good_or_bad} versions"
-                logger.log(precondition_failure_log_level, err)
-                logger.log(precondition_failure_log_level, check.stdouterr)
+                logger.fatal(err)
+                logger.fatal(check.stdouterr)
                 raise CouldNotReproduceDesiredOutcome(err, outcome=outcome)
             if outcome == ClassifiedTestOutcome.AMBIGUOUS:
                 # For metric-based triage, these up-front checking loops are important
@@ -599,8 +597,8 @@ def version_search(
                     logger.info(f"Verified test result using {good_or_bad} versions.")
             elif outcome in {ClassifiedTestOutcome.PASS, ClassifiedTestOutcome.FAIL}:
                 err = f"Could not reproduce results with {good_or_bad} versions ({outcome}, iteration {n})"
-                logger.log(precondition_failure_log_level, err)
-                logger.log(precondition_failure_log_level, check.stdouterr)
+                logger.fatal(err)
+                logger.fatal(check.stdouterr)
                 raise CouldNotReproduceDesiredOutcome(err, outcome=outcome)
 
     def _check_success():

--- a/.github/triage/jax_toolbox_triage/logic.py
+++ b/.github/triage/jax_toolbox_triage/logic.py
@@ -8,11 +8,22 @@ from dataclasses import dataclass
 from enum import Enum, auto
 
 
-class CouldNotReproduceFailure(Exception):
+class CouldNotReproduceOutcome(Exception):
+    def __init__(
+        self,
+        message: str,
+        *,
+        outcome: typing.Optional["ClassifiedTestOutcome"] = None,
+    ) -> None:
+        super().__init__(message)
+        self.outcome = outcome
+
+
+class CouldNotReproduceFailure(CouldNotReproduceOutcome):
     pass
 
 
-class CouldNotReproduceSuccess(Exception):
+class CouldNotReproduceSuccess(CouldNotReproduceOutcome):
     pass
 
 
@@ -434,149 +445,6 @@ def version_cache_key(
     )
 
 
-@dataclass(frozen=True)
-class CulpritVerification:
-    candidate_outcome: ClassifiedTestOutcome
-    candidate_results: typing.Sequence[TestResult]
-    parent_outcome: ClassifiedTestOutcome
-    parent_results: typing.Sequence[TestResult]
-
-    @property
-    def confirmed(self) -> bool:
-        return (
-            self.candidate_outcome == ClassifiedTestOutcome.FAIL
-            and self.parent_outcome == ClassifiedTestOutcome.PASS
-        )
-
-
-def verify_culprit(
-    *,
-    candidate_versions: typing.Dict[str, str],
-    parent_versions: typing.Dict[str, str],
-    build_and_test: BuildAndTest,
-    logger: logging.Logger,
-    confirmation_iterations: int = 1,
-    max_repetitions: typing.Optional[int] = None,
-    result_cache: typing.Optional[typing.Dict[FlatVersionDict, TestResult]] = None,
-    classifier: typing.Optional[ExecutionClassifier] = None,
-) -> CulpritVerification:
-    """Build and test a suspected culprit commit and its parent.
-
-    The candidate is deliberately tested first so users can immediately verify that
-    the reported failure is the one they intend to triage. Unlike version-search
-    preconditions, neither outcome is assumed: both are measured so the caller can use
-    the observations to select a fallback bisection range.
-    """
-    assert candidate_versions.keys() == parent_versions.keys(), (
-        candidate_versions,
-        parent_versions,
-    )
-    assert candidate_versions != parent_versions
-    if max_repetitions is None:
-        max_repetitions = confirmation_iterations + 2
-    assert max_repetitions >= confirmation_iterations
-    if result_cache is None:
-        result_cache = {}
-    if classifier is None:
-        classifier = ExitCodeClassifier()
-
-    def build_cached(
-        versions: typing.Dict[str, str],
-        *,
-        repetition: int,
-        test_output_log_level: int,
-    ) -> TestResult:
-        cache_key = version_cache_key(versions, repetition=repetition)
-        result = result_cache.get(cache_key)
-        if result is not None:
-            logger.info(
-                f"Reusing cached result for {dict(cache_key)}: "
-                f"{result.result}: {result.metrics}"
-            )
-            return result
-        result = build_and_test(
-            versions=_strip_build_failures(versions),
-            test_output_log_level=test_output_log_level,
-            test_repetition=repetition,
-        )
-        logger.info(
-            f"New result for {dict(cache_key)}: {result.result}: {result.metrics}"
-        )
-        result_cache[cache_key] = result
-        return result
-
-    def outcome_with_retries(
-        label: str,
-        versions: typing.Dict[str, str],
-        *,
-        first_log_level: int,
-    ) -> typing.Tuple[ClassifiedTestOutcome, typing.Sequence[TestResult]]:
-        min_runs = 1 + confirmation_iterations
-        max_runs = 1 + max_repetitions
-        logger.info(f"Testing {label} versions at least {min_runs} time(s)")
-        results = []
-        for repetition in range(min_runs):
-            result = build_cached(
-                versions,
-                repetition=repetition,
-                test_output_log_level=(
-                    first_log_level if repetition == 0 else logging.DEBUG
-                ),
-            )
-            results.append(result)
-            if result.result != TestExecutionOutcome.TEST_YIELDED_RESULTS:
-                # Repeating a build failure or an execution error cannot make it
-                # classifiable. Still continue on to test the other revision.
-                break
-
-        outcome = classifier(results)
-        if outcome == ClassifiedTestOutcome.AMBIGUOUS:
-            logger.info(
-                f"Ambiguous result from {len(results)} {label} measurement(s), "
-                f"running up to {max_runs - len(results)} extra measurement(s)."
-            )
-            for repetition in range(len(results), max_runs):
-                results.append(
-                    build_cached(
-                        versions,
-                        repetition=repetition,
-                        test_output_log_level=logging.DEBUG,
-                    )
-                )
-                outcome = classifier(results)
-                if outcome != ClassifiedTestOutcome.AMBIGUOUS:
-                    logger.info(
-                        f"Got non-ambiguous {label} outcome {outcome} from "
-                        f"{len(results)} measurements."
-                    )
-                    break
-
-        logger.info(f"Observed {label} outcome: {outcome}")
-        classifier_status = classifier.text_summary()
-        if classifier_status:
-            logger.info("Updated classifier status:")
-            for row in classifier_status:
-                logger.info(row)
-        return outcome, results
-
-    candidate_outcome, candidate_results = outcome_with_retries(
-        "candidate commit",
-        candidate_versions,
-        first_log_level=logging.INFO,
-    )
-    parent_outcome, parent_results = outcome_with_retries(
-        "parent commit",
-        parent_versions,
-        first_log_level=logging.DEBUG,
-    )
-    return CulpritVerification(
-        candidate_outcome=candidate_outcome,
-        candidate_results=candidate_results,
-        parent_outcome=parent_outcome,
-        parent_results=parent_results,
-    )
-
-
 def version_search(
     *,
     versions: typing.OrderedDict[
@@ -590,6 +458,7 @@ def version_search(
     max_repetitions: typing.Optional[int] = None,
     result_cache: typing.Optional[typing.Dict[FlatVersionDict, TestResult]] = None,
     classifier: ExecutionClassifier = ExitCodeClassifier(),
+    precondition_failure_log_level: int = logging.FATAL,
 ) -> typing.Tuple[
     typing.Dict[str, str], typing.Sequence[TestResult], typing.Sequence[TestResult]
 ]:
@@ -613,6 +482,7 @@ def version_search(
         of times any given set of versions will be executed is `max_repetitions + 1`.
         Defaults to be `confirmation_iterations + 2`.
     result_cache: previously completed build/test results to reuse
+    precondition_failure_log_level: log level for endpoint verification failures
 
     Returns a 3-tuple of (summary_dict, last_known_good, first_known_bad),
     where the last element can be None if skip_precondition_checks=True. The
@@ -687,11 +557,17 @@ def version_search(
             )
             if check.result == TestExecutionOutcome.BUILD_FAILURE:
                 err = f"Build failure attempting to reproduce result with {good_or_bad} versions"
-                logger.fatal(err)
-                logger.fatal(check.build_stdouterr)
-                raise CouldNotReproduceDesiredOutcome(err)
+                logger.log(precondition_failure_log_level, err)
+                logger.log(precondition_failure_log_level, check.build_stdouterr)
+                raise CouldNotReproduceDesiredOutcome(
+                    err, outcome=ClassifiedTestOutcome.ERROR
+                )
             outcome = classifier([check])
-            assert outcome != ClassifiedTestOutcome.ERROR
+            if outcome == ClassifiedTestOutcome.ERROR:
+                err = f"Test error attempting to reproduce result with {good_or_bad} versions"
+                logger.log(precondition_failure_log_level, err)
+                logger.log(precondition_failure_log_level, check.stdouterr)
+                raise CouldNotReproduceDesiredOutcome(err, outcome=outcome)
             if outcome == ClassifiedTestOutcome.AMBIGUOUS:
                 # For metric-based triage, these up-front checking loops are important
                 # to help initialise the classifier state. Rather than spending a long
@@ -720,9 +596,9 @@ def version_search(
                     logger.info(f"Verified test result using {good_or_bad} versions.")
             elif outcome in {ClassifiedTestOutcome.PASS, ClassifiedTestOutcome.FAIL}:
                 err = f"Could not reproduce results with {good_or_bad} versions ({outcome}, iteration {n})"
-                logger.fatal(err)
-                logger.fatal(check.stdouterr)
-                raise CouldNotReproduceDesiredOutcome(err)
+                logger.log(precondition_failure_log_level, err)
+                logger.log(precondition_failure_log_level, check.stdouterr)
+                raise CouldNotReproduceDesiredOutcome(err, outcome=outcome)
 
     def _check_success():
         _check(

--- a/.github/triage/jax_toolbox_triage/logic.py
+++ b/.github/triage/jax_toolbox_triage/logic.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import datetime
 import functools
 import itertools
@@ -15,8 +17,8 @@ class CouldNotReproduceDesiredOutcome(Exception):
         self,
         message: str,
         *,
-        expected_outcome: "ClassifiedTestOutcome",
-        actual_outcome: "ClassifiedTestOutcome",
+        expected_outcome: ClassifiedTestOutcome,
+        actual_outcome: ClassifiedTestOutcome,
     ) -> None:
         super().__init__(message)
         self.expected_outcome = expected_outcome
@@ -367,11 +369,9 @@ def _get_versions(
     *,
     logger: logging.Logger,
     primary: str,
-    primary_index: typing.Optional[int] = None,
-    versions: typing.OrderedDict[
-        str, typing.Sequence[typing.Tuple[str, datetime.datetime]]
-    ],
-) -> typing.Tuple[typing.Dict[str, str], typing.Dict[str, int]]:
+    primary_index: int | None = None,
+    versions: typing.OrderedDict[str, typing.Sequence[tuple[str, datetime.datetime]]],
+) -> tuple[dict[str, str], dict[str, int]]:
     """Select the primary version and contemporary versions of other packages.
 
     For each secondary package, choose the oldest version whose timestamp is not
@@ -869,16 +869,14 @@ def version_search(
             # as given middle=fail, and Q1=fail the points between Q1 and middle will
             # not be checked.
             n_primary = len(versions[primary])
-            unavailable_commits = []
+            unavailable_commits: list[str] = []
             for n in range(1, n_primary - 1):
                 versions_n, _ = get_versions(primary_index=n, versions=versions)
                 # Should have yielded no usable results if tested.
                 result_n = result_cache.get(version_cache_key(versions_n))
                 if result_n is not None:
-                    assert (
-                        result_n.result == TestExecutionOutcome.BUILD_FAILURE
-                    ), result_n
-                build_fail_commits.append(versions_n[primary])
+                    assert not _yielded_results(result_n), result_n
+                unavailable_commits.append(versions_n[primary])
             logger.warning(
                 f"Could not triage {primary} to a single version because some "
                 f"executions yielded no results; adding {n_primary - 2} version(s) to both "

--- a/.github/triage/jax_toolbox_triage/logic.py
+++ b/.github/triage/jax_toolbox_triage/logic.py
@@ -354,7 +354,7 @@ def _not_first(d: typing.Dict[T, U]) -> typing.Iterable[typing.Tuple[T, U]]:
     return itertools.islice(d.items(), 1, None)
 
 
-def get_aligned_versions(
+def _get_versions(
     *,
     logger: logging.Logger,
     primary: str,
@@ -644,9 +644,7 @@ def version_search(
     # take the oldest versions of the other packages that are newer than the
     # first package.
     primary = _first(versions.keys())
-    get_versions = functools.partial(
-        get_aligned_versions, logger=logger, primary=primary
-    )
+    get_versions = functools.partial(_get_versions, logger=logger, primary=primary)
 
     def find_successful_build(versions):
         # Try to find a set of versions where the build does not fail, starting with

--- a/.github/triage/jax_toolbox_triage/logic.py
+++ b/.github/triage/jax_toolbox_triage/logic.py
@@ -1,11 +1,11 @@
-from dataclasses import dataclass
 import datetime
-from enum import auto, Enum
 import functools
 import itertools
 import logging
 import pathlib
 import typing
+from dataclasses import dataclass
+from enum import Enum, auto
 
 
 class CouldNotReproduceFailure(Exception):
@@ -434,6 +434,149 @@ def version_cache_key(
     )
 
 
+@dataclass(frozen=True)
+class CulpritVerification:
+    candidate_outcome: ClassifiedTestOutcome
+    candidate_results: typing.Sequence[TestResult]
+    parent_outcome: ClassifiedTestOutcome
+    parent_results: typing.Sequence[TestResult]
+
+    @property
+    def confirmed(self) -> bool:
+        return (
+            self.candidate_outcome == ClassifiedTestOutcome.FAIL
+            and self.parent_outcome == ClassifiedTestOutcome.PASS
+        )
+
+
+def verify_culprit(
+    *,
+    candidate_versions: typing.Dict[str, str],
+    parent_versions: typing.Dict[str, str],
+    build_and_test: BuildAndTest,
+    logger: logging.Logger,
+    confirmation_iterations: int = 1,
+    max_repetitions: typing.Optional[int] = None,
+    result_cache: typing.Optional[typing.Dict[FlatVersionDict, TestResult]] = None,
+    classifier: typing.Optional[ExecutionClassifier] = None,
+) -> CulpritVerification:
+    """Build and test a suspected culprit commit and its parent.
+
+    The candidate is deliberately tested first so users can immediately verify that
+    the reported failure is the one they intend to triage. Unlike version-search
+    preconditions, neither outcome is assumed: both are measured so the caller can use
+    the observations to select a fallback bisection range.
+    """
+    assert candidate_versions.keys() == parent_versions.keys(), (
+        candidate_versions,
+        parent_versions,
+    )
+    assert candidate_versions != parent_versions
+    if max_repetitions is None:
+        max_repetitions = confirmation_iterations + 2
+    assert max_repetitions >= confirmation_iterations
+    if result_cache is None:
+        result_cache = {}
+    if classifier is None:
+        classifier = ExitCodeClassifier()
+
+    def build_cached(
+        versions: typing.Dict[str, str],
+        *,
+        repetition: int,
+        test_output_log_level: int,
+    ) -> TestResult:
+        cache_key = version_cache_key(versions, repetition=repetition)
+        result = result_cache.get(cache_key)
+        if result is not None:
+            logger.info(
+                f"Reusing cached result for {dict(cache_key)}: "
+                f"{result.result}: {result.metrics}"
+            )
+            return result
+        result = build_and_test(
+            versions=_strip_build_failures(versions),
+            test_output_log_level=test_output_log_level,
+            test_repetition=repetition,
+        )
+        logger.info(
+            f"New result for {dict(cache_key)}: {result.result}: {result.metrics}"
+        )
+        result_cache[cache_key] = result
+        return result
+
+    def outcome_with_retries(
+        label: str,
+        versions: typing.Dict[str, str],
+        *,
+        first_log_level: int,
+    ) -> typing.Tuple[ClassifiedTestOutcome, typing.Sequence[TestResult]]:
+        min_runs = 1 + confirmation_iterations
+        max_runs = 1 + max_repetitions
+        logger.info(f"Testing {label} versions at least {min_runs} time(s)")
+        results = []
+        for repetition in range(min_runs):
+            result = build_cached(
+                versions,
+                repetition=repetition,
+                test_output_log_level=(
+                    first_log_level if repetition == 0 else logging.DEBUG
+                ),
+            )
+            results.append(result)
+            if result.result != TestExecutionOutcome.TEST_YIELDED_RESULTS:
+                # Repeating a build failure or an execution error cannot make it
+                # classifiable. Still continue on to test the other revision.
+                break
+
+        outcome = classifier(results)
+        if outcome == ClassifiedTestOutcome.AMBIGUOUS:
+            logger.info(
+                f"Ambiguous result from {len(results)} {label} measurement(s), "
+                f"running up to {max_runs - len(results)} extra measurement(s)."
+            )
+            for repetition in range(len(results), max_runs):
+                results.append(
+                    build_cached(
+                        versions,
+                        repetition=repetition,
+                        test_output_log_level=logging.DEBUG,
+                    )
+                )
+                outcome = classifier(results)
+                if outcome != ClassifiedTestOutcome.AMBIGUOUS:
+                    logger.info(
+                        f"Got non-ambiguous {label} outcome {outcome} from "
+                        f"{len(results)} measurements."
+                    )
+                    break
+
+        logger.info(f"Observed {label} outcome: {outcome}")
+        classifier_status = classifier.text_summary()
+        if classifier_status:
+            logger.info("Updated classifier status:")
+            for row in classifier_status:
+                logger.info(row)
+        return outcome, results
+
+    candidate_outcome, candidate_results = outcome_with_retries(
+        "candidate commit",
+        candidate_versions,
+        first_log_level=logging.INFO,
+    )
+    parent_outcome, parent_results = outcome_with_retries(
+        "parent commit",
+        parent_versions,
+        first_log_level=logging.DEBUG,
+    )
+    return CulpritVerification(
+        candidate_outcome=candidate_outcome,
+        candidate_results=candidate_results,
+        parent_outcome=parent_outcome,
+        parent_results=parent_results,
+    )
+
+
 def version_search(
     *,
     versions: typing.OrderedDict[
@@ -790,9 +933,9 @@ def version_search(
                 # Should have been a build failure if tested.
                 result_n = result_cache.get(version_cache_key(versions_n))
                 if result_n is not None:
-                    assert result_n.result == TestExecutionOutcome.BUILD_FAILURE, (
-                        result_n
-                    )
+                    assert (
+                        result_n.result == TestExecutionOutcome.BUILD_FAILURE
+                    ), result_n
                 build_fail_commits.append(versions_n[primary])
             logger.warning(
                 f"Could not triage {primary} to a single version due to build "

--- a/.github/triage/jax_toolbox_triage/logic.py
+++ b/.github/triage/jax_toolbox_triage/logic.py
@@ -8,26 +8,19 @@ from dataclasses import dataclass
 from enum import Enum, auto
 
 
-class CouldNotReproduceFailure(Exception):
+class CouldNotReproduceDesiredOutcome(Exception):
+    """Raised when a precondition check does not produce its expected outcome."""
+
     def __init__(
         self,
         message: str,
         *,
-        outcome: typing.Optional["ClassifiedTestOutcome"] = None,
+        expected_outcome: "ClassifiedTestOutcome",
+        actual_outcome: "ClassifiedTestOutcome",
     ) -> None:
         super().__init__(message)
-        self.outcome = outcome
-
-
-class CouldNotReproduceSuccess(Exception):
-    def __init__(
-        self,
-        message: str,
-        *,
-        outcome: typing.Optional["ClassifiedTestOutcome"] = None,
-    ) -> None:
-        super().__init__(message)
-        self.outcome = outcome
+        self.expected_outcome = expected_outcome
+        self.actual_outcome = actual_outcome
 
 
 class TestExecutionOutcome(Enum):
@@ -361,7 +354,7 @@ def _not_first(d: typing.Dict[T, U]) -> typing.Iterable[typing.Tuple[T, U]]:
     return itertools.islice(d.items(), 1, None)
 
 
-def _get_versions(
+def get_aligned_versions(
     *,
     logger: logging.Logger,
     primary: str,
@@ -370,6 +363,13 @@ def _get_versions(
         str, typing.Sequence[typing.Tuple[str, datetime.datetime]]
     ],
 ) -> typing.Tuple[typing.Dict[str, str], typing.Dict[str, int]]:
+    """Select the primary version and contemporary versions of other packages.
+
+    For each secondary package, choose the oldest version whose timestamp is not
+    older than the selected primary version, falling back to its latest version.
+    The returned indices allow callers to narrow every package history around the
+    selected version vector.
+    """
     if primary_index is None:
         primary_index = len(versions[primary]) // 2
         log_msg = f"Chose from {len(versions[primary])} remaining {primary} versions"
@@ -535,9 +535,7 @@ def version_search(
         result_cache[cache_key] = bisect_result
         return bisect_result
 
-    def _check(
-        good_or_bad, check_versions, desired_outcome, CouldNotReproduceDesiredOutcome
-    ):
+    def _check(good_or_bad, check_versions, desired_outcome):
         # Verify that we can build successfully and that the test gives the expected results.
         logger.info(
             f"Verifying test outcome using {good_or_bad} versions "
@@ -561,14 +559,20 @@ def version_search(
                 logger.fatal(err)
                 logger.fatal(check.build_stdouterr)
                 raise CouldNotReproduceDesiredOutcome(
-                    err, outcome=ClassifiedTestOutcome.ERROR
+                    err,
+                    expected_outcome=desired_outcome,
+                    actual_outcome=ClassifiedTestOutcome.ERROR,
                 )
             outcome = classifier([check])
             if outcome == ClassifiedTestOutcome.ERROR:
                 err = f"Test error attempting to reproduce result with {good_or_bad} versions"
                 logger.fatal(err)
                 logger.fatal(check.stdouterr)
-                raise CouldNotReproduceDesiredOutcome(err, outcome=outcome)
+                raise CouldNotReproduceDesiredOutcome(
+                    err,
+                    expected_outcome=desired_outcome,
+                    actual_outcome=outcome,
+                )
             if outcome == ClassifiedTestOutcome.AMBIGUOUS:
                 # For metric-based triage, these up-front checking loops are important
                 # to help initialise the classifier state. Rather than spending a long
@@ -599,14 +603,17 @@ def version_search(
                 err = f"Could not reproduce results with {good_or_bad} versions ({outcome}, iteration {n})"
                 logger.fatal(err)
                 logger.fatal(check.stdouterr)
-                raise CouldNotReproduceDesiredOutcome(err, outcome=outcome)
+                raise CouldNotReproduceDesiredOutcome(
+                    err,
+                    expected_outcome=desired_outcome,
+                    actual_outcome=outcome,
+                )
 
     def _check_success():
         _check(
             "'good'",
             _earliest_versions(versions),
             ClassifiedTestOutcome.PASS,
-            CouldNotReproduceSuccess,
         )
 
     def _check_failure():
@@ -614,7 +621,6 @@ def version_search(
             "'bad'",
             _latest_versions(versions),
             ClassifiedTestOutcome.FAIL,
-            CouldNotReproduceFailure,
         )
 
     if skip_precondition_checks:
@@ -638,7 +644,9 @@ def version_search(
     # take the oldest versions of the other packages that are newer than the
     # first package.
     primary = _first(versions.keys())
-    get_versions = functools.partial(_get_versions, logger=logger, primary=primary)
+    get_versions = functools.partial(
+        get_aligned_versions, logger=logger, primary=primary
+    )
 
     def find_successful_build(versions):
         # Try to find a set of versions where the build does not fail, starting with

--- a/.github/triage/jax_toolbox_triage/logic.py
+++ b/.github/triage/jax_toolbox_triage/logic.py
@@ -8,7 +8,7 @@ from dataclasses import dataclass
 from enum import Enum, auto
 
 
-class CouldNotReproduceOutcome(Exception):
+class CouldNotReproduceFailure(Exception):
     def __init__(
         self,
         message: str,
@@ -19,12 +19,15 @@ class CouldNotReproduceOutcome(Exception):
         self.outcome = outcome
 
 
-class CouldNotReproduceFailure(CouldNotReproduceOutcome):
-    pass
-
-
-class CouldNotReproduceSuccess(CouldNotReproduceOutcome):
-    pass
+class CouldNotReproduceSuccess(Exception):
+    def __init__(
+        self,
+        message: str,
+        *,
+        outcome: typing.Optional["ClassifiedTestOutcome"] = None,
+    ) -> None:
+        super().__init__(message)
+        self.outcome = outcome
 
 
 class TestExecutionOutcome(Enum):

--- a/.github/triage/jax_toolbox_triage/triage_tool.py
+++ b/.github/triage/jax_toolbox_triage/triage_tool.py
@@ -11,7 +11,7 @@ import shlex
 import time
 from typing import Any, Dict, Optional, Set, Tuple, Union
 
-from .bisect import get_commit_history, resolve_commit_and_parent
+from .bisect import get_commit_history
 from .container import Container
 from .container_factory import make_container
 from .docker import DockerContainer
@@ -27,7 +27,6 @@ from .logic import (
     TestExecutionOutcome,
     TestResult,
     container_search,
-    verify_culprit,
     version_search,
 )
 from .metric_classifier import MetricClassifier
@@ -907,31 +906,73 @@ class TriageTool:
         candidate = None
         # Prepare the container for the bisection
         with self._make_container(self.bisection_url) as worker:
-            commit_spec = getattr(self.args, "commit", None)
-            if commit_spec is not None:
+            if self.args.commit is not None:
                 assert self.package_dirs is not None
-                candidate = resolve_commit_and_parent(
-                    worker,
-                    commit_spec,
-                    self.package_dirs,
-                    self.args.override_remotes,
-                )
-                if candidate.package not in passing_versions:
+                package, revision = next(iter(self.args.commit.items()))
+                if package not in self.package_dirs:
                     raise ValueError(
-                        f"The package selected by --commit ({candidate.package}) "
+                        f"--commit package {package!r} is not a Git repository "
+                        "known to the triage environment"
+                    )
+                if package not in passing_versions:
+                    raise ValueError(
+                        f"The package selected by --commit ({package}) "
                         "does not have passing and failing endpoint versions"
                     )
+
+                directory = self.package_dirs[package]
+                resolve_command = [
+                    "git",
+                    "rev-list",
+                    "--parents",
+                    "-n",
+                    "1",
+                    revision,
+                ]
+                commit_info = worker.exec(
+                    resolve_command,
+                    policy="once",
+                    stderr="separate",
+                    workdir=directory,
+                )
+                needs_fetch = commit_info.returncode != 0
+                if needs_fetch:
+                    worker.check_exec(
+                        [
+                            "git",
+                            "fetch",
+                            self.args.override_remotes.get(package, "origin"),
+                            revision,
+                        ],
+                        policy="once_per_container",
+                        stderr="separate",
+                        workdir=directory,
+                    )
+                    commit_info = worker.check_exec(
+                        resolve_command,
+                        policy="once",
+                        stderr="separate",
+                        workdir=directory,
+                    )
+                commit_and_parents = commit_info.stdout.split()
+                if len(commit_and_parents) == 1:
+                    raise ValueError(
+                        f"--commit {commit_and_parents[0]} has no parent to test"
+                    )
+                commit, parent = commit_and_parents[:2]
+                candidate = (package, commit, parent)
+
                 # A package can be static across the original container endpoints but
                 # still need to be checked out when an explicit candidate is supplied.
-                self.dynamic_packages.add(candidate.package)
-                if candidate.needs_fetch and self.args.container_runtime != "local":
+                self.dynamic_packages.add(package)
+                if needs_fetch and self.args.container_runtime != "local":
                     # Preparation happens in a disposable container. Make the
                     # candidate (and therefore its ancestors) available again in each
                     # fresh build container.
-                    self.commits_to_fetch[candidate.package] = candidate.commit
+                    self.commits_to_fetch[package] = commit
                 self.logger.info(
-                    f"Resolved --commit to {candidate.package} {candidate.commit}; "
-                    f"its first parent is {candidate.parent}"
+                    f"Resolved --commit to {package} {commit}; "
+                    f"its first parent is {parent}"
                 )
             package_versions = self._gather_histories(
                 worker, passing_versions, failing_versions
@@ -963,101 +1004,83 @@ class TriageTool:
         last_known_good = None
         first_known_bad = None
         if candidate is not None:
+            package, commit, parent = candidate
             # Keep every other package at its bisection-compatible failing endpoint.
             # This isolates the candidate while preserving any automatically-derived
             # cherry-picks needed to reproduce the failing environment.
-            candidate_versions = {
-                package: versions[-1][0]
-                for package, versions in package_versions.items()
-            }
-            candidate_versions[candidate.package] = candidate.commit
-            parent_versions = candidate_versions.copy()
-            parent_versions[candidate.package] = candidate.parent
+            candidate_date = package_versions[package][-1][1]
+            candidate_range = collections.OrderedDict(
+                [(package, [(parent, candidate_date), (commit, candidate_date)])]
+            )
+            candidate_range.update(
+                (
+                    other_package,
+                    [(versions[-1][0], candidate_date)],
+                )
+                for other_package, versions in package_versions.items()
+                if other_package != package
+            )
 
             self.logger.info(
-                f"Validating suspected culprit {candidate.package} "
-                f"{candidate.commit} against parent {candidate.parent}"
+                f"Validating suspected culprit {package} {commit} "
+                f"against parent {parent}"
             )
-            verification = verify_culprit(
-                candidate_versions=candidate_versions,
-                parent_versions=parent_versions,
-                build_and_test=self._build_and_test,
-                logger=self.logger,
-                confirmation_iterations=self.args.confirmation_iterations,
-                result_cache=result_cache,
-                classifier=classifier,
-            )
-            if verification.candidate_outcome == ClassifiedTestOutcome.FAIL:
-                self.logger.info(
-                    "The supplied commit reproduced a failure. IMPORTANT: check "
-                    "that the candidate test output above shows the regression you "
-                    "intended to triage."
+            fallback_range = None
+            try:
+                result, last_known_good, first_known_bad = version_search(
+                    versions=candidate_range,
+                    build_and_test=self._build_and_test,
+                    logger=self.logger,
+                    skip_precondition_checks=False,
+                    check_success_before_failure=False,
+                    confirmation_iterations=self.args.confirmation_iterations,
+                    result_cache=result_cache,
+                    classifier=classifier,
+                    precondition_failure_log_level=logging.INFO,
                 )
-            if verification.confirmed:
-                self.logger.info(
-                    f"Confirmed {candidate.package} {candidate.commit} as the "
-                    "culprit: the candidate fails and its first parent passes"
+            except CouldNotReproduceSuccess:
+                # The candidate failed but its parent did not pass. Search backwards.
+                fallback_range = (
+                    passing_versions,
+                    {**failing_versions, package: commit},
                 )
-                result = {
-                    f"{candidate.package}_bad": candidate.commit,
-                    f"{candidate.package}_good": candidate.parent,
-                }
-                for package, version in candidate_versions.items():
-                    if package != candidate.package:
-                        result[f"{package}_ref"] = version
-                last_known_good = verification.parent_results
-                first_known_bad = verification.candidate_results
-            else:
                 self.logger.info(
-                    f"Could not confirm {candidate.package} {candidate.commit} "
-                    "directly: candidate outcome "
-                    f"{verification.candidate_outcome}, parent outcome "
-                    f"{verification.parent_outcome}"
+                    "Falling back to version-level bisection with --commit "
+                    "as the failing endpoint"
                 )
-
-                fallback_passing_versions = passing_versions
-                fallback_failing_versions = failing_versions
-                if verification.candidate_outcome == ClassifiedTestOutcome.FAIL:
-                    # The candidate is a valid bad endpoint. Search backwards from it.
-                    fallback_failing_versions = failing_versions.copy()
-                    fallback_failing_versions[candidate.package] = candidate.commit
-                    self.logger.info(
-                        "Falling back to version-level bisection with --commit "
-                        "as the failing endpoint"
+            except CouldNotReproduceFailure as error:
+                if error.outcome == ClassifiedTestOutcome.PASS:
+                    # The candidate passed. Search forward from exactly what we tested.
+                    fallback_range = (
+                        {**failing_versions, package: commit},
+                        failing_versions,
                     )
-                elif verification.candidate_outcome == ClassifiedTestOutcome.PASS:
-                    # The candidate is a valid good endpoint. Search forward from it,
-                    # holding all other packages at the versions just tested.
-                    fallback_passing_versions = failing_versions.copy()
-                    fallback_passing_versions[candidate.package] = candidate.commit
                     self.logger.info(
                         "Falling back to version-level bisection with --commit "
                         "as the passing endpoint"
                     )
                 else:
                     self.logger.info(
-                        "The candidate did not yield a classifiable test result; "
-                        "falling back to the original version-level range"
+                        "The candidate did not yield a test result; falling back "
+                        "to the original version-level range"
                     )
 
-                if (
-                    fallback_passing_versions != passing_versions
-                    or fallback_failing_versions != failing_versions
-                ):
-                    if fallback_passing_versions == fallback_failing_versions:
-                        self.logger.warning(
-                            "The candidate-derived endpoints are identical; using "
-                            "the original version-level range instead"
+            if fallback_range is not None:
+                fallback_passing_versions, fallback_failing_versions = fallback_range
+                if fallback_passing_versions == fallback_failing_versions:
+                    self.logger.warning(
+                        "The candidate-derived endpoints are identical; using the "
+                        "original version-level range instead"
+                    )
+                else:
+                    with self._make_container(self.bisection_url) as worker:
+                        package_versions = self._gather_histories(
+                            worker,
+                            fallback_passing_versions,
+                            fallback_failing_versions,
                         )
-                    else:
-                        with self._make_container(self.bisection_url) as worker:
-                            package_versions = self._gather_histories(
-                                worker,
-                                fallback_passing_versions,
-                                fallback_failing_versions,
-                            )
-                        for package in packages_missing_scripts:
-                            package_versions.pop(package, None)
+                    for missing_package in packages_missing_scripts:
+                        package_versions.pop(missing_package, None)
 
         # Run the ordinary version-level bisection unless direct validation converged.
         if result is None:

--- a/.github/triage/jax_toolbox_triage/triage_tool.py
+++ b/.github/triage/jax_toolbox_triage/triage_tool.py
@@ -7,42 +7,46 @@ import json
 import logging
 import pathlib
 import platform
+import shlex
 import time
-from typing import Dict, Tuple, Union, Any, Optional, Set
+from typing import Any, Dict, Optional, Set, Tuple, Union
 
+from .bisect import get_commit_history, resolve_commit_and_parent
 from .container import Container
+from .container_factory import make_container
+from .docker import DockerContainer
 from .logic import (
     _EXIT_CODE_METRIC,
     _REPETITION_KEY,
     _WORKLOAD_VERSION_KEY,
     ClassifiedTestOutcome,
-    container_search,
+    CouldNotReproduceFailure,
+    CouldNotReproduceSuccess,
     ExecutionClassifier,
     ExitCodeClassifier,
     TestExecutionOutcome,
     TestResult,
+    container_search,
+    verify_culprit,
     version_search,
-    CouldNotReproduceFailure,
-    CouldNotReproduceSuccess,
 )
 from .metric_classifier import MetricClassifier
-from .versions import get_versions_dirs_env
 from .summary import (
-    add_summary_record,
     CONTAINER_CACHE_SECTION,
+    VERSION_CACHE_SECTION,
+    add_summary_record,
     create_output_symlinks,
     load_summary,
     result_cache_from_summary,
-    VERSION_CACHE_SECTION,
 )
-from .bisect import get_commit_history
-from .docker import DockerContainer
 from .utils import (
     container_url as container_url_base,
+)
+from .utils import (
     prepare_bazel_cache_mounts,
     run_and_log,
 )
-from .container_factory import make_container
+from .versions import get_versions_dirs_env
 
 
 class InconsistentResults(Exception):
@@ -67,6 +71,7 @@ class TriageTool:
         self.package_dirs = None
         self.dynamic_packages = set()
         self.packages_with_scripts = set()
+        self.commits_to_fetch = {}
         self.bazel_cache_mounts = prepare_bazel_cache_mounts(self.args.bazel_cache)
         self.check_success_before_failure = True
         self.restart_cache = (
@@ -111,9 +116,7 @@ class TriageTool:
             while out_dir.exists():
                 out_dir = base_out_dir.with_name(f"{base_out_dir.name}-restart-{n}")
                 n += 1
-        assert not out_dir.exists(), (
-            f"{out_dir} should not already exist, maybe you are re-using {self.args.output_prefix}?"
-        )
+        assert not out_dir.exists(), f"{out_dir} should not already exist, maybe you are re-using {self.args.output_prefix}?"
         out_dir.mkdir(mode=0o755)
         return out_dir.resolve()
 
@@ -159,9 +162,9 @@ class TriageTool:
         """
         if explicit_versions is not None and container_url is None:
             return explicit_versions, None, None, None
-        assert container_url is not None, (
-            "Container URL must be provided if explicit versions are not set."
-        )
+        assert (
+            container_url is not None
+        ), "Container URL must be provided if explicit versions are not set."
 
         with self._make_container(container_url) as worker:
             url_versions, dirs, env = get_versions_dirs_env(
@@ -222,7 +225,8 @@ class TriageTool:
             for cherry_pick_range in cherry_pick_ranges:
                 if package not in self.args.cherry_pick:
                     self.args.cherry_pick[package] = []
-                self.args.cherry_pick[package].append(cherry_pick_range)
+                if cherry_pick_range not in self.args.cherry_pick[package]:
+                    self.args.cherry_pick[package].append(cherry_pick_range)
 
             assert all(
                 b[1] >= a[1]
@@ -533,6 +537,12 @@ class TriageTool:
                     f"cd ${{JAX_TOOLBOX_TRIAGE_PREFIX}}{self.package_dirs[package]}"
                 )
                 git_commands.append("git stash")
+                if package in self.commits_to_fetch:
+                    remote = self.args.override_remotes.get(package, "origin")
+                    commit = self.commits_to_fetch[package]
+                    git_commands.append(
+                        f"git fetch {shlex.quote(remote)} {shlex.quote(commit)}"
+                    )
                 # this is a checkout on the main branch
                 git_commands.append(f"git checkout {version}")
                 for cherry_pick_range in self.args.cherry_pick.get(package, []):
@@ -893,8 +903,36 @@ class TriageTool:
             )
         else:
             classifier = ExitCodeClassifier()
+
+        candidate = None
         # Prepare the container for the bisection
         with self._make_container(self.bisection_url) as worker:
+            commit_spec = getattr(self.args, "commit", None)
+            if commit_spec is not None:
+                assert self.package_dirs is not None
+                candidate = resolve_commit_and_parent(
+                    worker,
+                    commit_spec,
+                    self.package_dirs,
+                    self.args.override_remotes,
+                )
+                if candidate.package not in passing_versions:
+                    raise ValueError(
+                        f"The package selected by --commit ({candidate.package}) "
+                        "does not have passing and failing endpoint versions"
+                    )
+                # A package can be static across the original container endpoints but
+                # still need to be checked out when an explicit candidate is supplied.
+                self.dynamic_packages.add(candidate.package)
+                if candidate.needs_fetch and self.args.container_runtime != "local":
+                    # Preparation happens in a disposable container. Make the
+                    # candidate (and therefore its ancestors) available again in each
+                    # fresh build container.
+                    self.commits_to_fetch[candidate.package] = candidate.commit
+                self.logger.info(
+                    f"Resolved --commit to {candidate.package} {candidate.commit}; "
+                    f"its first parent is {candidate.parent}"
+                )
             package_versions = self._gather_histories(
                 worker, passing_versions, failing_versions
             )
@@ -910,8 +948,6 @@ class TriageTool:
             for package in packages_missing_scripts:
                 del package_versions[package]
 
-        # Run the version-level bisection
-        self.logger.info("Running version-level bisection...")
         result_cache = {
             key: result
             for (section, key), result in self.restart_cache.items()
@@ -922,17 +958,122 @@ class TriageTool:
                 f"Loaded {len(result_cache)} completed version-level result(s) "
                 f"from {self.args.output_prefix / 'summary.json'}"
             )
-        try:
-            result, last_known_good, first_known_bad = version_search(
-                versions=package_versions,
+
+        result = None
+        last_known_good = None
+        first_known_bad = None
+        if candidate is not None:
+            # Keep every other package at its bisection-compatible failing endpoint.
+            # This isolates the candidate while preserving any automatically-derived
+            # cherry-picks needed to reproduce the failing environment.
+            candidate_versions = {
+                package: versions[-1][0]
+                for package, versions in package_versions.items()
+            }
+            candidate_versions[candidate.package] = candidate.commit
+            parent_versions = candidate_versions.copy()
+            parent_versions[candidate.package] = candidate.parent
+
+            self.logger.info(
+                f"Validating suspected culprit {candidate.package} "
+                f"{candidate.commit} against parent {candidate.parent}"
+            )
+            verification = verify_culprit(
+                candidate_versions=candidate_versions,
+                parent_versions=parent_versions,
                 build_and_test=self._build_and_test,
                 logger=self.logger,
-                skip_precondition_checks=self.args.skip_precondition_checks,
-                check_success_before_failure=self.check_success_before_failure,
                 confirmation_iterations=self.args.confirmation_iterations,
                 result_cache=result_cache,
                 classifier=classifier,
             )
+            if verification.candidate_outcome == ClassifiedTestOutcome.FAIL:
+                self.logger.info(
+                    "The supplied commit reproduced a failure. IMPORTANT: check "
+                    "that the candidate test output above shows the regression you "
+                    "intended to triage."
+                )
+            if verification.confirmed:
+                self.logger.info(
+                    f"Confirmed {candidate.package} {candidate.commit} as the "
+                    "culprit: the candidate fails and its first parent passes"
+                )
+                result = {
+                    f"{candidate.package}_bad": candidate.commit,
+                    f"{candidate.package}_good": candidate.parent,
+                }
+                for package, version in candidate_versions.items():
+                    if package != candidate.package:
+                        result[f"{package}_ref"] = version
+                last_known_good = verification.parent_results
+                first_known_bad = verification.candidate_results
+            else:
+                self.logger.info(
+                    f"Could not confirm {candidate.package} {candidate.commit} "
+                    "directly: candidate outcome "
+                    f"{verification.candidate_outcome}, parent outcome "
+                    f"{verification.parent_outcome}"
+                )
+
+                fallback_passing_versions = passing_versions
+                fallback_failing_versions = failing_versions
+                if verification.candidate_outcome == ClassifiedTestOutcome.FAIL:
+                    # The candidate is a valid bad endpoint. Search backwards from it.
+                    fallback_failing_versions = failing_versions.copy()
+                    fallback_failing_versions[candidate.package] = candidate.commit
+                    self.logger.info(
+                        "Falling back to version-level bisection with --commit "
+                        "as the failing endpoint"
+                    )
+                elif verification.candidate_outcome == ClassifiedTestOutcome.PASS:
+                    # The candidate is a valid good endpoint. Search forward from it,
+                    # holding all other packages at the versions just tested.
+                    fallback_passing_versions = failing_versions.copy()
+                    fallback_passing_versions[candidate.package] = candidate.commit
+                    self.logger.info(
+                        "Falling back to version-level bisection with --commit "
+                        "as the passing endpoint"
+                    )
+                else:
+                    self.logger.info(
+                        "The candidate did not yield a classifiable test result; "
+                        "falling back to the original version-level range"
+                    )
+
+                if (
+                    fallback_passing_versions != passing_versions
+                    or fallback_failing_versions != failing_versions
+                ):
+                    if fallback_passing_versions == fallback_failing_versions:
+                        self.logger.warning(
+                            "The candidate-derived endpoints are identical; using "
+                            "the original version-level range instead"
+                        )
+                    else:
+                        with self._make_container(self.bisection_url) as worker:
+                            package_versions = self._gather_histories(
+                                worker,
+                                fallback_passing_versions,
+                                fallback_failing_versions,
+                            )
+                        for package in packages_missing_scripts:
+                            package_versions.pop(package, None)
+
+        # Run the ordinary version-level bisection unless direct validation converged.
+        if result is None:
+            self.logger.info("Running version-level bisection...")
+        try:
+            if result is None:
+                result, last_known_good, first_known_bad = version_search(
+                    versions=package_versions,
+                    build_and_test=self._build_and_test,
+                    logger=self.logger,
+                    skip_precondition_checks=self.args.skip_precondition_checks,
+                    check_success_before_failure=self.check_success_before_failure,
+                    confirmation_iterations=self.args.confirmation_iterations,
+                    result_cache=result_cache,
+                    classifier=classifier,
+                )
         except CouldNotReproduceFailure as e:
             if (
                 self.args.failing_container is not None
@@ -958,9 +1099,9 @@ class TriageTool:
                         f"Reproduced failure in {self.args.failing_container} but not {self.bisection_url}"
                     ) from e
                 else:
-                    assert check_fail_outcome == ClassifiedTestOutcome.PASS, (
-                        check_fail_outcome
-                    )
+                    assert (
+                        check_fail_outcome == ClassifiedTestOutcome.PASS
+                    ), check_fail_outcome
                     raise CouldNotReproduceFailure(
                         f"Could not reproduce failure with 'bad' container ({self.args.failing_container}, {check_fail.result})"
                     ) from e
@@ -991,14 +1132,17 @@ class TriageTool:
                         f"Reproduced success in {self.args.passing_container} but not {self.bisection_url}"
                     ) from e
                 else:
-                    assert check_pass_outcome == ClassifiedTestOutcome.FAIL, (
-                        check_pass_outcome
-                    )
+                    assert (
+                        check_pass_outcome == ClassifiedTestOutcome.FAIL
+                    ), check_pass_outcome
                     raise CouldNotReproduceSuccess(
                         f"Could not reproduce success with 'good' container ({self.args.passing_container}, {check_pass.result})"
                     ) from e
             raise
         # Write final summary
+        assert result is not None
+        assert last_known_good is not None
+        assert first_known_bad is not None
         create_output_symlinks(
             self.args.output_prefix, last_known_good, first_known_bad
         )

--- a/.github/triage/jax_toolbox_triage/triage_tool.py
+++ b/.github/triage/jax_toolbox_triage/triage_tool.py
@@ -9,7 +9,8 @@ import pathlib
 import platform
 import shlex
 import time
-from typing import Any, Dict, Optional, Set, Tuple, Union
+from dataclasses import dataclass
+from typing import Any, Dict, List, Optional, Set, Tuple, Union
 
 from .bisect import get_commit_history
 from .container import Container
@@ -20,13 +21,13 @@ from .logic import (
     _REPETITION_KEY,
     _WORKLOAD_VERSION_KEY,
     ClassifiedTestOutcome,
-    CouldNotReproduceFailure,
-    CouldNotReproduceSuccess,
+    CouldNotReproduceDesiredOutcome,
     ExecutionClassifier,
     ExitCodeClassifier,
     TestExecutionOutcome,
     TestResult,
     container_search,
+    get_aligned_versions,
     version_search,
 )
 from .metric_classifier import MetricClassifier
@@ -52,6 +53,15 @@ class InconsistentResults(Exception):
     pass
 
 
+@dataclass(frozen=True)
+class _CommitCandidate:
+    package: str
+    commit: str
+    parent: str
+    date: datetime.datetime
+    references: Dict[str, str]
+
+
 class TriageTool:
     """
     This is the main class that orchestrates the whole triage process.
@@ -70,7 +80,7 @@ class TriageTool:
         self.package_dirs = None
         self.dynamic_packages = set()
         self.packages_with_scripts = set()
-        self.commits_to_fetch = {}
+        self.commits_to_fetch: Dict[str, Set[str]] = {}
         self.bazel_cache_mounts = prepare_bazel_cache_mounts(self.args.bazel_cache)
         self.check_success_before_failure = True
         self.restart_cache = (
@@ -538,9 +548,12 @@ class TriageTool:
                 git_commands.append("git stash")
                 if package in self.commits_to_fetch:
                     remote = self.args.override_remotes.get(package, "origin")
-                    commit = self.commits_to_fetch[package]
+                    commits = sorted(self.commits_to_fetch[package])
                     git_commands.append(
-                        f"git fetch {shlex.quote(remote)} {shlex.quote(commit)}"
+                        "git fetch "
+                        + shlex.quote(remote)
+                        + " "
+                        + " ".join(map(shlex.quote, commits))
                     )
                 # this is a checkout on the main branch
                 git_commands.append(f"git checkout {version}")
@@ -878,40 +891,251 @@ class TriageTool:
         assert self.bisection_versions is not None
         return passing_versions, failing_versions
 
+    def _resolve_commit_candidates(
+        self,
+        worker: Container,
+        known_versions: Dict[str, str],
+    ) -> List[_CommitCandidate]:
+        """Resolve candidate vectors while the preparation container is available."""
+        assert self.package_dirs is not None
+        candidates = []
+        for hint in self.args.commit or []:
+            package, revision = next(iter(hint.items()))
+            if package not in self.package_dirs:
+                raise ValueError(
+                    f"--commit culprit {package!r} is not a Git repository "
+                    "known to the triage environment"
+                )
+
+            resolved_versions = {}
+            parent = None
+            candidate_date = None
+            for hint_package, hint_revision in hint.items():
+                if hint_package not in known_versions:
+                    raise ValueError(
+                        f"--commit package {hint_package!r} does not have passing "
+                        "and failing endpoint versions"
+                    )
+                if hint_package not in self.package_dirs:
+                    # Non-Git packages can still be supplied as fixed references.
+                    resolved_versions[hint_package] = hint_revision
+                    if known_versions[hint_package] != hint_revision:
+                        self.dynamic_packages.add(hint_package)
+                    continue
+
+                directory = self.package_dirs[hint_package]
+                resolve_command = [
+                    "git",
+                    "rev-list",
+                    "--timestamp",
+                    "--parents",
+                    "-n",
+                    "1",
+                    hint_revision,
+                ]
+                commit_info = worker.exec(
+                    resolve_command,
+                    policy="once",
+                    stderr="separate",
+                    workdir=directory,
+                )
+                needs_fetch = commit_info.returncode != 0
+                if needs_fetch:
+                    worker.check_exec(
+                        [
+                            "git",
+                            "fetch",
+                            self.args.override_remotes.get(hint_package, "origin"),
+                            hint_revision,
+                        ],
+                        policy="once_per_container",
+                        stderr="separate",
+                        workdir=directory,
+                    )
+                    commit_info = worker.check_exec(
+                        resolve_command,
+                        policy="once",
+                        stderr="separate",
+                        workdir=directory,
+                    )
+
+                timestamp_commit_and_parents = commit_info.stdout.split()
+                if len(timestamp_commit_and_parents) < 2:
+                    raise ValueError(
+                        f"Could not resolve --commit {hint_package}:{hint_revision}"
+                    )
+                timestamp, resolved_commit, *parents = timestamp_commit_and_parents
+                resolved_versions[hint_package] = resolved_commit
+                if hint_package == package:
+                    if not parents:
+                        raise ValueError(
+                            f"--commit {resolved_commit} has no parent to test"
+                        )
+                    parent = parents[0]
+                    candidate_date = datetime.datetime.fromtimestamp(
+                        int(timestamp), datetime.timezone.utc
+                    )
+
+                if needs_fetch and self.args.container_runtime != "local":
+                    self.commits_to_fetch.setdefault(hint_package, set()).add(
+                        resolved_commit
+                    )
+                # Git references may differ from a static endpoint and still need to
+                # be checked out for direct validation.
+                self.dynamic_packages.add(hint_package)
+
+            assert parent is not None
+            assert candidate_date is not None
+            commit = resolved_versions.pop(package)
+            candidates.append(
+                _CommitCandidate(
+                    package=package,
+                    commit=commit,
+                    parent=parent,
+                    date=candidate_date,
+                    references=resolved_versions,
+                )
+            )
+            reference_text = "".join(
+                f", {reference_package} {reference_version}"
+                for reference_package, reference_version in resolved_versions.items()
+            )
+            self.logger.info(
+                f"Resolved --commit to {package} {commit}{reference_text}; "
+                f"the culprit's first parent is {parent}"
+            )
+        return candidates
+
+    def _candidate_configuration(
+        self,
+        candidate: _CommitCandidate,
+        package_versions: collections.OrderedDict,
+    ):
+        """Return the candidate vector and its indices in the package histories."""
+
+        def version_index(package, version):
+            if package not in package_versions:
+                raise ValueError(
+                    f"--commit package {package!r} is not in the bisection histories"
+                )
+            for index, (history_version, _) in enumerate(package_versions[package]):
+                if history_version == version:
+                    return index
+            return None
+
+        candidate_index = version_index(candidate.package, candidate.commit)
+        # Put the suspected culprit first so the existing timestamp-alignment logic
+        # chooses contemporary versions for all unspecified references.
+        ordered_histories = collections.OrderedDict(
+            [
+                (
+                    candidate.package,
+                    package_versions[candidate.package]
+                    if candidate_index is not None
+                    else [(candidate.commit, candidate.date)],
+                )
+            ]
+        )
+        ordered_histories.update(
+            (package, versions)
+            for package, versions in package_versions.items()
+            if package != candidate.package
+        )
+        versions, indices = get_aligned_versions(
+            logger=self.logger,
+            primary=candidate.package,
+            primary_index=0 if candidate_index is None else candidate_index,
+            versions=ordered_histories,
+        )
+        can_narrow = candidate_index is not None
+
+        # Explicit references override the automatically aligned versions.
+        for package, version in candidate.references.items():
+            reference_index = version_index(package, version)
+            versions[package] = version
+            if reference_index is None:
+                can_narrow = False
+            else:
+                indices[package] = reference_index
+
+        return versions, indices if can_narrow else None, candidate.date
+
+    def _narrow_histories_from_candidate(
+        self,
+        package_versions: collections.OrderedDict,
+        indices: Dict[str, int],
+        outcome: ClassifiedTestOutcome,
+    ) -> collections.OrderedDict:
+        """Narrow every history around a known passing or failing version vector."""
+        assert outcome in {
+            ClassifiedTestOutcome.PASS,
+            ClassifiedTestOutcome.FAIL,
+        }
+        narrowed = collections.OrderedDict()
+        for package, versions in package_versions.items():
+            index = indices[package]
+            narrowed[package] = (
+                versions[index:]
+                if outcome == ClassifiedTestOutcome.PASS
+                else versions[: index + 1]
+            )
+
+        if sum(map(len, narrowed.values())) == len(narrowed):
+            self.logger.warning(
+                "The candidate-derived range contains no versions to search; "
+                "retaining the previous bisection range"
+            )
+            return package_versions
+
+        old_sizes = {
+            package: len(versions) for package, versions in package_versions.items()
+        }
+        new_sizes = {package: len(versions) for package, versions in narrowed.items()}
+        self.logger.info(
+            f"Narrowed package histories using a known {outcome} candidate vector: "
+            f"{old_sizes} -> {new_sizes}"
+        )
+        return narrowed
+
     def _check_candidate_commit(
         self,
         *,
-        candidate: Tuple[str, str, str],
+        candidate: _CommitCandidate,
         package_versions: collections.OrderedDict,
-        passing_versions: Dict[str, str],
-        failing_versions: Dict[str, str],
-        packages_missing_scripts: Set[str],
         result_cache,
         classifier: ExecutionClassifier,
     ):
-        """Check ``--commit`` and prepare histories for any required fallback.
+        """Check one ``--commit`` vector and narrow histories if it is wrong.
 
         A direct result is returned when the candidate fails and its parent passes.
         Otherwise, the returned histories define the ordinary bisection range.
         """
-        package, commit, parent = candidate
+        package = candidate.package
+        commit = candidate.commit
+        parent = candidate.parent
+        candidate_versions, candidate_indices, candidate_date = (
+            self._candidate_configuration(candidate, package_versions)
+        )
 
-        # Test the candidate with every other package fixed at the failing endpoint.
-        candidate_date = package_versions[package][-1][1]
+        # Hold every reference fixed so the candidate and its parent differ only in
+        # the package named first in the --commit vector.
         candidate_range: collections.OrderedDict = collections.OrderedDict(
             [(package, [(parent, candidate_date), (commit, candidate_date)])]
         )
         candidate_range.update(
-            (
-                other_package,
-                [(versions[-1][0], candidate_date)],
-            )
-            for other_package, versions in package_versions.items()
+            (other_package, [(version, candidate_date)])
+            for other_package, version in candidate_versions.items()
             if other_package != package
         )
 
+        reference_text = "".join(
+            f", {reference_package} {reference_version}"
+            for reference_package, reference_version in candidate_versions.items()
+            if reference_package != package
+        )
         self.logger.info(
-            f"Validating suspected culprit {package} {commit} against parent {parent}"
+            f"Validating suspected culprit {package} {commit} against parent "
+            f"{parent}{reference_text}"
         )
         try:
             candidate_result = version_search(
@@ -924,55 +1148,59 @@ class TriageTool:
                 result_cache=result_cache,
                 classifier=classifier,
             )
-        except CouldNotReproduceSuccess:
-            # Candidate fails, parent does not pass: search backwards from candidate.
-            fallback_range = (
-                passing_versions,
-                {**failing_versions, package: commit},
-            )
+        except CouldNotReproduceDesiredOutcome as error:
+            if error.expected_outcome == ClassifiedTestOutcome.PASS:
+                if candidate_indices is None:
+                    self.logger.info(
+                        "The candidate or an explicit reference is outside the "
+                        "current histories; retaining the current bisection range"
+                    )
+                    return None, package_versions
+                # The candidate failed, but its parent did not pass. Use the parent as
+                # the tighter failing pivot when it belongs to the current history.
+                failing_indices = candidate_indices.copy()
+                if error.actual_outcome == ClassifiedTestOutcome.FAIL:
+                    for index, (version, _) in enumerate(package_versions[package]):
+                        if version == parent and index < candidate_indices[package]:
+                            failing_indices[package] = index
+                            break
+                self.logger.info(
+                    "The candidate was not the transition; narrowing the bisection "
+                    "with the known failing candidate vector"
+                )
+                return None, self._narrow_histories_from_candidate(
+                    package_versions,
+                    failing_indices,
+                    ClassifiedTestOutcome.FAIL,
+                )
+            assert error.expected_outcome == ClassifiedTestOutcome.FAIL
+            if error.actual_outcome == ClassifiedTestOutcome.PASS:
+                if candidate_indices is None:
+                    self.logger.info(
+                        "The candidate or an explicit reference is outside the "
+                        "current histories; retaining the current bisection range"
+                    )
+                    return None, package_versions
+                # A passing candidate is a contemporary known-good pivot, so discard
+                # all older portions of every package history.
+                self.logger.info(
+                    "The candidate passed; narrowing the bisection with the known "
+                    "passing candidate vector"
+                )
+                return None, self._narrow_histories_from_candidate(
+                    package_versions,
+                    candidate_indices,
+                    ClassifiedTestOutcome.PASS,
+                )
+            # A candidate that cannot be tested provides no ordering information.
             self.logger.info(
-                "Falling back to version-level bisection with --commit "
-                "as the failing endpoint"
+                "The candidate did not yield a test result; retaining the current "
+                "version-level range"
             )
-        except CouldNotReproduceFailure as error:
-            if error.outcome == ClassifiedTestOutcome.PASS:
-                # Candidate passes: search forward from the combination just tested.
-                fallback_range = (
-                    {**failing_versions, package: commit},
-                    failing_versions,
-                )
-                self.logger.info(
-                    "Falling back to version-level bisection with --commit "
-                    "as the passing endpoint"
-                )
-            else:
-                # Candidate cannot be tested: retain the original range.
-                self.logger.info(
-                    "The candidate did not yield a test result; falling back "
-                    "to the original version-level range"
-                )
-                return None, package_versions
+            return None, package_versions
         else:
             # Candidate fails, parent passes: culprit confirmed.
             return candidate_result, package_versions
-
-        fallback_passing_versions, fallback_failing_versions = fallback_range
-        if fallback_passing_versions == fallback_failing_versions:
-            self.logger.warning(
-                "The candidate-derived endpoints are identical; using the "
-                "original version-level range instead"
-            )
-            return None, package_versions
-
-        with self._make_container(self.bisection_url) as worker:
-            package_versions = self._gather_histories(
-                worker,
-                fallback_passing_versions,
-                fallback_failing_versions,
-            )
-        for missing_package in packages_missing_scripts:
-            package_versions.pop(missing_package, None)
-        return None, package_versions
 
     def run_version_bisection(
         self,
@@ -999,77 +1227,11 @@ class TriageTool:
         else:
             classifier = ExitCodeClassifier()
 
-        candidate = None
+        candidates = []
         # Prepare the container for the bisection
         with self._make_container(self.bisection_url) as worker:
             if self.args.commit is not None:
-                assert self.package_dirs is not None
-                package, revision = next(iter(self.args.commit.items()))
-                if package not in self.package_dirs:
-                    raise ValueError(
-                        f"--commit package {package!r} is not a Git repository "
-                        "known to the triage environment"
-                    )
-                if package not in passing_versions:
-                    raise ValueError(
-                        f"The package selected by --commit ({package}) "
-                        "does not have passing and failing endpoint versions"
-                    )
-
-                directory = self.package_dirs[package]
-                resolve_command = [
-                    "git",
-                    "rev-list",
-                    "--parents",
-                    "-n",
-                    "1",
-                    revision,
-                ]
-                commit_info = worker.exec(
-                    resolve_command,
-                    policy="once",
-                    stderr="separate",
-                    workdir=directory,
-                )
-                needs_fetch = commit_info.returncode != 0
-                if needs_fetch:
-                    worker.check_exec(
-                        [
-                            "git",
-                            "fetch",
-                            self.args.override_remotes.get(package, "origin"),
-                            revision,
-                        ],
-                        policy="once_per_container",
-                        stderr="separate",
-                        workdir=directory,
-                    )
-                    commit_info = worker.check_exec(
-                        resolve_command,
-                        policy="once",
-                        stderr="separate",
-                        workdir=directory,
-                    )
-                commit_and_parents = commit_info.stdout.split()
-                if len(commit_and_parents) == 1:
-                    raise ValueError(
-                        f"--commit {commit_and_parents[0]} has no parent to test"
-                    )
-                commit, parent = commit_and_parents[:2]
-                candidate = (package, commit, parent)
-
-                # A package can be static across the original container endpoints but
-                # still need to be checked out when an explicit candidate is supplied.
-                self.dynamic_packages.add(package)
-                if needs_fetch and self.args.container_runtime != "local":
-                    # Preparation happens in a disposable container. Make the
-                    # candidate (and therefore its ancestors) available again in each
-                    # fresh build container.
-                    self.commits_to_fetch[package] = commit
-                self.logger.info(
-                    f"Resolved --commit to {package} {commit}; "
-                    f"its first parent is {parent}"
-                )
+                candidates = self._resolve_commit_candidates(worker, passing_versions)
             package_versions = self._gather_histories(
                 worker, passing_versions, failing_versions
             )
@@ -1085,6 +1247,12 @@ class TriageTool:
             for package in packages_missing_scripts:
                 del package_versions[package]
 
+        # Validate that every package named in a candidate can participate in the
+        # bisection. Candidate versions outside the range can still be checked
+        # directly, but their outcomes are not used to narrow the histories.
+        for candidate in candidates:
+            self._candidate_configuration(candidate, package_versions)
+
         result_cache = {
             key: result
             for (section, key), result in self.restart_cache.items()
@@ -1099,24 +1267,20 @@ class TriageTool:
         result = None
         last_known_good = None
         first_known_bad = None
-        if candidate is not None:
+        for candidate in candidates:
             candidate_result, package_versions = self._check_candidate_commit(
                 candidate=candidate,
                 package_versions=package_versions,
-                passing_versions=passing_versions,
-                failing_versions=failing_versions,
-                packages_missing_scripts=packages_missing_scripts,
                 result_cache=result_cache,
                 classifier=classifier,
             )
             if candidate_result is not None:
                 result, last_known_good, first_known_bad = candidate_result
+                break
 
-        # Run the ordinary version-level bisection unless direct validation converged.
         if result is None:
             self.logger.info("Running version-level bisection...")
-        try:
-            if result is None:
+            try:
                 result, last_known_good, first_known_bad = version_search(
                     versions=package_versions,
                     build_and_test=self._build_and_test,
@@ -1127,72 +1291,79 @@ class TriageTool:
                     result_cache=result_cache,
                     classifier=classifier,
                 )
-        except CouldNotReproduceFailure as e:
-            if (
-                self.args.failing_container is not None
-                and self.bisection_url == self.args.passing_container
-            ):
-                # Could not reproduce failing with 'bad' versions in the 'good' container. Triage
-                # will not succeed, but before exiting we can check if we can even reproduce
-                # failure in the 'bad' container.
-                self.logger.fatal(
-                    f"Checking if failure can be reproduced in {self.args.failing_container}..."
-                )
-                check_fail = self._check_container_by_url(
-                    self.args.failing_container, test_output_log_level=logging.INFO
-                )
-                check_fail_outcome = classifier([check_fail])
-                if check_fail_outcome == ClassifiedTestOutcome.FAIL:
+            except CouldNotReproduceDesiredOutcome as e:
+                if e.expected_outcome == ClassifiedTestOutcome.FAIL:
+                    if not (
+                        self.args.failing_container is not None
+                        and self.bisection_url == self.args.passing_container
+                    ):
+                        raise
+                    # Could not reproduce failing with 'bad' versions in the 'good' container. Triage
+                    # will not succeed, but before exiting we can check if we can even reproduce
+                    # failure in the 'bad' container.
                     self.logger.fatal(
-                        f"Reproduced failure in {self.args.failing_container} after failing to "
-                        f"reproduce in {self.bisection_url}. This may mean the failure is due to "
-                        "a variable not visible to the bisection tool."
+                        f"Checking if failure can be reproduced in {self.args.failing_container}..."
                     )
-                    raise InconsistentResults(
-                        f"Reproduced failure in {self.args.failing_container} but not {self.bisection_url}"
-                    ) from e
+                    check_fail = self._check_container_by_url(
+                        self.args.failing_container,
+                        test_output_log_level=logging.INFO,
+                    )
+                    check_fail_outcome = classifier([check_fail])
+                    if check_fail_outcome == ClassifiedTestOutcome.FAIL:
+                        self.logger.fatal(
+                            f"Reproduced failure in {self.args.failing_container} after failing to "
+                            f"reproduce in {self.bisection_url}. This may mean the failure is due to "
+                            "a variable not visible to the bisection tool."
+                        )
+                        raise InconsistentResults(
+                            f"Reproduced failure in {self.args.failing_container} but not {self.bisection_url}"
+                        ) from e
+                    else:
+                        assert (
+                            check_fail_outcome == ClassifiedTestOutcome.PASS
+                        ), check_fail_outcome
+                        raise CouldNotReproduceDesiredOutcome(
+                            f"Could not reproduce failure with 'bad' container ({self.args.failing_container}, {check_fail.result})",
+                            expected_outcome=ClassifiedTestOutcome.FAIL,
+                            actual_outcome=check_fail_outcome,
+                        ) from e
                 else:
-                    assert (
-                        check_fail_outcome == ClassifiedTestOutcome.PASS
-                    ), check_fail_outcome
-                    raise CouldNotReproduceFailure(
-                        f"Could not reproduce failure with 'bad' container ({self.args.failing_container}, {check_fail.result})"
-                    ) from e
+                    assert e.expected_outcome == ClassifiedTestOutcome.PASS
+                    if not (
+                        self.args.passing_container is not None
+                        and self.bisection_url == self.args.failing_container
+                    ):
+                        raise
+                    # Could not reproduce pass with 'good' versions in the 'bad' container. Triage
+                    # will not succeed, but before exiting we can check if success is reproducible
+                    # in the 'good' container.
+                    self.logger.fatal(
+                        f"Checking if success can be reproduced in {self.args.passing_container}..."
+                    )
+                    check_pass = self._check_container_by_url(
+                        self.args.passing_container,
+                        test_output_log_level=logging.INFO,
+                    )
+                    check_pass_outcome = classifier([check_pass])
+                    if check_pass_outcome == ClassifiedTestOutcome.PASS:
+                        self.logger.fatal(
+                            f"Reproduced success in {self.args.passing_container} after failing to "
+                            f"reproduce in {self.bisection_url}. This may mean the failure is due to "
+                            "a variable not visible to the bisection tool."
+                        )
+                        raise InconsistentResults(
+                            f"Reproduced success in {self.args.passing_container} but not {self.bisection_url}"
+                        ) from e
+                    else:
+                        assert (
+                            check_pass_outcome == ClassifiedTestOutcome.FAIL
+                        ), check_pass_outcome
+                        raise CouldNotReproduceDesiredOutcome(
+                            f"Could not reproduce success with 'good' container ({self.args.passing_container}, {check_pass.result})",
+                            expected_outcome=ClassifiedTestOutcome.PASS,
+                            actual_outcome=check_pass_outcome,
+                        ) from e
 
-            raise
-        except CouldNotReproduceSuccess as e:
-            if (
-                self.args.passing_container is not None
-                and self.bisection_url == self.args.failing_container
-            ):
-                # Could not reproduce pass with 'good' versions in the 'bad' container. Triage
-                # will not succeed, but before exiting we can check if success is reproducible
-                # in the 'good' container.
-                self.logger.fatal(
-                    f"Checking if success can be reproduced in {self.args.passing_container}..."
-                )
-                check_pass = self._check_container_by_url(
-                    self.args.passing_container, test_output_log_level=logging.INFO
-                )
-                check_pass_outcome = classifier([check_pass])
-                if check_pass_outcome == ClassifiedTestOutcome.PASS:
-                    self.logger.fatal(
-                        f"Reproduced success in {self.args.passing_container} after failing to "
-                        f"reproduce in {self.bisection_url}. This may mean the failure is due to "
-                        "a variable not visible to the bisection tool."
-                    )
-                    raise InconsistentResults(
-                        f"Reproduced success in {self.args.passing_container} but not {self.bisection_url}"
-                    ) from e
-                else:
-                    assert (
-                        check_pass_outcome == ClassifiedTestOutcome.FAIL
-                    ), check_pass_outcome
-                    raise CouldNotReproduceSuccess(
-                        f"Could not reproduce success with 'good' container ({self.args.passing_container}, {check_pass.result})"
-                    ) from e
-            raise
-        # Write final summary
         assert result is not None
         assert last_known_good is not None
         assert first_known_bad is not None

--- a/.github/triage/jax_toolbox_triage/triage_tool.py
+++ b/.github/triage/jax_toolbox_triage/triage_tool.py
@@ -8,7 +8,9 @@ import logging
 import pathlib
 import platform
 import shlex
+import tempfile
 import time
+import urllib.parse
 from dataclasses import dataclass
 from typing import Any, Dict, List, Optional, Set, Tuple, Union
 
@@ -51,6 +53,40 @@ from .versions import get_versions_dirs_env
 
 class InconsistentResults(Exception):
     pass
+
+
+def _remote_without_credentials(
+    remote: str,
+) -> Tuple[str, Optional[Tuple[str, str, str]]]:
+    """Return a URL safe for build arguments and optional netrc credentials."""
+    parsed = urllib.parse.urlsplit(remote)
+    if (
+        parsed.scheme not in {"http", "https"}
+        or parsed.hostname is None
+        or parsed.username is None
+    ):
+        return remote, None
+
+    hostname = parsed.hostname
+    netloc = f"[{hostname}]" if ":" in hostname else hostname
+    if parsed.port is not None:
+        netloc += f":{parsed.port}"
+    sanitized = urllib.parse.urlunsplit(parsed._replace(netloc=netloc))
+    credentials = (
+        hostname,
+        urllib.parse.unquote(parsed.username),
+        urllib.parse.unquote(parsed.password or ""),
+    )
+    return sanitized, credentials
+
+
+def _git_fetch_refs(version: str, cherry_picks: List[str]) -> List[str]:
+    """Return every object needed to check out and cherry-pick a version."""
+    refs = [version]
+    for revision in cherry_picks:
+        start, separator, end = revision.partition("..")
+        refs.extend([start, end] if separator else [revision])
+    return list(dict.fromkeys(refs))
 
 
 @dataclass(frozen=True)
@@ -522,6 +558,8 @@ class TriageTool:
         """
         # Amortise container startup overhead by batching together git commands
         git_commands, changed, skipped = [], [], []
+        git_credentials: Dict[str, Tuple[str, str]] = {}
+        push_intermediate_containers = self.args.container_runtime == "plugin"
         for package in sorted(self.dynamic_packages):
             version = versions[package]
             if self.bisection_versions.get(package) == version:
@@ -546,15 +584,34 @@ class TriageTool:
                     f"cd ${{JAX_TOOLBOX_TRIAGE_PREFIX}}{self.package_dirs[package]}"
                 )
                 git_commands.append("git stash")
-                if package in self.commits_to_fetch:
-                    remote = self.args.override_remotes.get(package, "origin")
-                    commits = sorted(self.commits_to_fetch[package])
-                    git_commands.append(
-                        "git fetch "
-                        + shlex.quote(remote)
-                        + " "
-                        + " ".join(map(shlex.quote, commits))
+                remote = self.args.override_remotes.get(package, "origin")
+                if push_intermediate_containers:
+                    remote, credentials = _remote_without_credentials(remote)
+                    if credentials is not None:
+                        hostname, username, password = credentials
+                        existing = git_credentials.setdefault(
+                            hostname, (username, password)
+                        )
+                        if existing != (username, password):
+                            raise ValueError(
+                                f"Conflicting Git credentials for {hostname}"
+                            )
+                fetch_refs = _git_fetch_refs(
+                    version, self.args.cherry_pick.get(package, [])
+                )
+                # Candidate commits may have been fetched only in the disposable
+                # preparation container. Include them when building a fresh image.
+                fetch_refs = list(
+                    dict.fromkeys(
+                        fetch_refs + sorted(self.commits_to_fetch.get(package, set()))
                     )
+                )
+                git_commands.append(
+                    "git fetch --no-tags "
+                    + shlex.quote(remote)
+                    + " "
+                    + " ".join(shlex.quote(ref) for ref in fetch_refs)
+                )
                 # this is a checkout on the main branch
                 git_commands.append(f"git checkout {version}")
                 for cherry_pick_range in self.args.cherry_pick.get(package, []):
@@ -595,7 +652,6 @@ class TriageTool:
         info_str = f"Checking out {change_str}"
         if len(skipped):
             info_str += f", leaving {' '.join(skipped)} unchanged"
-        push_intermediate_containers = self.args.container_runtime == "plugin"
         with (
             contextlib.nullcontext()
             if push_intermediate_containers
@@ -651,12 +707,21 @@ class TriageTool:
                     if DockerContainer(
                         container_name, logger=self.logger, mounts=[]
                     ).exists():
-                        command = [
-                            "echo",
-                            f"Skipping building {container_name} because it already exists",
-                        ]
-                    else:
-                        # TODO: organise this better to encourage layer sharing
+                        return run_and_log(
+                            [
+                                "echo",
+                                f"Skipping building {container_name} because it already exists",
+                            ],
+                            logger=self.logger,
+                            stderr="interleaved",
+                        )
+
+                    # TODO: organise this better to encourage layer sharing
+                    with (
+                        tempfile.NamedTemporaryFile(mode="w", encoding="utf-8")
+                        if git_credentials
+                        else contextlib.nullcontext()
+                    ) as netrc_file:
                         command = [
                             "docker",
                             "buildx",
@@ -670,13 +735,29 @@ class TriageTool:
                             str(data_files_dir / "Dockerfile.triage-tool"),
                             str(data_files_dir),
                         ]
+                        if netrc_file is not None:
+                            for hostname, (username, password) in sorted(
+                                git_credentials.items()
+                            ):
+                                netrc_file.write(
+                                    f"machine {hostname}\n"
+                                    f"login {username}\n"
+                                    f"password {password}\n"
+                                )
+                            netrc_file.flush()
+                            command.extend(
+                                [
+                                    "--secret",
+                                    f"id=git-netrc,src={netrc_file.name}",
+                                ]
+                            )
                         if self.args.container_registry is not None:
                             command.append("--push")
-                    return run_and_log(
-                        command,
-                        logger=self.logger,
-                        stderr="interleaved",
-                    )
+                        return run_and_log(
+                            command,
+                            logger=self.logger,
+                            stderr="interleaved",
+                        )
 
                 def _test():
                     return (

--- a/.github/triage/jax_toolbox_triage/triage_tool.py
+++ b/.github/triage/jax_toolbox_triage/triage_tool.py
@@ -15,7 +15,7 @@ import tempfile
 import time
 import urllib.parse
 from dataclasses import dataclass
-from typing import Any, Dict, List, Optional, Set, Tuple, Union
+from typing import Any
 
 from .bisect import get_commit_history
 from .container import Container
@@ -58,7 +58,6 @@ class InconsistentResults(Exception):
     pass
 
 
-
 def _bounded_tag_suffix(container_registry: str | None, tag_suffix: str) -> str:
     """Keep the complete Docker tag within its 128-character limit."""
     if container_registry is None:
@@ -97,8 +96,8 @@ def _remote_without_credentials(
         urllib.parse.unquote(parsed.password or ""),
     )
     return sanitized, credentials
-  
-  
+
+
 def _git_fetch_refs(version: str, cherry_picks: list[str]) -> list[str]:
     """Return every object needed to check out and cherry-pick a version."""
     refs = [version]
@@ -114,7 +113,7 @@ class _CommitCandidate:
     commit: str
     parent: str
     date: datetime.datetime
-    references: Dict[str, str]
+    references: dict[str, str]
 
 
 class TriageTool:
@@ -135,7 +134,7 @@ class TriageTool:
         self.package_dirs = None
         self.dynamic_packages = set()
         self.packages_with_scripts = set()
-        self.commits_to_fetch: Dict[str, Set[str]] = {}
+        self.commits_to_fetch: dict[str, set[str]] = {}
         self.bazel_cache_mounts = prepare_bazel_cache_mounts(self.args.bazel_cache)
         self.check_success_before_failure = True
         self.restart_cache = (
@@ -1020,13 +1019,13 @@ class TriageTool:
     def _resolve_commit_candidates(
         self,
         worker: Container,
-        known_versions: Dict[str, str],
-    ) -> List[_CommitCandidate]:
+        known_versions: dict[str, str],
+    ) -> list[_CommitCandidate]:
         """Resolve candidate vectors while the preparation container is available."""
         assert self.package_dirs is not None
         candidates = []
         for hint in self.args.commit or []:
-            package, revision = next(iter(hint.items()))
+            package = next(iter(hint))
             if package not in self.package_dirs:
                 raise ValueError(
                     f"--commit culprit {package!r} is not a Git repository "
@@ -1189,7 +1188,7 @@ class TriageTool:
     def _narrow_histories_from_candidate(
         self,
         package_versions: collections.OrderedDict,
-        indices: Dict[str, int],
+        indices: dict[str, int],
         outcome: ClassifiedTestOutcome,
     ) -> collections.OrderedDict:
         """Narrow every history around a known passing or failing version vector."""
@@ -1230,6 +1229,8 @@ class TriageTool:
         package_versions: collections.OrderedDict,
         result_cache,
         classifier: ExecutionClassifier,
+        metric_name: str | None = None,
+        missing_metric_retries: int = 1,
     ):
         """Check one ``--commit`` vector and narrow histories if it is wrong.
 
@@ -1273,6 +1274,8 @@ class TriageTool:
                 confirmation_iterations=self.args.confirmation_iterations,
                 result_cache=result_cache,
                 classifier=classifier,
+                metric_name=metric_name,
+                missing_metric_retries=missing_metric_retries,
             )
         except CouldNotReproduceDesiredOutcome as error:
             if error.expected_outcome == ClassifiedTestOutcome.PASS:
@@ -1418,6 +1421,8 @@ class TriageTool:
                     confirmation_iterations=self.args.confirmation_iterations,
                     result_cache=result_cache,
                     classifier=classifier,
+                    metric_name=self.args.metric_name,
+                    missing_metric_retries=self.args.missing_metric_retries,
                 )
             except CouldNotReproduceDesiredOutcome as e:
                 if e.expected_outcome == ClassifiedTestOutcome.FAIL:

--- a/.github/triage/jax_toolbox_triage/triage_tool.py
+++ b/.github/triage/jax_toolbox_triage/triage_tool.py
@@ -878,6 +878,103 @@ class TriageTool:
         assert self.bisection_versions is not None
         return passing_versions, failing_versions
 
+    def _check_candidate_commit(
+        self,
+        *,
+        candidate: Tuple[str, str, str],
+        package_versions: collections.OrderedDict,
+        passing_versions: Dict[str, str],
+        failing_versions: Dict[str, str],
+        packages_missing_scripts: Set[str],
+        result_cache,
+        classifier: ExecutionClassifier,
+    ):
+        """Check ``--commit`` and prepare histories for any required fallback.
+
+        A direct result is returned when the candidate fails and its parent passes.
+        Otherwise, the returned histories define the ordinary bisection range.
+        """
+        package, commit, parent = candidate
+
+        # Test the candidate with every other package fixed at the failing endpoint.
+        candidate_date = package_versions[package][-1][1]
+        candidate_range: collections.OrderedDict = collections.OrderedDict(
+            [(package, [(parent, candidate_date), (commit, candidate_date)])]
+        )
+        candidate_range.update(
+            (
+                other_package,
+                [(versions[-1][0], candidate_date)],
+            )
+            for other_package, versions in package_versions.items()
+            if other_package != package
+        )
+
+        self.logger.info(
+            f"Validating suspected culprit {package} {commit} against parent {parent}"
+        )
+        try:
+            candidate_result = version_search(
+                versions=candidate_range,
+                build_and_test=self._build_and_test,
+                logger=self.logger,
+                skip_precondition_checks=False,
+                check_success_before_failure=False,
+                confirmation_iterations=self.args.confirmation_iterations,
+                result_cache=result_cache,
+                classifier=classifier,
+                precondition_failure_log_level=logging.INFO,
+            )
+        except CouldNotReproduceSuccess:
+            # Candidate fails, parent does not pass: search backwards from candidate.
+            fallback_range = (
+                passing_versions,
+                {**failing_versions, package: commit},
+            )
+            self.logger.info(
+                "Falling back to version-level bisection with --commit "
+                "as the failing endpoint"
+            )
+        except CouldNotReproduceFailure as error:
+            if error.outcome == ClassifiedTestOutcome.PASS:
+                # Candidate passes: search forward from the combination just tested.
+                fallback_range = (
+                    {**failing_versions, package: commit},
+                    failing_versions,
+                )
+                self.logger.info(
+                    "Falling back to version-level bisection with --commit "
+                    "as the passing endpoint"
+                )
+            else:
+                # Candidate cannot be tested: retain the original range.
+                self.logger.info(
+                    "The candidate did not yield a test result; falling back "
+                    "to the original version-level range"
+                )
+                return None, package_versions
+        else:
+            # Candidate fails, parent passes: culprit confirmed.
+            return candidate_result, package_versions
+
+        fallback_passing_versions, fallback_failing_versions = fallback_range
+        if fallback_passing_versions == fallback_failing_versions:
+            self.logger.warning(
+                "The candidate-derived endpoints are identical; using the "
+                "original version-level range instead"
+            )
+            return None, package_versions
+
+        with self._make_container(self.bisection_url) as worker:
+            package_versions = self._gather_histories(
+                worker,
+                fallback_passing_versions,
+                fallback_failing_versions,
+            )
+        for missing_package in packages_missing_scripts:
+            package_versions.pop(missing_package, None)
+        return None, package_versions
+
     def run_version_bisection(
         self,
         passing_versions: Dict[str, str],
@@ -1004,83 +1101,17 @@ class TriageTool:
         last_known_good = None
         first_known_bad = None
         if candidate is not None:
-            package, commit, parent = candidate
-            # Keep every other package at its bisection-compatible failing endpoint.
-            # This isolates the candidate while preserving any automatically-derived
-            # cherry-picks needed to reproduce the failing environment.
-            candidate_date = package_versions[package][-1][1]
-            candidate_range = collections.OrderedDict(
-                [(package, [(parent, candidate_date), (commit, candidate_date)])]
+            candidate_result, package_versions = self._check_candidate_commit(
+                candidate=candidate,
+                package_versions=package_versions,
+                passing_versions=passing_versions,
+                failing_versions=failing_versions,
+                packages_missing_scripts=packages_missing_scripts,
+                result_cache=result_cache,
+                classifier=classifier,
             )
-            candidate_range.update(
-                (
-                    other_package,
-                    [(versions[-1][0], candidate_date)],
-                )
-                for other_package, versions in package_versions.items()
-                if other_package != package
-            )
-
-            self.logger.info(
-                f"Validating suspected culprit {package} {commit} "
-                f"against parent {parent}"
-            )
-            fallback_range = None
-            try:
-                result, last_known_good, first_known_bad = version_search(
-                    versions=candidate_range,
-                    build_and_test=self._build_and_test,
-                    logger=self.logger,
-                    skip_precondition_checks=False,
-                    check_success_before_failure=False,
-                    confirmation_iterations=self.args.confirmation_iterations,
-                    result_cache=result_cache,
-                    classifier=classifier,
-                    precondition_failure_log_level=logging.INFO,
-                )
-            except CouldNotReproduceSuccess:
-                # The candidate failed but its parent did not pass. Search backwards.
-                fallback_range = (
-                    passing_versions,
-                    {**failing_versions, package: commit},
-                )
-                self.logger.info(
-                    "Falling back to version-level bisection with --commit "
-                    "as the failing endpoint"
-                )
-            except CouldNotReproduceFailure as error:
-                if error.outcome == ClassifiedTestOutcome.PASS:
-                    # The candidate passed. Search forward from exactly what we tested.
-                    fallback_range = (
-                        {**failing_versions, package: commit},
-                        failing_versions,
-                    )
-                    self.logger.info(
-                        "Falling back to version-level bisection with --commit "
-                        "as the passing endpoint"
-                    )
-                else:
-                    self.logger.info(
-                        "The candidate did not yield a test result; falling back "
-                        "to the original version-level range"
-                    )
-
-            if fallback_range is not None:
-                fallback_passing_versions, fallback_failing_versions = fallback_range
-                if fallback_passing_versions == fallback_failing_versions:
-                    self.logger.warning(
-                        "The candidate-derived endpoints are identical; using the "
-                        "original version-level range instead"
-                    )
-                else:
-                    with self._make_container(self.bisection_url) as worker:
-                        package_versions = self._gather_histories(
-                            worker,
-                            fallback_passing_versions,
-                            fallback_failing_versions,
-                        )
-                    for missing_package in packages_missing_scripts:
-                        package_versions.pop(missing_package, None)
+            if candidate_result is not None:
+                result, last_known_good, first_known_bad = candidate_result
 
         # Run the ordinary version-level bisection unless direct validation converged.
         if result is None:

--- a/.github/triage/jax_toolbox_triage/triage_tool.py
+++ b/.github/triage/jax_toolbox_triage/triage_tool.py
@@ -26,8 +26,8 @@ from .logic import (
     ExitCodeClassifier,
     TestExecutionOutcome,
     TestResult,
+    _get_versions,
     container_search,
-    get_aligned_versions,
     version_search,
 )
 from .metric_classifier import MetricClassifier
@@ -1041,7 +1041,7 @@ class TriageTool:
             for package, versions in package_versions.items()
             if package != candidate.package
         )
-        versions, indices = get_aligned_versions(
+        versions, indices = _get_versions(
             logger=self.logger,
             primary=candidate.package,
             primary_index=0 if candidate_index is None else candidate_index,

--- a/.github/triage/jax_toolbox_triage/triage_tool.py
+++ b/.github/triage/jax_toolbox_triage/triage_tool.py
@@ -923,7 +923,6 @@ class TriageTool:
                 confirmation_iterations=self.args.confirmation_iterations,
                 result_cache=result_cache,
                 classifier=classifier,
-                precondition_failure_log_level=logging.INFO,
             )
         except CouldNotReproduceSuccess:
             # Candidate fails, parent does not pass: search backwards from candidate.

--- a/.github/triage/jax_toolbox_triage/triage_tool.py
+++ b/.github/triage/jax_toolbox_triage/triage_tool.py
@@ -482,7 +482,7 @@ class TriageTool:
 
         known_scripts_result = worker.exec(
             [
-                "sh",
+                "bash",
                 "-o",
                 "pipefail",
                 "-c",

--- a/.github/triage/jax_toolbox_triage/triage_tool.py
+++ b/.github/triage/jax_toolbox_triage/triage_tool.py
@@ -194,7 +194,9 @@ class TriageTool:
             while out_dir.exists():
                 out_dir = base_out_dir.with_name(f"{base_out_dir.name}-restart-{n}")
                 n += 1
-        assert not out_dir.exists(), f"{out_dir} should not already exist, maybe you are re-using {self.args.output_prefix}?"
+        assert not out_dir.exists(), (
+            f"{out_dir} should not already exist, maybe you are re-using {self.args.output_prefix}?"
+        )
         out_dir.mkdir(mode=0o755)
         return out_dir.resolve()
 
@@ -240,9 +242,9 @@ class TriageTool:
         """
         if explicit_versions is not None and container_url is None:
             return explicit_versions, None, None, None
-        assert (
-            container_url is not None
-        ), "Container URL must be provided if explicit versions are not set."
+        assert container_url is not None, (
+            "Container URL must be provided if explicit versions are not set."
+        )
 
         with self._make_container(container_url) as worker:
             url_versions, dirs, env = get_versions_dirs_env(
@@ -481,8 +483,10 @@ class TriageTool:
         known_scripts_result = worker.exec(
             [
                 "sh",
+                "-o",
+                "pipefail",
                 "-c",
-                f'find ${{JAX_TOOLBOX_TRIAGE_PREFIX}}{self.args.build_scripts_path} -maxdepth 1 -type f -and -executable -print0 | sed -e "s|^${{JAX_TOOLBOX_TRIAGE_PREFIX}}||"',
+                f'find ${{JAX_TOOLBOX_TRIAGE_PREFIX}}{self.args.build_scripts_path} -maxdepth 1 -type f -print0 | sed -e "s|^${{JAX_TOOLBOX_TRIAGE_PREFIX}}||"',
             ],
             policy="once",
             stderr="separate",
@@ -1452,9 +1456,9 @@ class TriageTool:
                             f"Reproduced failure in {self.args.failing_container} but not {self.bisection_url}"
                         ) from e
                     else:
-                        assert (
-                            check_fail_outcome == ClassifiedTestOutcome.PASS
-                        ), check_fail_outcome
+                        assert check_fail_outcome == ClassifiedTestOutcome.PASS, (
+                            check_fail_outcome
+                        )
                         raise CouldNotReproduceDesiredOutcome(
                             f"Could not reproduce failure with 'bad' container ({self.args.failing_container}, {check_fail.result})",
                             expected_outcome=ClassifiedTestOutcome.FAIL,
@@ -1488,9 +1492,9 @@ class TriageTool:
                             f"Reproduced success in {self.args.passing_container} but not {self.bisection_url}"
                         ) from e
                     else:
-                        assert (
-                            check_pass_outcome == ClassifiedTestOutcome.FAIL
-                        ), check_pass_outcome
+                        assert check_pass_outcome == ClassifiedTestOutcome.FAIL, (
+                            check_pass_outcome
+                        )
                         raise CouldNotReproduceDesiredOutcome(
                             f"Could not reproduce success with 'good' container ({self.args.passing_container}, {check_pass.result})",
                             expected_outcome=ClassifiedTestOutcome.PASS,

--- a/.github/triage/tests/mock_scripts/build-jax.sh
+++ b/.github/triage/tests/mock_scripts/build-jax.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-cd /opt/jax
+cd ${JAX_TOOLBOX_TRIAGE_PREFIX}/opt/jax
 if [ ! -f "feature_file.txt" ]; then
     echo "Build FAILED: The feature commit was not applied (feature_file.txt is missing)."
     exit 1

--- a/.github/triage/tests/mock_scripts/installPACKAGE.sh
+++ b/.github/triage/tests/mock_scripts/installPACKAGE.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
+set -exo pipefail
 new_version=$1
 echo "Setting PACKAGE_VERSION to $new_version"
 cat ${JAX_TOOLBOX_TRIAGE_PREFIX}.env
-sed -i "s|^PACKAGE_VERSION=.*$|PACKAGE_VERSION=$new_version|" ${JAX_TOOLBOX_TRIAGE_PREFIX}.env
+sed -i "" "s|^PACKAGE_VERSION=.*$|PACKAGE_VERSION=$new_version|" ${JAX_TOOLBOX_TRIAGE_PREFIX}.env
 cat ${JAX_TOOLBOX_TRIAGE_PREFIX}.env

--- a/.github/triage/tests/test_arg_parsing.py
+++ b/.github/triage/tests/test_arg_parsing.py
@@ -73,6 +73,12 @@ def test_good_local_args():
     assert "xla" in args.failing_versions
 
 
+@pytest.mark.parametrize("commit", ["0123456789abcdef", "jax:0123456789abcdef"])
+def test_commit_argument(commit):
+    args = parse_args(valid_start_end_container + ["--commit", commit] + test_command)
+    assert args.commit == commit
+
+
 @pytest.mark.parametrize("date_args", valid_start_end_date_args)
 def test_bad_container_arg_combinations_across_groups(date_args):
     # Can't combine --{start,end}-container with --container/--{start,end}-date

--- a/.github/triage/tests/test_arg_parsing.py
+++ b/.github/triage/tests/test_arg_parsing.py
@@ -73,10 +73,22 @@ def test_good_local_args():
     assert "xla" in args.failing_versions
 
 
-@pytest.mark.parametrize("commit", ["0123456789abcdef", "jax:0123456789abcdef"])
-def test_commit_argument(commit):
+@pytest.mark.parametrize(
+    "commit,expected",
+    [
+        ("0123456789abcdef", {"jax": "0123456789abcdef"}),
+        ("xla:0123456789abcdef", {"xla": "0123456789abcdef"}),
+    ],
+)
+def test_commit_argument(commit, expected):
     args = parse_args(valid_start_end_container + ["--commit", commit] + test_command)
-    assert args.commit == commit
+    assert args.commit == expected
+
+
+@pytest.mark.parametrize("commit", ["", "-bad", "jax:", "jax:a,xla:b"])
+def test_bad_commit_argument(commit):
+    with pytest.raises(SystemExit):
+        parse_args(valid_start_end_container + ["--commit", commit] + test_command)
 
 
 @pytest.mark.parametrize("date_args", valid_start_end_date_args)

--- a/.github/triage/tests/test_arg_parsing.py
+++ b/.github/triage/tests/test_arg_parsing.py
@@ -76,8 +76,12 @@ def test_good_local_args():
 @pytest.mark.parametrize(
     "commit,expected",
     [
-        ("0123456789abcdef", {"jax": "0123456789abcdef"}),
-        ("xla:0123456789abcdef", {"xla": "0123456789abcdef"}),
+        ("jax:0123456789abcdef", [{"jax": "0123456789abcdef"}]),
+        ("xla:0123456789abcdef", [{"xla": "0123456789abcdef"}]),
+        (
+            "jax:0123456789abcdef,xla:fedcba9876543210",
+            [{"jax": "0123456789abcdef", "xla": "fedcba9876543210"}],
+        ),
     ],
 )
 def test_commit_argument(commit, expected):
@@ -85,7 +89,27 @@ def test_commit_argument(commit, expected):
     assert args.commit == expected
 
 
-@pytest.mark.parametrize("commit", ["", "-bad", "jax:", "jax:a,xla:b"])
+def test_repeated_commit_arguments():
+    args = parse_args(
+        valid_start_end_container
+        + [
+            "--commit",
+            "jax:a,xla:b",
+            "--commit",
+            "xla:c,jax:d",
+        ]
+        + test_command
+    )
+    assert args.commit == [
+        {"jax": "a", "xla": "b"},
+        {"xla": "c", "jax": "d"},
+    ]
+
+
+@pytest.mark.parametrize(
+    "commit",
+    ["", "-bad", "0123456789abcdef", "jax:", "jax:a,jax:b", "jax:a, xla:b"],
+)
 def test_bad_commit_argument(commit):
     with pytest.raises(SystemExit):
         parse_args(valid_start_end_container + ["--commit", commit] + test_command)

--- a/.github/triage/tests/test_arg_parsing.py
+++ b/.github/triage/tests/test_arg_parsing.py
@@ -114,6 +114,8 @@ def test_repeated_commit_arguments():
 def test_bad_commit_argument(commit):
     with pytest.raises(SystemExit):
         parse_args(valid_start_end_container + ["--commit", commit] + test_command)
+
+
 def test_missing_metric_retries():
     assert parse_args(valid_local_args + test_command).missing_metric_retries == 1
     assert (

--- a/.github/triage/tests/test_arg_parsing.py
+++ b/.github/triage/tests/test_arg_parsing.py
@@ -107,15 +107,6 @@ def test_repeated_commit_arguments():
     ]
 
 
-@pytest.mark.parametrize(
-    "commit",
-    ["", "-bad", "0123456789abcdef", "jax:", "jax:a,jax:b", "jax:a, xla:b"],
-)
-def test_bad_commit_argument(commit):
-    with pytest.raises(SystemExit):
-        parse_args(valid_start_end_container + ["--commit", commit] + test_command)
-
-
 def test_missing_metric_retries():
     assert parse_args(valid_local_args + test_command).missing_metric_retries == 1
     assert (

--- a/.github/triage/tests/test_commit_candidates.py
+++ b/.github/triage/tests/test_commit_candidates.py
@@ -1,0 +1,204 @@
+import collections
+import datetime
+import logging
+import pathlib
+from types import SimpleNamespace
+
+import pytest
+
+from jax_toolbox_triage.logic import (
+    _EXIT_CODE_METRIC,
+    ExitCodeClassifier,
+    TestExecutionOutcome,
+    TestResult,
+)
+from jax_toolbox_triage.triage_tool import TriageTool, _CommitCandidate
+
+
+START = datetime.datetime(2026, 1, 1)
+DAY = datetime.timedelta(days=1)
+
+
+def make_histories():
+    return collections.OrderedDict(
+        [
+            (
+                "xla",
+                [
+                    ("X0", START),
+                    ("X1", START + 2 * DAY),
+                    ("X2", START + 4 * DAY),
+                    ("X3", START + 6 * DAY),
+                ],
+            ),
+            (
+                "jax",
+                [
+                    ("J0", START),
+                    ("J1", START + DAY),
+                    ("J2", START + 3 * DAY),
+                    ("J3", START + 5 * DAY),
+                ],
+            ),
+            (
+                "flax",
+                [
+                    ("F0", START),
+                    ("F1", START + 3 * DAY),
+                    ("F2", START + 5 * DAY),
+                ],
+            ),
+        ]
+    )
+
+
+def make_test_result(passes):
+    return TestResult(
+        build_stdouterr="",
+        host_output_directory=pathlib.Path("output"),
+        result=TestExecutionOutcome.TEST_YIELDED_RESULTS,
+        stdouterr="",
+        time=0.0,
+        metrics={_EXIT_CODE_METRIC: 0 if passes else 1},
+    )
+
+
+def make_tool(predicate):
+    tool = object.__new__(TriageTool)
+    tool.args = SimpleNamespace(confirmation_iterations=0)
+    tool.logger = logging.getLogger("commit-candidate-tests")
+    observed_versions = []
+
+    def build_and_test(*, versions, **kwargs):
+        observed_versions.append(versions.copy())
+        return make_test_result(predicate(versions))
+
+    tool._build_and_test = build_and_test
+    return tool, observed_versions
+
+
+@pytest.mark.parametrize(
+    "references,expected_xla",
+    [
+        ({}, "X2"),
+        ({"xla": "X1"}, "X1"),
+    ],
+)
+def test_candidate_uses_contemporary_or_explicit_references(references, expected_xla):
+    tool, observed_versions = make_tool(lambda versions: versions["jax"] == "J1")
+    candidate = _CommitCandidate(
+        package="jax",
+        commit="J2",
+        parent="J1",
+        date=START + 3 * DAY,
+        references=references,
+    )
+
+    candidate_result, _ = tool._check_candidate_commit(
+        candidate=candidate,
+        package_versions=make_histories(),
+        result_cache={},
+        classifier=ExitCodeClassifier(),
+    )
+
+    result, _, _ = candidate_result
+    assert result == {
+        "jax_bad": "J2",
+        "jax_good": "J1",
+        "xla_ref": expected_xla,
+        "flax_ref": "F1",
+    }
+    assert {versions["xla"] for versions in observed_versions} == {expected_xla}
+    assert {versions["flax"] for versions in observed_versions} == {"F1"}
+
+
+def test_passing_candidate_narrows_every_package_history():
+    tool, _ = make_tool(lambda versions: True)
+    candidate = _CommitCandidate(
+        package="jax",
+        commit="J1",
+        parent="J0",
+        date=START + DAY,
+        references={},
+    )
+
+    candidate_result, narrowed = tool._check_candidate_commit(
+        candidate=candidate,
+        package_versions=make_histories(),
+        result_cache={},
+        classifier=ExitCodeClassifier(),
+    )
+
+    assert candidate_result is None
+    assert [version for version, _ in narrowed["jax"]] == ["J1", "J2", "J3"]
+    assert [version for version, _ in narrowed["xla"]] == ["X1", "X2", "X3"]
+    assert [version for version, _ in narrowed["flax"]] == ["F1", "F2"]
+
+
+def test_failing_parent_narrows_every_package_history():
+    tool, _ = make_tool(lambda versions: False)
+    candidate = _CommitCandidate(
+        package="jax",
+        commit="J2",
+        parent="J1",
+        date=START + 3 * DAY,
+        references={"xla": "X1"},
+    )
+
+    candidate_result, narrowed = tool._check_candidate_commit(
+        candidate=candidate,
+        package_versions=make_histories(),
+        result_cache={},
+        classifier=ExitCodeClassifier(),
+    )
+
+    assert candidate_result is None
+    assert [version for version, _ in narrowed["jax"]] == ["J0", "J1"]
+    assert [version for version, _ in narrowed["xla"]] == ["X0", "X1"]
+    assert [version for version, _ in narrowed["flax"]] == ["F0", "F1"]
+
+
+def test_candidate_outside_range_can_still_be_confirmed():
+    tool, observed_versions = make_tool(lambda versions: versions["jax"] == "J1")
+    candidate = _CommitCandidate(
+        package="jax",
+        commit="J-outside",
+        parent="J1",
+        date=START + 3 * DAY,
+        references={},
+    )
+
+    candidate_result, _ = tool._check_candidate_commit(
+        candidate=candidate,
+        package_versions=make_histories(),
+        result_cache={},
+        classifier=ExitCodeClassifier(),
+    )
+
+    result, _, _ = candidate_result
+    assert result["jax_bad"] == "J-outside"
+    assert result["jax_good"] == "J1"
+    assert result["xla_ref"] == "X2"
+    assert {versions["xla"] for versions in observed_versions} == {"X2"}
+
+
+def test_wrong_candidate_outside_range_does_not_narrow_histories():
+    tool, _ = make_tool(lambda versions: True)
+    histories = make_histories()
+    candidate = _CommitCandidate(
+        package="jax",
+        commit="J-outside",
+        parent="J1",
+        date=START + 3 * DAY,
+        references={},
+    )
+
+    candidate_result, remaining = tool._check_candidate_commit(
+        candidate=candidate,
+        package_versions=histories,
+        result_cache={},
+        classifier=ExitCodeClassifier(),
+    )
+
+    assert candidate_result is None
+    assert remaining is histories

--- a/.github/triage/tests/test_commit_candidates.py
+++ b/.github/triage/tests/test_commit_candidates.py
@@ -14,7 +14,6 @@ from jax_toolbox_triage.logic import (
 )
 from jax_toolbox_triage.triage_tool import TriageTool, _CommitCandidate
 
-
 START = datetime.datetime(2026, 1, 1)
 DAY = datetime.timedelta(days=1)
 

--- a/.github/triage/tests/test_container_runtimes.py
+++ b/.github/triage/tests/test_container_runtimes.py
@@ -1,6 +1,9 @@
 from jax_toolbox_triage.args import parse_args
 from jax_toolbox_triage.container_factory import make_container
-from jax_toolbox_triage.logic import CouldNotReproduceFailure, CouldNotReproduceSuccess
+from jax_toolbox_triage.logic import (
+    ClassifiedTestOutcome,
+    CouldNotReproduceDesiredOutcome,
+)
 from jax_toolbox_triage.triage_tool import TriageTool
 import logging
 import os
@@ -193,7 +196,7 @@ def test_plugin_backend_metric_always_good(
     """
     passing_container_url, _ = passing_container
     failing_container_url, _ = passing_container_with_later_version
-    with pytest.raises(CouldNotReproduceFailure):
+    with pytest.raises(CouldNotReproduceDesiredOutcome) as error:
         run_with_plugin_backend(
             tool=[
                 "--passing-container",
@@ -203,6 +206,8 @@ def test_plugin_backend_metric_always_good(
             ]
             + metric_args,
         )
+    assert error.value.expected_outcome == ClassifiedTestOutcome.FAIL
+    assert error.value.actual_outcome == ClassifiedTestOutcome.PASS
 
 
 @skip_if_no_docker
@@ -217,7 +222,7 @@ def test_plugin_backend_metric_always_bad(
     """
     passing_container_url, _ = failing_container
     failing_container_url, _ = failing_container_with_later_version
-    with pytest.raises(CouldNotReproduceSuccess):
+    with pytest.raises(CouldNotReproduceDesiredOutcome) as error:
         run_with_plugin_backend(
             tool=[
                 "--passing-container",
@@ -227,3 +232,5 @@ def test_plugin_backend_metric_always_bad(
             ]
             + metric_args,
         )
+    assert error.value.expected_outcome == ClassifiedTestOutcome.PASS
+    assert error.value.actual_outcome == ClassifiedTestOutcome.FAIL

--- a/.github/triage/tests/test_mocked_git_history.py
+++ b/.github/triage/tests/test_mocked_git_history.py
@@ -255,12 +255,17 @@ def test_triage_scenarios(
 
 
 @pytest.mark.parametrize(
-    "history,candidate_key,explicit_package,expected_log",
+    "history,candidate_keys,expected_log",
     [
-        ("linear", "bad_commit_for_linear", False, "Bisected failure to jax"),
-        ("linear", "failing_linear", True, "as the failing endpoint"),
-        ("linear", "good_linear", True, "as the passing endpoint"),
-        ("nonlinear", "bad_main", True, "Bisected failure to jax"),
+        ("linear", ["bad_commit_for_linear"], "Bisected failure to jax"),
+        ("linear", ["failing_linear"], "known failing candidate vector"),
+        ("linear", ["good_linear"], "known passing candidate vector"),
+        (
+            "linear",
+            ["good_linear", "bad_commit_for_linear"],
+            "Bisected failure to jax",
+        ),
+        ("nonlinear", ["bad_main"], "Bisected failure to jax"),
     ],
 )
 def test_specific_commit_validation_and_fallback(
@@ -268,8 +273,7 @@ def test_specific_commit_validation_and_fallback(
     triage_env,
     monkeypatch,
     history,
-    candidate_key,
-    explicit_package,
+    candidate_keys,
     expected_log,
 ):
     caplog.set_level(logging.DEBUG)
@@ -296,8 +300,11 @@ def test_specific_commit_validation_and_fallback(
     failing_commit = commits[scenario["failing"]]
     culprit_commit = commits[scenario["culprit"]]
     expected_good_commit = commits[scenario["expected_good"]]
-    candidate_commit = commits[candidate_key]
-    commit_arg = f"jax:{candidate_commit}" if explicit_package else candidate_commit
+    commit_args = [
+        argument
+        for candidate_key in candidate_keys
+        for argument in ["--commit", f"jax:{commits[candidate_key]}"]
+    ]
 
     args = parse_args(
         [
@@ -311,10 +318,11 @@ def test_specific_commit_validation_and_fallback(
             f"jax:{passing_commit}",
             "--failing-versions",
             f"jax:{failing_commit}",
-            "--commit",
-            commit_arg,
             "--confirmation-iterations",
             "0",
+        ]
+        + commit_args
+        + [
             "--",
             str(paths["scripts"] / "test-case.sh"),
             str(jax_repo_path),

--- a/.github/triage/tests/test_mocked_git_history.py
+++ b/.github/triage/tests/test_mocked_git_history.py
@@ -257,10 +257,10 @@ def test_triage_scenarios(
 @pytest.mark.parametrize(
     "history,candidate_key,explicit_package,expected_log",
     [
-        ("linear", "bad_commit_for_linear", False, "Confirmed"),
+        ("linear", "bad_commit_for_linear", False, "Bisected failure to jax"),
         ("linear", "failing_linear", True, "as the failing endpoint"),
         ("linear", "good_linear", True, "as the passing endpoint"),
-        ("nonlinear", "bad_main", True, "Confirmed"),
+        ("nonlinear", "bad_main", True, "Bisected failure to jax"),
     ],
 )
 def test_specific_commit_validation_and_fallback(

--- a/.github/triage/tests/test_mocked_git_history.py
+++ b/.github/triage/tests/test_mocked_git_history.py
@@ -252,3 +252,86 @@ def test_triage_scenarios(
 
     assert result.get("jax_good") == all_commits[expected_good_key]
     assert result.get("jax_bad") == all_commits[bad_commit_key]
+
+
+@pytest.mark.parametrize(
+    "history,candidate_key,explicit_package,expected_log",
+    [
+        ("linear", "bad_commit_for_linear", False, "Confirmed"),
+        ("linear", "failing_linear", True, "as the failing endpoint"),
+        ("linear", "good_linear", True, "as the passing endpoint"),
+        ("nonlinear", "bad_main", True, "Confirmed"),
+    ],
+)
+def test_specific_commit_validation_and_fallback(
+    caplog,
+    triage_env,
+    monkeypatch,
+    history,
+    candidate_key,
+    explicit_package,
+    expected_log,
+):
+    caplog.set_level(logging.DEBUG)
+    paths = triage_env["paths"]
+    commits = triage_env["commits"]
+    jax_repo_path = paths["repo"] / "jax"
+    scenario = {
+        "linear": {
+            "passing": "good_linear",
+            "failing": "failing_linear",
+            "culprit": "bad_commit_for_linear",
+            "expected_good": "good_linear",
+            "main_branch": "linear_feature_branch",
+        },
+        "nonlinear": {
+            "passing": "passing_nonlinear",
+            "failing": "failing_nonlinear",
+            "culprit": "bad_main",
+            "expected_good": "good_main",
+            "main_branch": "main",
+        },
+    }[history]
+    passing_commit = commits[scenario["passing"]]
+    failing_commit = commits[scenario["failing"]]
+    culprit_commit = commits[scenario["culprit"]]
+    expected_good_commit = commits[scenario["expected_good"]]
+    candidate_commit = commits[candidate_key]
+    commit_arg = f"jax:{candidate_commit}" if explicit_package else candidate_commit
+
+    args = parse_args(
+        [
+            "--main-branch",
+            scenario["main_branch"],
+            "--output-prefix",
+            str(paths["output"]),
+            "--container-runtime",
+            "local",
+            "--passing-versions",
+            f"jax:{passing_commit}",
+            "--failing-versions",
+            f"jax:{failing_commit}",
+            "--commit",
+            commit_arg,
+            "--confirmation-iterations",
+            "0",
+            "--",
+            str(paths["scripts"] / "test-case.sh"),
+            str(jax_repo_path),
+            culprit_commit,
+        ]
+    )
+    monkeypatch.setenv("PATH", str(paths["scripts"]), prepend=":")
+
+    tool = TriageTool(args, logging.getLogger())
+    tool.package_dirs = {"jax": str(jax_repo_path)}
+    tool.dynamic_packages = {"jax"}
+    tool.bisection_url = "local"
+
+    summary_data = tool.run_version_bisection(
+        {"jax": passing_commit}, {"jax": failing_commit}
+    )
+
+    assert summary_data["result"]["jax_good"] == expected_good_commit
+    assert summary_data["result"]["jax_bad"] == culprit_commit
+    assert expected_log in caplog.text

--- a/.github/triage/tests/test_triage_logic.py
+++ b/.github/triage/tests/test_triage_logic.py
@@ -10,7 +10,6 @@ from jax_toolbox_triage.logic import (
     _EXIT_CODE_METRIC,
     ClassifiedTestOutcome,
     CouldNotReproduceDesiredOutcome,
-    container_search,
     ExitCodeClassifier,
     TestExecutionOutcome,
     TestResult,

--- a/.github/triage/tests/test_triage_logic.py
+++ b/.github/triage/tests/test_triage_logic.py
@@ -11,7 +11,6 @@ from jax_toolbox_triage.logic import (
     ExitCodeClassifier,
     TestExecutionOutcome,
     TestResult,
-    verify_culprit,
     version_search,
 )
 from jax_toolbox_triage.metric_classifier import MetricClassifier
@@ -48,83 +47,6 @@ def make_commits(jax, xla, flax=None):
     return collections.OrderedDict(
         (("xla", xla), ("jax", jax)) + (() if flax is None else (("flax", flax),))
     )
-
-
-def test_verify_culprit_tests_candidate_then_parent(logger):
-    calls = []
-
-    def dummy_test(*, versions, **kwargs):
-        calls.append(versions.copy())
-        return wrap(versions["jax"] == "parent", versions)
-
-    verification = verify_culprit(
-        candidate_versions={"jax": "candidate", "xla": "reference"},
-        parent_versions={"jax": "parent", "xla": "reference"},
-        build_and_test=dummy_test,
-        logger=logger,
-        confirmation_iterations=0,
-    )
-
-    assert verification.confirmed
-    assert verification.candidate_outcome == ClassifiedTestOutcome.FAIL
-    assert verification.parent_outcome == ClassifiedTestOutcome.PASS
-    assert [call["jax"] for call in calls] == ["candidate", "parent"]
-
-
-@pytest.mark.parametrize(
-    "passing_versions,expected_candidate,expected_parent",
-    [
-        (
-            {"candidate", "parent"},
-            ClassifiedTestOutcome.PASS,
-            ClassifiedTestOutcome.PASS,
-        ),
-        (set(), ClassifiedTestOutcome.FAIL, ClassifiedTestOutcome.FAIL),
-    ],
-)
-def test_verify_culprit_returns_unconfirmed_observations(
-    logger, passing_versions, expected_candidate, expected_parent
-):
-    def dummy_test(*, versions, **kwargs):
-        return wrap(versions["jax"] in passing_versions, versions)
-
-    verification = verify_culprit(
-        candidate_versions={"jax": "candidate"},
-        parent_versions={"jax": "parent"},
-        build_and_test=dummy_test,
-        logger=logger,
-        confirmation_iterations=0,
-    )
-
-    assert not verification.confirmed
-    assert verification.candidate_outcome == expected_candidate
-    assert verification.parent_outcome == expected_parent
-
-
-def test_verify_culprit_still_tests_parent_after_candidate_build_failure(logger):
-    calls = []
-
-    def dummy_test(*, versions, **kwargs):
-        revision = versions["jax"]
-        calls.append(revision)
-        return wrap(
-            revision == "parent",
-            versions,
-            build_failure=revision == "candidate",
-        )
-
-    verification = verify_culprit(
-        candidate_versions={"jax": "candidate"},
-        parent_versions={"jax": "parent"},
-        build_and_test=dummy_test,
-        logger=logger,
-        confirmation_iterations=1,
-    )
-
-    assert not verification.confirmed
-    assert verification.candidate_outcome == ClassifiedTestOutcome.ERROR
-    assert verification.parent_outcome == ClassifiedTestOutcome.PASS
-    assert calls == ["candidate", "parent", "parent"]
 
 
 @pytest.mark.parametrize(

--- a/.github/triage/tests/test_triage_logic.py
+++ b/.github/triage/tests/test_triage_logic.py
@@ -11,6 +11,7 @@ from jax_toolbox_triage.logic import (
     ExitCodeClassifier,
     TestExecutionOutcome,
     TestResult,
+    verify_culprit,
     version_search,
 )
 from jax_toolbox_triage.metric_classifier import MetricClassifier
@@ -47,6 +48,83 @@ def make_commits(jax, xla, flax=None):
     return collections.OrderedDict(
         (("xla", xla), ("jax", jax)) + (() if flax is None else (("flax", flax),))
     )
+
+
+def test_verify_culprit_tests_candidate_then_parent(logger):
+    calls = []
+
+    def dummy_test(*, versions, **kwargs):
+        calls.append(versions.copy())
+        return wrap(versions["jax"] == "parent", versions)
+
+    verification = verify_culprit(
+        candidate_versions={"jax": "candidate", "xla": "reference"},
+        parent_versions={"jax": "parent", "xla": "reference"},
+        build_and_test=dummy_test,
+        logger=logger,
+        confirmation_iterations=0,
+    )
+
+    assert verification.confirmed
+    assert verification.candidate_outcome == ClassifiedTestOutcome.FAIL
+    assert verification.parent_outcome == ClassifiedTestOutcome.PASS
+    assert [call["jax"] for call in calls] == ["candidate", "parent"]
+
+
+@pytest.mark.parametrize(
+    "passing_versions,expected_candidate,expected_parent",
+    [
+        (
+            {"candidate", "parent"},
+            ClassifiedTestOutcome.PASS,
+            ClassifiedTestOutcome.PASS,
+        ),
+        (set(), ClassifiedTestOutcome.FAIL, ClassifiedTestOutcome.FAIL),
+    ],
+)
+def test_verify_culprit_returns_unconfirmed_observations(
+    logger, passing_versions, expected_candidate, expected_parent
+):
+    def dummy_test(*, versions, **kwargs):
+        return wrap(versions["jax"] in passing_versions, versions)
+
+    verification = verify_culprit(
+        candidate_versions={"jax": "candidate"},
+        parent_versions={"jax": "parent"},
+        build_and_test=dummy_test,
+        logger=logger,
+        confirmation_iterations=0,
+    )
+
+    assert not verification.confirmed
+    assert verification.candidate_outcome == expected_candidate
+    assert verification.parent_outcome == expected_parent
+
+
+def test_verify_culprit_still_tests_parent_after_candidate_build_failure(logger):
+    calls = []
+
+    def dummy_test(*, versions, **kwargs):
+        revision = versions["jax"]
+        calls.append(revision)
+        return wrap(
+            revision == "parent",
+            versions,
+            build_failure=revision == "candidate",
+        )
+
+    verification = verify_culprit(
+        candidate_versions={"jax": "candidate"},
+        parent_versions={"jax": "parent"},
+        build_and_test=dummy_test,
+        logger=logger,
+        confirmation_iterations=1,
+    )
+
+    assert not verification.confirmed
+    assert verification.candidate_outcome == ClassifiedTestOutcome.ERROR
+    assert verification.parent_outcome == ClassifiedTestOutcome.PASS
+    assert calls == ["candidate", "parent", "parent"]
 
 
 @pytest.mark.parametrize(
@@ -263,9 +341,9 @@ def create_commits(num_commits, num_projects):
     """
     Generate commits for test_commit_search_exhaustive.
     """
-    assert num_commits > num_projects, (
-        "Need at least a good commit for each project plus one bad commit for a culprit project"
-    )
+    assert (
+        num_commits > num_projects
+    ), "Need at least a good commit for each project plus one bad commit for a culprit project"
 
     def fake_hash():
         fake_hash.n += 1

--- a/.github/triage/tests/test_triage_logic.py
+++ b/.github/triage/tests/test_triage_logic.py
@@ -7,6 +7,7 @@ import random
 from jax_toolbox_triage.logic import (
     _EXIT_CODE_METRIC,
     ClassifiedTestOutcome,
+    CouldNotReproduceDesiredOutcome,
     container_search,
     ExitCodeClassifier,
     TestExecutionOutcome,
@@ -405,9 +406,27 @@ def test_version_search_no_commits(logger, commits):
         )
 
 
-@pytest.mark.parametrize("value", [True, False])
-def test_version_search_static_test_function(logger, value):
-    with pytest.raises(Exception, match="Could not reproduce"):
+@pytest.mark.parametrize(
+    "value,expected_outcome,actual_outcome",
+    [
+        (
+            True,
+            ClassifiedTestOutcome.FAIL,
+            ClassifiedTestOutcome.PASS,
+        ),
+        (
+            False,
+            ClassifiedTestOutcome.PASS,
+            ClassifiedTestOutcome.FAIL,
+        ),
+    ],
+)
+def test_version_search_static_test_function(
+    logger, value, expected_outcome, actual_outcome
+):
+    with pytest.raises(
+        CouldNotReproduceDesiredOutcome, match="Could not reproduce"
+    ) as error:
         version_search(
             build_and_test=lambda **kwargs: wrap(value),
             versions=make_commits(
@@ -417,6 +436,8 @@ def test_version_search_static_test_function(logger, value):
             logger=logger,
             skip_precondition_checks=False,
         )
+    assert error.value.expected_outcome == expected_outcome
+    assert error.value.actual_outcome == actual_outcome
 
 
 far_future = datetime.date(year=2100, month=1, day=1)

--- a/.github/triage/tests/test_triage_logic.py
+++ b/.github/triage/tests/test_triage_logic.py
@@ -436,9 +436,9 @@ def create_commits(num_commits, num_projects):
     """
     Generate commits for test_commit_search_exhaustive.
     """
-    assert (
-        num_commits > num_projects
-    ), "Need at least a good commit for each project plus one bad commit for a culprit project"
+    assert num_commits > num_projects, (
+        "Need at least a good commit for each project plus one bad commit for a culprit project"
+    )
 
     def fake_hash():
         fake_hash.n += 1

--- a/.github/workflows/triage-ci.yaml
+++ b/.github/workflows/triage-ci.yaml
@@ -58,7 +58,7 @@ jobs:
     runs-on: ubuntu-24.04
     strategy:
       matrix:
-        tool: ["check", "format"]
+        tool: ["check", "format --check"]
       fail-fast: false
     steps:
       - name: Check out the repository under ${GITHUB_WORKSPACE}

--- a/docs/triage-tool.md
+++ b/docs/triage-tool.md
@@ -33,6 +33,13 @@ the given containers are closely related to those from JAX-Toolbox
 * JAX, XLA, Flax[, MaxText] sources at `/opt/{jax,xla,flax,maxtext}[-source]`
 * `build-jax.sh` script from JAX-Toolbox available in the container
 
+If a likely culprit commit is already known, pass it with `--commit`. The tool tests
+that commit and its first parent before starting the normal version-level search. A
+candidate that fails while its parent passes is reported immediately. Otherwise, a
+failing candidate becomes the failing endpoint of a backward bisection, while a
+passing candidate becomes the passing endpoint of a forward bisection. A build or test
+error falls back to the original range.
+
 ## Installation
 
 The triage tool can be installed using `pip`:
@@ -162,6 +169,12 @@ To use the tool, there are two compulsory inputs:
       * **Version Search between Containers**: `--passing-container` and `--failing-container`: a pair of URLs to containers to use in the version-level search; if these are passed then no container-level search is performed.
       * **Local Commit Search**: Use `--container-runtime=local` when you are already inside a JAX container. This mode skips all container orchestration and performs a version-level search directly in the local container. It requires you to specify the version range with `--passing-versions` and `--failing-versions`.
 
+Any of these scopes can be combined with `--commit REVISION` to check a suspected
+culprit first. A bare revision is auto-detected among the known source repositories.
+Use `--commit PACKAGE:REVISION` (for example, `--commit jax:abc123`) if the revision
+needs to be associated with a specific package. The ordinary scope arguments are still
+required because they provide the build environment and the fallback search range.
+
 The test command will be executed directly in the container, not inside a shell, so be
 sure not to add excessive quotation marks (*i.e.* run
 `jax-toolbox-triage --container=jax test-jax.sh foo` not
@@ -244,6 +257,9 @@ paths and `http`/`https`/`grpc` URLs.
 If `--skip-precondition-checks` is passed, a sanity check that the failure can be
 reproduced after rebuilding the JAX/XLA commits from the first-known-bad container
 inside that container will be skipped.
+
+The explicit candidate and parent checks requested by `--commit` are always run, even
+when `--skip-precondition-checks` is passed.
 
 ## Example
 

--- a/docs/triage-tool.md
+++ b/docs/triage-tool.md
@@ -34,11 +34,11 @@ the given containers are closely related to those from JAX-Toolbox
 * `build-jax.sh` script from JAX-Toolbox available in the container
 
 If a likely culprit commit is already known, pass it with `--commit`. The tool tests
-that commit and its first parent before starting the normal version-level search. A
-candidate that fails while its parent passes is reported immediately. Otherwise, a
-failing candidate becomes the failing endpoint of a backward bisection, while a
-passing candidate becomes the passing endpoint of a forward bisection. A build or test
-error falls back to the original range.
+that commit and, if it reproduces the failure, its first parent. A candidate that fails
+while its parent passes is reported immediately. Otherwise, a failing candidate becomes
+the failing endpoint of a backward bisection, while a passing candidate becomes the
+passing endpoint of a forward bisection. A build or test error falls back to the
+original range.
 
 ## Installation
 
@@ -170,10 +170,10 @@ To use the tool, there are two compulsory inputs:
       * **Local Commit Search**: Use `--container-runtime=local` when you are already inside a JAX container. This mode skips all container orchestration and performs a version-level search directly in the local container. It requires you to specify the version range with `--passing-versions` and `--failing-versions`.
 
 Any of these scopes can be combined with `--commit REVISION` to check a suspected
-culprit first. A bare revision is auto-detected among the known source repositories.
-Use `--commit PACKAGE:REVISION` (for example, `--commit jax:abc123`) if the revision
-needs to be associated with a specific package. The ordinary scope arguments are still
-required because they provide the build environment and the fallback search range.
+culprit first. A bare revision refers to JAX. For another source repository, use
+`--commit PACKAGE:REVISION` (for example, `--commit xla:abc123`). The ordinary scope
+arguments are still required because they provide the build environment and the
+fallback search range.
 
 The test command will be executed directly in the container, not inside a shell, so be
 sure not to add excessive quotation marks (*i.e.* run
@@ -258,8 +258,8 @@ If `--skip-precondition-checks` is passed, a sanity check that the failure can b
 reproduced after rebuilding the JAX/XLA commits from the first-known-bad container
 inside that container will be skipped.
 
-The explicit candidate and parent checks requested by `--commit` are always run, even
-when `--skip-precondition-checks` is passed.
+The explicit candidate check requested by `--commit`, and its parent check when the
+candidate fails, are still run when `--skip-precondition-checks` is passed.
 
 ## Example
 

--- a/docs/triage-tool.md
+++ b/docs/triage-tool.md
@@ -169,11 +169,10 @@ To use the tool, there are two compulsory inputs:
       * **Version Search between Containers**: `--passing-container` and `--failing-container`: a pair of URLs to containers to use in the version-level search; if these are passed then no container-level search is performed.
       * **Local Commit Search**: Use `--container-runtime=local` when you are already inside a JAX container. This mode skips all container orchestration and performs a version-level search directly in the local container. It requires you to specify the version range with `--passing-versions` and `--failing-versions`.
 
-Any of these scopes can be combined with `--commit REVISION` to check a suspected
-culprit first. A bare revision refers to JAX. For another source repository, use
-`--commit PACKAGE:REVISION` (for example, `--commit xla:abc123`). The ordinary scope
-arguments are still required because they provide the build environment and the
-fallback search range.
+Version-level search can be combined with `--commit PACKAGE:REVISION` to hint a probable culprit commit.
+`--commit` may be passed multiple times to pass multiple hints.
+If multiple packages are listed in the same instance (`--commit P1:R1,P2:R2`) then the 2nd and subsequent packages and revisions are interpreted as reference values; i.e. the hint is that `(R1, R2)` fails and `(parent of R1, R2)` passes.
+The ordinary scope arguments are still required because they provide the build environment and the fallback search range.
 
 The test command will be executed directly in the container, not inside a shell, so be
 sure not to add excessive quotation marks (*i.e.* run


### PR DESCRIPTION
When a `--commit` is provided, the tool:
- resolves the supplied commit and its first parent
- builds and tests the candidate from the failing endpoint
- tests the parent when the candidate reproduces the regression
- reports the candidate immediately when it fails and its parent passes
- falls back to standard version search in case the candidate is not confirmed and here we have: 
    - A failing candidate becomes the failing endpoint for a backward search
    - a passing candidate becomes the passing endpoint for a forward search
    - a build or test error retains the original bisection range

To use it: 
```bash 
jax-toolbox-triage --commit xla:<revision> --passing-container ghrc.io/something-pass --failing-container ghcr.io/something-fail -v ... --
```