### PR TITLE
Triage tool improvements:

### DIFF
--- a/.github/triage/jax_toolbox_triage/args.py
+++ b/.github/triage/jax_toolbox_triage/args.py
@@ -289,9 +289,15 @@ def parse_args(args=None) -> argparse.Namespace:
         default=[],
         help="""
             Takes a ENV_VAR=val format value and propagates it to the build-te.sh execution
-            environment. Can be passed multiple times. If used, --cache will be passed to
+            environment. Can be passed multiple times. If used, --ccache will be passed to
             build-te.sh. This is intended to allow configuration of a remote ccache cache.
         """,
+    )
+    version_search_args.add_argument(
+        "--extra-build-jax-args",
+        action="append",
+        default=[],
+        help="Extra arguments to pass to build-jax.sh",
     )
     version_search_args.add_argument(
         "--confirmation-iterations",
@@ -301,6 +307,16 @@ def parse_args(args=None) -> argparse.Namespace:
             When the version level search converges, re-check the last-known-good and
             first-known-bad versions this many times. This is a final line of defence
             against flaky test cases.
+        """,
+    )
+    version_search_args.add_argument(
+        "--missing-metric-retries",
+        default=1,
+        type=int,
+        help="""
+            Retry a measurement this many times if it does not produce the metric
+            requested by --metric-name. This applies to both cached and newly executed
+            results. Default: 1.
         """,
     )
     parser.add_argument(
@@ -376,6 +392,8 @@ def parse_args(args=None) -> argparse.Namespace:
                 "You should pass seed metric values via --passing-metric and "
                 "--failing-metric if --metric-name is passed."
             )
+    if args.missing_metric_retries < 0:
+        raise Exception("--missing-metric-retries must be non-negative")
     if (args.passing_metric or args.failing_metric) and args.metric_name is None:
         raise Exception(
             "--metric-name must be passed if --passing-metric or --failing-metric is."

--- a/.github/triage/jax_toolbox_triage/data_files/Dockerfile.triage-tool
+++ b/.github/triage/jax_toolbox_triage/data_files/Dockerfile.triage-tool
@@ -5,5 +5,5 @@ ARG GIT_CMD
 FROM ${BASE_IMAGE}
 ARG BUILD_CMD
 ARG GIT_CMD
-RUN sh -c "${GIT_CMD}"
+RUN --mount=type=secret,id=git-netrc,target=/root/.netrc sh -c "${GIT_CMD}"
 RUN --mount=type=cache,target=/root/.cache sh -c "${BUILD_CMD}"

--- a/.github/triage/jax_toolbox_triage/logic.py
+++ b/.github/triage/jax_toolbox_triage/logic.py
@@ -50,6 +50,9 @@ class TestResult:
     stdouterr: typing.Optional[str]
     time: typing.Optional[float]
     metrics: typing.Dict[str, typing.Any]
+    # Intentionally not serialized: --restart should make one fresh attempt to obtain
+    # a result, while repeated use within one search should not consume more retries.
+    required_metric_retries_exhausted: bool = False
 
     def exit_code_based_pass(self):
         exit_code = self.metrics.get(_EXIT_CODE_METRIC)
@@ -66,6 +69,10 @@ class TestResult:
             and isinstance(exit_code, int)
             and exit_code != 0
         )
+
+
+def _yielded_results(result: TestResult) -> bool:
+    return result.result == TestExecutionOutcome.TEST_YIELDED_RESULTS
 
 
 class ClassifiedTestOutcome(Enum):
@@ -326,10 +333,12 @@ class BuildAndTest(typing.Protocol):
         versions: typing.Dict[str, str],
         test_repetition: int = 0,
         test_output_log_level: int = logging.DEBUG,
+        repeating_test_repetition: bool = False,
     ) -> TestResult:
         """
         Given an [unordered] set of {package_name: package_version}, build
-        those package versions and return the test result.
+        those package versions and return the test result. repeating_test_repetition
+        indicates an intentional retry with the same test_repetition value.
         """
         ...
 
@@ -396,8 +405,10 @@ def _latest_versions(
     return {package: version_list[-1][0] for package, version_list in versions.items()}
 
 
-def _strip_build_failures(versions: typing.Dict[str, str]) -> typing.Dict[str, str]:
-    def remove_build_failures(ver):
+def _strip_unavailable_versions(
+    versions: typing.Dict[str, str],
+) -> typing.Dict[str, str]:
+    def remove_unavailable_versions(ver):
         ver_bits = ver.split(",")
         if len(ver_bits) == 1:
             return ver
@@ -409,7 +420,7 @@ def _strip_build_failures(versions: typing.Dict[str, str]) -> typing.Dict[str, s
             assert ver_bits[0][0] == "[" and ver_bits[-2][-1] == "]", ver_bits
             return ver_bits[-1]
 
-    return {k: remove_build_failures(v) for k, v in versions.items()}
+    return {k: remove_unavailable_versions(v) for k, v in versions.items()}
 
 
 # Fake version key used to distinguish between intentional repeated measurements of the
@@ -429,7 +440,7 @@ def version_cache_key(
     repetition: int = 0,
 ) -> FlatVersionDict:
     return tuple(
-        sorted(_strip_build_failures(versions).items())
+        sorted(_strip_unavailable_versions(versions).items())
         + [(_REPETITION_KEY, str(repetition))]
     )
 
@@ -447,6 +458,8 @@ def version_search(
     max_repetitions: typing.Optional[int] = None,
     result_cache: typing.Optional[typing.Dict[FlatVersionDict, TestResult]] = None,
     classifier: ExecutionClassifier = ExitCodeClassifier(),
+    metric_name: typing.Optional[str] = None,
+    missing_metric_retries: int = 1,
 ) -> typing.Tuple[
     typing.Dict[str, str], typing.Sequence[TestResult], typing.Sequence[TestResult]
 ]:
@@ -470,6 +483,13 @@ def version_search(
         of times any given set of versions will be executed is `max_repetitions + 1`.
         Defaults to be `confirmation_iterations + 2`.
     result_cache: previously completed build/test results to reuse
+    metric_name: metric that each successful test execution must produce. Functional
+        triage requires the ``exit_code`` metric. If a cached or new execution does
+        not produce the required metric, the measurement is retried. If the retries
+        are exhausted, the version set is treated as yielding no usable results so
+        the search can make progress around it.
+    missing_metric_retries: maximum number of extra measurement attempts when
+        the required metric is absent. Defaults to one retry.
 
     Returns a 3-tuple of (summary_dict, last_known_good, first_known_bad),
     where the last element can be None if skip_precondition_checks=True. The
@@ -483,6 +503,7 @@ def version_search(
         max_repetitions,
         confirmation_iterations,
     )
+    assert missing_metric_retries >= 0, missing_metric_retries
     if result_cache is None:
         result_cache = {}
 
@@ -508,17 +529,55 @@ def version_search(
                 f"Reusing cached result for {dict(cache_key)}: "
                 f"{bisect_result.result}: {bisect_result.metrics}"
             )
-            return bisect_result
-        bisect_result = build_and_test(
-            versions=_strip_build_failures(bisect_versions),
-            test_output_log_level=test_output_log_level,
-            test_repetition=repetition,
-        )
-        logger.info(
-            f"New result for {dict(cache_key)}: {bisect_result.result}: "
-            f"{bisect_result.metrics}"
-        )
-        result_cache[cache_key] = bisect_result
+        else:
+            bisect_result = build_and_test(
+                versions=_strip_unavailable_versions(bisect_versions),
+                test_output_log_level=test_output_log_level,
+                test_repetition=repetition,
+            )
+            logger.info(
+                f"New result for {dict(cache_key)}: {bisect_result.result}: "
+                f"{bisect_result.metrics}"
+            )
+            result_cache[cache_key] = bisect_result
+
+        required_metric = metric_name or _EXIT_CODE_METRIC
+        retries = 0
+        while (
+            bisect_result.result != TestExecutionOutcome.BUILD_FAILURE
+            and not bisect_result.required_metric_retries_exhausted
+            and (
+                bisect_result.result != TestExecutionOutcome.TEST_YIELDED_RESULTS
+                or required_metric not in bisect_result.metrics
+            )
+        ):
+            if retries == missing_metric_retries:
+                logger.warning(
+                    f"Execution for {dict(cache_key)} did not produce metric "
+                    f"{required_metric!r} after {retries + 1} attempt(s); "
+                    "treating this version set as yielding no usable results "
+                    "so the bisection can continue"
+                )
+                bisect_result.result = TestExecutionOutcome.TEST_ERROR
+                bisect_result.required_metric_retries_exhausted = True
+                break
+            retries += 1
+            logger.warning(
+                f"Execution for {dict(cache_key)} did not produce metric "
+                f"{required_metric!r}; retrying measurement "
+                f"({retries}/{missing_metric_retries})"
+            )
+            bisect_result = build_and_test(
+                versions=_strip_unavailable_versions(bisect_versions),
+                test_output_log_level=test_output_log_level,
+                test_repetition=repetition,
+                repeating_test_repetition=True,
+            )
+            logger.info(
+                f"Retry result for {dict(cache_key)}: {bisect_result.result}: "
+                f"{bisect_result.metrics}"
+            )
+            result_cache[cache_key] = bisect_result
         return bisect_result
 
     def _check(
@@ -542,10 +601,14 @@ def version_search(
                 repetition=n,
                 test_output_log_level=test_output_log_level,
             )
-            if check.result == TestExecutionOutcome.BUILD_FAILURE:
-                err = f"Build failure attempting to reproduce result with {good_or_bad} versions"
+            if not _yielded_results(check):
+                err = (
+                    "Could not obtain test results while attempting to reproduce "
+                    f"the result with {good_or_bad} versions"
+                )
                 logger.fatal(err)
                 logger.fatal(check.build_stdouterr)
+                logger.fatal(check.stdouterr)
                 raise CouldNotReproduceDesiredOutcome(err)
             outcome = classifier([check])
             assert outcome != ClassifiedTestOutcome.ERROR
@@ -620,24 +683,25 @@ def version_search(
     primary = _first(versions.keys())
     get_versions = functools.partial(_get_versions, logger=logger, primary=primary)
 
-    def find_successful_build(versions):
-        # Try to find a set of versions where the build does not fail, starting with
-        # the set of versions that implement in a binary search for the actual test failure
+    def find_usable_result(versions):
+        # Try to find a set of versions where the build succeeds and the test yields
+        # results, starting with the set of versions selected by binary search for the
+        # actual test failure.
         bisect_versions, indices = get_versions(versions=versions)
         bisect_result = build_cached(bisect_versions)
-        if bisect_result.result != TestExecutionOutcome.BUILD_FAILURE:
+        if _yielded_results(bisect_result):
             return bisect_result, bisect_versions
         logger.info(
-            f"Encountered build failure using index={indices[primary]} of "
+            f"Execution yielded no usable results using index={indices[primary]} of "
             f"the remaining {len(versions[primary])} {primary} versions"
         )
-        # Versions based on the middle of the remaining `primary` commits led to a
-        # build failure (n), but the endpoints build OK (y).
+        # Versions based on the middle of the remaining `primary` commits yielded no
+        # usable results (n), but the endpoints yielded results (y).
         # y -- ? -- n -- ? -- y
         # |         |         |
         # start   middle     end
         #
-        # We may know about other build failures (n values) in the range due to
+        # We may know about other unavailable executions (n values) in the range due to
         # previous iterations.
         #       cached
         #         |
@@ -647,25 +711,27 @@ def version_search(
         #
         # And the hope of this logic is that we will find either an early version where
         # the build succeeds and the test fails (so we can throw away the range with
-        # build failures), or a late version where the build succeeds and the test
-        # succeeds so we can do the same. The somewhat arbitrary logic here is to take
+        # unavailable results), or a late version where the test yields results and
+        # passes so we can do the same. The somewhat arbitrary logic here is to take
         # the shorter y??????n run and refine it in the hope one of the ? is a y.
-        assert (
-            result_cache[version_cache_key(_earliest_versions(versions))].result
-            != TestExecutionOutcome.BUILD_FAILURE
-        ), result_cache[version_cache_key(_earliest_versions(versions))].result
+        assert _yielded_results(
+            result_cache[version_cache_key(_earliest_versions(versions))]
+        ), result_cache[version_cache_key(_earliest_versions(versions))]
         build_statuses = [(True, {p: 0 for p in versions})]
         for n in range(1, len(versions[primary]) - 1):
             versions_n, indices_n = get_versions(primary_index=n, versions=versions)
             result_n = result_cache.get(version_cache_key(versions_n))
-            assert (
-                result_n is None
-                or result_n.result == TestExecutionOutcome.BUILD_FAILURE
-            )
+            if result_n is not None and _yielded_results(result_n):
+                logger.info(
+                    "Found a cached execution that yielded results while searching "
+                    f"around unavailable {primary} versions; reusing index={n} of "
+                    f"the remaining {len(versions[primary])} versions"
+                )
+                return result_n, versions_n
+            assert result_n is None or not _yielded_results(result_n)
             build_statuses.append((None if result_n is None else False, indices_n))
-        assert (
-            result_cache[version_cache_key(_latest_versions(versions))].result
-            != TestExecutionOutcome.BUILD_FAILURE
+        assert _yielded_results(
+            result_cache[version_cache_key(_latest_versions(versions))]
         ), result_cache.get(version_cache_key(_latest_versions(versions))).result
         build_statuses.append((True, {p: len(vs) - 1 for p, vs in versions.items()}))
         assert len(build_statuses) == len(versions[primary])
@@ -699,10 +765,10 @@ def version_search(
             while len(range_versions[primary]) > 2:
                 bisect_versions, indices = get_versions(versions=range_versions)
                 bisect_result = build_cached(bisect_versions)
-                if bisect_result.result != TestExecutionOutcome.BUILD_FAILURE:
+                if _yielded_results(bisect_result):
                     return bisect_result, bisect_versions
                 logger.info(
-                    "Encountered another build failure when refining "
+                    "Encountered another execution with no usable results when refining "
                     f"{len(range_versions[primary])} {primary} versions in "
                     f"{len(ranges)} candidate range(s)"
                 )
@@ -739,7 +805,7 @@ def version_search(
         return outcome, results
 
     while len(versions[primary]) > 2:
-        bisect_result, bisect_versions = find_successful_build(versions=versions)
+        bisect_result, bisect_versions = find_usable_result(versions=versions)
 
         # reconstruct the indices in `versions` of the versions in `bisect_versions`
         def _index(pkg, ver):
@@ -784,27 +850,26 @@ def version_search(
             # as given middle=fail, and Q1=fail the points between Q1 and middle will
             # not be checked.
             n_primary = len(versions[primary])
-            build_fail_commits = []
+            unavailable_commits = []
             for n in range(1, n_primary - 1):
                 versions_n, _ = get_versions(primary_index=n, versions=versions)
-                # Should have been a build failure if tested.
+                # Should have yielded no usable results if tested.
                 result_n = result_cache.get(version_cache_key(versions_n))
                 if result_n is not None:
-                    assert result_n.result == TestExecutionOutcome.BUILD_FAILURE, (
-                        result_n
-                    )
-                build_fail_commits.append(versions_n[primary])
+                    assert not _yielded_results(result_n), result_n
+                unavailable_commits.append(versions_n[primary])
             logger.warning(
-                f"Could not triage {primary} to a single version due to build "
-                f"failures, adding {n_primary - 2} build failure version(s) to both "
+                f"Could not triage {primary} to a single version because some "
+                f"executions yielded no results; adding {n_primary - 2} version(s) to both "
                 "last-known-good and first-known-bad versions to represent this lack "
                 "of signal. The tool has not positively verified that *all* of these "
-                "commits actually lead to build failures."
+                "commits fail to yield results."
             )
             test_pass_commit, test_pass_date = versions[primary][0]
             test_fail_commit, test_fail_date = versions[primary][-1]
-            test_pass_range = f"{test_pass_commit},[{','.join(build_fail_commits)}]"
-            test_fail_range = f"[{','.join(build_fail_commits)}],{test_fail_commit}"
+            unavailable_range = ",".join(unavailable_commits)
+            test_pass_range = f"{test_pass_commit},[{unavailable_range}]"
+            test_fail_range = f"[{unavailable_range}],{test_fail_commit}"
             versions[primary] = [
                 (test_pass_range, test_pass_date),
                 (test_fail_range, test_fail_date),
@@ -901,7 +966,10 @@ def version_search(
             skip_precondition_checks=True,
             result_cache=result_cache,
             confirmation_iterations=confirmation_iterations,
+            max_repetitions=max_repetitions,
             classifier=classifier,
+            metric_name=metric_name,
+            missing_metric_retries=missing_metric_retries,
         )
     else:
         err = f"Could not handle blame outcome {blame_outcome}"

--- a/.github/triage/jax_toolbox_triage/metric_classifier.py
+++ b/.github/triage/jax_toolbox_triage/metric_classifier.py
@@ -19,7 +19,7 @@ class MetricClassifier(ExecutionClassifier):
         passing_values: typing.List[float],
         failing_values: typing.List[float],
         threshold: float = 0.997,
-        common_variance: bool = True,
+        common_variance: typing.Optional[bool] = None,
     ):
         """
         The classifier models the metric as two Gaussian distributions (pass/fail),
@@ -29,7 +29,15 @@ class MetricClassifier(ExecutionClassifier):
         using `add_data_with_label`. If new values can be assigned to one of the two
         populations with confidence greater than `threshold`, they are also used to
         update the estimated parameters of the distributions.
+
+        By default, fit separate variances when both populations have multiple seed
+        values. Fall back to a common variance when either population has only one
+        seed, since its variance cannot then be estimated independently. An explicit
+        `common_variance` value overrides this choice.
         """
+        if common_variance is None:
+            common_variance = len(passing_values) <= 1 or len(failing_values) <= 1
+        self.common_variance = common_variance
         self._metric_name = metric_name
         self._threshold = threshold
         self._log_threshold_odds = math.log(threshold / (1 - threshold))
@@ -41,7 +49,7 @@ class MetricClassifier(ExecutionClassifier):
         self._pass["b"] = max(self._min_b, self._pass["b"])
         self._fail["b"] = max(self._min_b, self._fail["b"])
         self._shared = {}
-        if common_variance:
+        if self.common_variance:
             self._shared["a"] = self._pass.pop("a") + self._fail.pop("a")
             self._shared["b"] = self._pass.pop("b") + self._fail.pop("b")
         self._pass_history = passing_values.copy()

--- a/.github/triage/jax_toolbox_triage/pyxis.py
+++ b/.github/triage/jax_toolbox_triage/pyxis.py
@@ -79,5 +79,9 @@ class PyxisContainer(Container):
     def exists(self) -> bool:
         # TODO: optimise to avoid an extra container creation (local-only,
         # nothing is re-downloaded) for each call to exists().
-        with self as worker:
-            return worker.exec(["true"]).returncode == 0
+        try:
+            with self as worker:
+                pass
+        except subprocess.CalledProcessError:
+            return False
+        return True

--- a/.github/triage/jax_toolbox_triage/triage_tool.py
+++ b/.github/triage/jax_toolbox_triage/triage_tool.py
@@ -7,8 +7,12 @@ import json
 import logging
 import pathlib
 import platform
+import shlex
+import shutil
+import tempfile
 import time
-from typing import Dict, Tuple, Union, Any, Optional, Set
+import urllib.parse
+from typing import Any, Dict, List, Optional, Set, Tuple, Union
 
 from .container import Container
 from .logic import (
@@ -49,6 +53,55 @@ class InconsistentResults(Exception):
     pass
 
 
+def _bounded_tag_suffix(container_registry: Optional[str], tag_suffix: str) -> str:
+    """Keep the complete Docker tag within its 128-character limit."""
+    if container_registry is None:
+        return tag_suffix
+
+    registry_leaf = container_registry.rsplit("/", 1)[-1]
+    tag_prefix = registry_leaf.split(":", 1)[1] if ":" in registry_leaf else ""
+    max_suffix_length = 128 - len(tag_prefix)
+    if len(tag_suffix) <= max_suffix_length:
+        return tag_suffix
+
+    digest = hashlib.sha1(tag_suffix.encode()).hexdigest()[:12]
+    return f"{tag_suffix[:max_suffix_length - len(digest) - 1]}-{digest}"
+
+
+def _remote_without_credentials(
+    remote: str,
+) -> Tuple[str, Optional[Tuple[str, str, str]]]:
+    """Return a URL safe for build arguments and optional netrc credentials."""
+    parsed = urllib.parse.urlsplit(remote)
+    if (
+        parsed.scheme not in {"http", "https"}
+        or parsed.hostname is None
+        or parsed.username is None
+    ):
+        return remote, None
+
+    hostname = parsed.hostname
+    netloc = f"[{hostname}]" if ":" in hostname else hostname
+    if parsed.port is not None:
+        netloc += f":{parsed.port}"
+    sanitized = urllib.parse.urlunsplit(parsed._replace(netloc=netloc))
+    credentials = (
+        hostname,
+        urllib.parse.unquote(parsed.username),
+        urllib.parse.unquote(parsed.password or ""),
+    )
+    return sanitized, credentials
+
+
+def _git_fetch_refs(version: str, cherry_picks: List[str]) -> List[str]:
+    """Return every object needed to check out and cherry-pick a version."""
+    refs = [version]
+    for revision in cherry_picks:
+        start, separator, end = revision.partition("..")
+        refs.extend([start, end] if separator else [revision])
+    return list(dict.fromkeys(refs))
+
+
 class TriageTool:
     """
     This is the main class that orchestrates the whole triage process.
@@ -87,12 +140,16 @@ class TriageTool:
 
     def _version_slug(self, url: str, versions: Dict[str, str]) -> str:
         hash_chars = 8
-        components = {"container": hashlib.sha1(url.encode()).hexdigest()}
+        components = {"container": [hashlib.sha1(url.encode()).hexdigest()]}
         components.update(versions)
-        return "-".join(f"{k}-{v[:hash_chars]}" for k, v in components.items())
+        return "-".join(f"{k}-{'_'.join(v[:hash_chars] for v in vs)}" for k, vs in components.items())
 
     def _test_output_directory(
-        self, url: str, versions: Union[Dict[str, str], None]
+        self,
+        url: str,
+        versions: Union[Dict[str, str], None],
+        *,
+        overwrite: bool = False,
     ) -> pathlib.Path:
         """
         Create a directory for test output based on the container URL and versions.
@@ -103,9 +160,15 @@ class TriageTool:
         Returns:
             pathlib.Path: The path to the output directory.
         """
-        out_dirname = self._version_slug(url=url, versions=versions or {})
+        out_dirname = self._version_slug(
+            url=url,
+            versions={k: [v] for k, v in (versions or {}).items()},
+        )
         out_dir = self.args.output_prefix / out_dirname
-        if out_dir.exists() and self.args.restart:
+        if out_dir.exists() and overwrite:
+            self.logger.info(f"Removing failed test output before retry: {out_dir}")
+            shutil.rmtree(out_dir)
+        elif out_dir.exists() and self.args.restart:
             base_out_dir = out_dir
             n = 1
             while out_dir.exists():
@@ -463,19 +526,24 @@ class TriageTool:
         with open(out_dir / "test.log", "w") as log:
             log.write(result.stdout)
         metrics = {_EXIT_CODE_METRIC: result.returncode}
-        if self.args.metric_name is None:
-            # For non-metric triage there is always a result: the exit code
-            result_enum = TestExecutionOutcome.TEST_YIELDED_RESULTS
-        else:
-            # metric-based triage
-            metrics_file = out_dir / "metrics.json"
+        metrics_file = out_dir / "metrics.json"
+        if self.args.container_runtime == "plugin" or self.args.metric_name is not None:
+            # A plugin distinguishes its own infrastructure failure from a
+            # completed workload failure by omitting exit_code. A missing or
+            # invalid metrics file is likewise not a workload exit code and is
+            # handled by the normal missing-metric retry.
             try:
                 with open(metrics_file) as ifile:
-                    metrics.update(json.load(ifile))
+                    metrics = json.load(ifile)
                 result_enum = TestExecutionOutcome.TEST_YIELDED_RESULTS
             except Exception as e:
+                metrics = {}
                 result_enum = TestExecutionOutcome.TEST_ERROR
                 self.logger.fatal(f"Failed to extract metrics: {e}")
+        else:
+            assert self.args.metric_name is None
+            # For non-metric triage there is always a result: the exit code
+            result_enum = TestExecutionOutcome.TEST_YIELDED_RESULTS
         self.logger.info(
             f"Test completed in {duration:.1f}s with metric values {metrics} in {container_url}"
         )
@@ -494,6 +562,7 @@ class TriageTool:
         versions: Dict[str, str],
         test_repetition: int = 0,
         test_output_log_level: int = logging.DEBUG,
+        repeating_test_repetition: bool = False,
     ) -> TestResult:
         """
         The main body of the bisection loop. Update JAX/XLA/... versions, rebuild, and
@@ -503,12 +572,16 @@ class TriageTool:
         Args:
             versions (dict): The versions of the software packages to use.
             test_output_log_level (int): The log level for test output.
+            repeating_test_repetition (bool): Whether this intentionally retries the
+                same test_repetition value.
 
         Returns:
             TestResult: The result of the test, including whether it passed and the output.
         """
         # Amortise container startup overhead by batching together git commands
         git_commands, changed, skipped = [], [], []
+        git_credentials = {}
+        push_intermediate_containers = self.args.container_runtime == "plugin"
         for package in sorted(self.dynamic_packages):
             version = versions[package]
             if self.bisection_versions.get(package) == version:
@@ -533,6 +606,27 @@ class TriageTool:
                     f"cd ${{JAX_TOOLBOX_TRIAGE_PREFIX}}{self.package_dirs[package]}"
                 )
                 git_commands.append("git stash")
+                remote = self.args.override_remotes.get(package, "origin")
+                if push_intermediate_containers:
+                    remote, credentials = _remote_without_credentials(remote)
+                    if credentials is not None:
+                        hostname, username, password = credentials
+                        existing = git_credentials.setdefault(
+                            hostname, (username, password)
+                        )
+                        if existing != (username, password):
+                            raise ValueError(
+                                f"Conflicting Git credentials for {hostname}"
+                            )
+                fetch_refs = _git_fetch_refs(
+                    version, self.args.cherry_pick.get(package, [])
+                )
+                git_commands.append(
+                    "git fetch --no-tags "
+                    + shlex.quote(remote)
+                    + " "
+                    + " ".join(shlex.quote(ref) for ref in fetch_refs)
+                )
                 # this is a checkout on the main branch
                 git_commands.append(f"git checkout {version}")
                 for cherry_pick_range in self.args.cherry_pick.get(package, []):
@@ -568,12 +662,12 @@ class TriageTool:
         out_dir = self._test_output_directory(
             self.bisection_url,
             versions=brief_versions,
+            overwrite=repeating_test_repetition,
         )
         change_str = " ".join(changed) if len(changed) else "<nothing>"
         info_str = f"Checking out {change_str}"
         if len(skipped):
             info_str += f", leaving {' '.join(skipped)} unchanged"
-        push_intermediate_containers = self.args.container_runtime == "plugin"
         with (
             contextlib.nullcontext()
             if push_intermediate_containers
@@ -589,10 +683,10 @@ class TriageTool:
                 # Not needed if we are pushing a container, because the local cache is not
                 # included in it.
                 build_cmds.append("bazel clean --expunge")
+            build_jax_cmd = ["build-jax.sh"] + self.args.extra_build_jax_args
             if self.args.bazel_cache:
-                build_cmds.append(f"build-jax.sh --bazel-cache={self.args.bazel_cache}")
-            else:
-                build_cmds.append("build-jax.sh")
+                build_jax_cmd.append(f"--bazel-cache={self.args.bazel_cache}")
+            build_cmds.append(' '.join(build_jax_cmd))
             if not self.args.exclude_transformer_engine:
                 if len(self.args.transformer_engine_ccache_env):
                     build_cmds.append(
@@ -607,12 +701,15 @@ class TriageTool:
                     self._version_slug(
                         self.bisection_url,
                         versions={
-                            k: v
+                            k: [v] + self.args.cherry_pick.get(k, [])
                             for k, v in brief_versions.items()
                             if k != _REPETITION_KEY
                         },
                     )
                     + f"-{platform.machine()}"
+                )
+                tag_suffix = _bounded_tag_suffix(
+                    self.args.container_registry, tag_suffix
                 )
                 if self.args.container_registry is None:
                     # Do not push, everything local.
@@ -629,12 +726,22 @@ class TriageTool:
                     if DockerContainer(
                         container_name, logger=self.logger, mounts=[]
                     ).exists():
-                        command = [
-                            "echo",
-                            f"Skipping building {container_name} because it already exists",
-                        ]
-                    else:
-                        # TODO: organise this better to encourage layer sharing
+                        return run_and_log(
+                            [
+                                "echo",
+                                f"Skipping building {container_name} because it already exists",
+                            ],
+                            logger=self.logger,
+                            stderr="interleaved",
+                        )
+
+                    # TODO: organise this better to encourage layer sharing
+                    netrc_context = (
+                        tempfile.NamedTemporaryFile(mode="w", encoding="utf-8")
+                        if git_credentials
+                        else contextlib.nullcontext()
+                    )
+                    with netrc_context as netrc_file:
                         command = [
                             "docker",
                             "buildx",
@@ -648,13 +755,29 @@ class TriageTool:
                             str(data_files_dir / "Dockerfile.triage-tool"),
                             str(data_files_dir),
                         ]
+                        if netrc_file is not None:
+                            for hostname, (username, password) in sorted(
+                                git_credentials.items()
+                            ):
+                                netrc_file.write(
+                                    f"machine {hostname}\n"
+                                    f"login {username}\n"
+                                    f"password {password}\n"
+                                )
+                            netrc_file.flush()
+                            command.extend(
+                                [
+                                    "--secret",
+                                    f"id=git-netrc,src={netrc_file.name}",
+                                ]
+                            )
                         if self.args.container_registry is not None:
                             command.append("--push")
-                    return run_and_log(
-                        command,
-                        logger=self.logger,
-                        stderr="interleaved",
-                    )
+                        return run_and_log(
+                            command,
+                            logger=self.logger,
+                            stderr="interleaved",
+                        )
 
                 def _test():
                     return (
@@ -932,6 +1055,8 @@ class TriageTool:
                 confirmation_iterations=self.args.confirmation_iterations,
                 result_cache=result_cache,
                 classifier=classifier,
+                metric_name=self.args.metric_name,
+                missing_metric_retries=self.args.missing_metric_retries,
             )
         except CouldNotReproduceFailure as e:
             if (

--- a/.github/triage/pyproject.toml
+++ b/.github/triage/pyproject.toml
@@ -12,6 +12,9 @@ requires-python = ">= 3.8"
 [project.scripts]
 jax-toolbox-triage = "jax_toolbox_triage:main"
 
+[tool.setuptools.package-data]
+jax_toolbox_triage = ["data_files/Dockerfile.triage-tool"]
+
 [dependency-groups]
 dev = [
     "mypy>=1.14.1",

--- a/.github/triage/tests/mock_scripts/mock_plugin.py
+++ b/.github/triage/tests/mock_scripts/mock_plugin.py
@@ -31,7 +31,15 @@ if result.returncode == 0:
 else:
     metric_value = 0.0
 with open(args.output_prefix / "metrics.json", "w") as ofile:
-    json.dump({"test_metric": metric_value}, ofile)
+    json.dump(
+        {
+            "test_metric": metric_value,
+            "exit_code": result.returncode
+            if args.exit_code is None
+            else args.exit_code,
+        },
+        ofile,
+    )
 if args.exit_code is None:
     result.check_returncode()
 else:

--- a/.github/triage/tests/test_arg_parsing.py
+++ b/.github/triage/tests/test_arg_parsing.py
@@ -73,6 +73,18 @@ def test_good_local_args():
     assert "xla" in args.failing_versions
 
 
+def test_missing_metric_retries():
+    assert parse_args(valid_local_args + test_command).missing_metric_retries == 1
+    assert (
+        parse_args(
+            valid_local_args + ["--missing-metric-retries=3"] + test_command
+        ).missing_metric_retries
+        == 3
+    )
+    with pytest.raises(Exception, match="must be non-negative"):
+        parse_args(valid_local_args + ["--missing-metric-retries=-1"] + test_command)
+
+
 @pytest.mark.parametrize("date_args", valid_start_end_date_args)
 def test_bad_container_arg_combinations_across_groups(date_args):
     # Can't combine --{start,end}-container with --container/--{start,end}-date

--- a/.github/triage/tests/test_container_tags.py
+++ b/.github/triage/tests/test_container_tags.py
@@ -1,0 +1,23 @@
+from jax_toolbox_triage.triage_tool import _bounded_tag_suffix
+
+
+def test_container_tag_suffix_is_bounded_and_stable():
+    registry = "gitlab-master.nvidia.com/dl/dgx/jax:triage-"
+    suffix = (
+        "container-194a08c5-xla-569d0d78_569d0d78_089e80dd-"
+        "jax-5b7d26a9_5b7d26a9_66588223-maxtext-df1b3598-"
+        "transformer-engine-38a82f5d-x86_64"
+    )
+
+    bounded = _bounded_tag_suffix(registry, suffix)
+
+    assert len("triage-" + bounded) == 128
+    assert bounded == _bounded_tag_suffix(registry, suffix)
+    assert bounded != _bounded_tag_suffix(registry, suffix + "-different")
+
+
+def test_short_container_tag_suffix_is_unchanged():
+    suffix = "container-12345678-jax-abcdef01-x86_64"
+
+    assert _bounded_tag_suffix("registry.example/repo:triage-", suffix) == suffix
+    assert _bounded_tag_suffix("registry.example:5005/repo", suffix) == suffix

--- a/.github/triage/tests/test_git_fetch.py
+++ b/.github/triage/tests/test_git_fetch.py
@@ -1,0 +1,39 @@
+from jax_toolbox_triage.triage_tool import (
+    _git_fetch_refs,
+    _remote_without_credentials,
+)
+
+
+def test_remote_credentials_are_removed_from_build_url():
+    remote = (
+        "https://gitlab-ci-token:secret-token@"
+        "gitlab-master.nvidia.com/dl/jax/jax.git"
+    )
+
+    sanitized, credentials = _remote_without_credentials(remote)
+
+    assert sanitized == "https://gitlab-master.nvidia.com/dl/jax/jax.git"
+    assert credentials == (
+        "gitlab-master.nvidia.com",
+        "gitlab-ci-token",
+        "secret-token",
+    )
+    assert "secret-token" not in sanitized
+
+
+def test_remote_without_credentials_is_unchanged():
+    remote = "origin"
+
+    assert _remote_without_credentials(remote) == (remote, None)
+
+
+def test_fetch_refs_include_checkout_and_cherry_pick_endpoints():
+    assert _git_fetch_refs(
+        "selected",
+        ["passing-main..passing-container", "explicit-fix"],
+    ) == [
+        "selected",
+        "passing-main",
+        "passing-container",
+        "explicit-fix",
+    ]

--- a/.github/triage/tests/test_metric_classifier.py
+++ b/.github/triage/tests/test_metric_classifier.py
@@ -33,6 +33,51 @@ def wrap(metric_value: float) -> TestResult:
     )
 
 
+@pytest.mark.parametrize(
+    "passing_values,failing_values,expected_common_variance",
+    [
+        ([1.0], [0.0], True),
+        ([1.0, 1.1], [0.0], True),
+        ([1.0], [0.0, 0.1], True),
+        ([1.0, 1.1], [0.0, 0.1], False),
+    ],
+)
+def test_default_common_variance(
+    passing_values, failing_values, expected_common_variance
+):
+    classifier = MetricClassifier(
+        metric_name=_METRIC_NAME,
+        passing_values=passing_values,
+        failing_values=failing_values,
+    )
+
+    assert classifier.common_variance is expected_common_variance
+
+
+def test_multiple_seed_values_classify_failed_job_midpoint():
+    classifier = MetricClassifier(
+        metric_name="tflops_per_sec",
+        passing_values=[754.4, 762.883, 743.832, 757.912, 700.865],
+        failing_values=[671.022, 669.106, 672.826, 667.27, 666.808],
+    )
+    labelled_results = [
+        (ClassifiedTestOutcome.FAIL, 665.573),
+        (ClassifiedTestOutcome.FAIL, 674.853),
+        (ClassifiedTestOutcome.PASS, 706.069),
+        (ClassifiedTestOutcome.PASS, 716.882),
+    ]
+    for label, value in labelled_results:
+        result = wrap(value)
+        result.metrics = {"tflops_per_sec": value}
+        outcome = classifier([result])
+        if outcome == ClassifiedTestOutcome.AMBIGUOUS:
+            classifier.add_data_with_label([result], label)
+
+    midpoint = wrap(708.014)
+    midpoint.metrics = {"tflops_per_sec": 708.014}
+    assert classifier([midpoint]) == ClassifiedTestOutcome.PASS
+
+
 @pytest.mark.parametrize("random_seed", range(4))
 # How many labelled values to seed the classifier with.
 @pytest.mark.parametrize("seed_values", [2, 4])

--- a/.github/triage/tests/test_plugin_results.py
+++ b/.github/triage/tests/test_plugin_results.py
@@ -1,0 +1,43 @@
+import json
+import logging
+import subprocess
+from types import SimpleNamespace
+
+from jax_toolbox_triage.logic import TestExecutionOutcome
+from jax_toolbox_triage.triage_tool import TriageTool
+
+
+def make_tool():
+    tool = object.__new__(TriageTool)
+    tool.args = SimpleNamespace(container_runtime="plugin", metric_name=None)
+    tool.logger = logging.getLogger("plugin-result-tests")
+    return tool
+
+
+def test_plugin_can_report_missing_exit_code(tmp_path):
+    with open(tmp_path / "metrics.json", "w") as metrics_file:
+        json.dump({}, metrics_file)
+
+    result = make_tool()._run_test(
+        lambda: (
+            subprocess.CompletedProcess([], 1, stdout="submission failed"),
+            tmp_path,
+            "example.invalid/container",
+        )
+    )
+
+    assert result.result == TestExecutionOutcome.TEST_YIELDED_RESULTS
+    assert result.metrics == {}
+
+
+def test_plugin_without_metrics_reports_test_error(tmp_path):
+    result = make_tool()._run_test(
+        lambda: (
+            subprocess.CompletedProcess([], 1, stdout="workload failed"),
+            tmp_path,
+            "example.invalid/container",
+        )
+    )
+
+    assert result.result == TestExecutionOutcome.TEST_ERROR
+    assert result.metrics == {}

--- a/.github/triage/tests/test_restart.py
+++ b/.github/triage/tests/test_restart.py
@@ -190,6 +190,55 @@ def test_restart_suffixed_stale_output_directory(tmp_path):
     assert retry.name.endswith("-restart-1")
 
 
+def test_retry_cleans_and_reuses_rep_zero_output_directory(tmp_path):
+    (tmp_path / "summary.json").write_text("{}")
+    args = parse_args(
+        [
+            "--restart",
+            "--output-prefix",
+            str(tmp_path),
+            "--container-runtime=local",
+            "--passing-versions",
+            "jax:jax-good,xla:xla-good",
+            "--failing-versions",
+            "jax:jax-bad,xla:xla-good",
+            "test-command",
+        ]
+    )
+    tool = TriageTool(args, logging.getLogger("triage-restart-test"))
+
+    failed = tool._test_output_directory("local", {"jax": "jax-good", "#rep": "0"})
+    (failed / "partial-output.log").write_text("failed")
+    retry = tool._test_output_directory(
+        "local", {"jax": "jax-good", "#rep": "0"}, overwrite=True
+    )
+
+    assert retry == failed
+    assert retry.name.endswith("#rep-0")
+    assert not (retry / "partial-output.log").exists()
+
+
+def test_container_output_directory_without_versions(tmp_path):
+    args = parse_args(
+        [
+            "--output-prefix",
+            str(tmp_path),
+            "--container-runtime=local",
+            "--passing-versions",
+            "jax:jax-good,xla:xla-good",
+            "--failing-versions",
+            "jax:jax-bad,xla:xla-good",
+            "test-command",
+        ]
+    )
+    tool = TriageTool(args, logging.getLogger("triage-restart-test"))
+
+    out_dir = tool._test_output_directory("container-url", None)
+
+    assert out_dir.parent == tmp_path
+    assert out_dir.name.startswith("container-")
+
+
 def test_triage_tool_loads_restart_cache(tmp_path):
     good_dir = tmp_path / "good"
     bad_dir = tmp_path / "bad"

--- a/.github/triage/tests/test_triage_logic.py
+++ b/.github/triage/tests/test_triage_logic.py
@@ -11,6 +11,7 @@ from jax_toolbox_triage.logic import (
     ExitCodeClassifier,
     TestExecutionOutcome,
     TestResult,
+    version_cache_key,
     version_search,
 )
 from jax_toolbox_triage.metric_classifier import MetricClassifier
@@ -102,6 +103,173 @@ def test_version_search_explicit(
     assert ExitCodeClassifier()(first_known_bad) == ClassifiedTestOutcome.FAIL
     assert last_known_good[0].host_output_directory == last_known_good_dir
     assert first_known_bad[0].host_output_directory == first_known_bad_dir
+
+
+def test_version_search_retries_cached_result_missing_metric(logger):
+    commits = make_commits(
+        jax=[("good", 1), ("bad", 2)],
+        xla=[("ref", 1)],
+    )
+    cached_bad_key = version_cache_key({"jax": "bad", "xla": "ref"}, repetition=0)
+    result_cache = {cached_bad_key: wrap(False)}
+    executions = collections.Counter()
+    calls = []
+
+    def dummy_test(*, versions, **kwargs):
+        executions[versions["jax"]] += 1
+        calls.append((versions["jax"], kwargs))
+        return wrap(
+            True,
+            versions,
+            metrics={_METRIC_NAME: 0 if versions["jax"] == "good" else 1},
+        )
+
+    version_search(
+        build_and_test=dummy_test,
+        versions=commits,
+        logger=logger,
+        skip_precondition_checks=False,
+        confirmation_iterations=0,
+        result_cache=result_cache,
+        classifier=MetricClassifier(
+            metric_name=_METRIC_NAME,
+            passing_values=[0],
+            failing_values=[1],
+        ),
+        metric_name=_METRIC_NAME,
+    )
+
+    assert executions["bad"] == 1
+    assert result_cache[cached_bad_key].metrics[_METRIC_NAME] == 1
+    bad_call = next(kwargs for version, kwargs in calls if version == "bad")
+    assert bad_call["test_repetition"] == 0
+    assert bad_call["repeating_test_repetition"] is True
+
+
+@pytest.mark.parametrize("metric_name", [None, _METRIC_NAME])
+def test_version_search_skips_persistent_missing_results(logger, metric_name):
+    commits = make_commits(
+        jax=[("ref", 1)],
+        xla=[
+            ("good", 1),
+            ("no-result-1", 2),
+            ("no-result-2", 3),
+            ("bad", 4),
+        ],
+    )
+    calls = collections.defaultdict(list)
+
+    def dummy_test(*, versions, **kwargs):
+        version = versions["xla"]
+        calls[version].append(kwargs)
+        if version.startswith("no-result"):
+            result = wrap(True, versions)
+            result.result = TestExecutionOutcome.TEST_ERROR
+            result.metrics = {}
+            return result
+        if metric_name is None:
+            return wrap(version == "good", versions)
+        return wrap(
+            True,
+            versions,
+            metrics={_METRIC_NAME: 0 if version == "good" else 1},
+        )
+
+    classifier = (
+        ExitCodeClassifier()
+        if metric_name is None
+        else MetricClassifier(
+            metric_name=_METRIC_NAME,
+            passing_values=[0],
+            failing_values=[1],
+        )
+    )
+    result, last_known_good, first_known_bad = version_search(
+        build_and_test=dummy_test,
+        versions=commits,
+        logger=logger,
+        skip_precondition_checks=False,
+        confirmation_iterations=0,
+        classifier=classifier,
+        metric_name=metric_name,
+        missing_metric_retries=2,
+    )
+
+    assert result == {
+        "jax_ref": "ref",
+        "xla_good": "good,[no-result-1,no-result-2]",
+        "xla_bad": "[no-result-1,no-result-2],bad",
+    }
+    assert classifier(last_known_good) == ClassifiedTestOutcome.PASS
+    assert classifier(first_known_bad) == ClassifiedTestOutcome.FAIL
+    tested_missing_versions = {
+        version: version_calls
+        for version, version_calls in calls.items()
+        if version.startswith("no-result")
+    }
+    assert tested_missing_versions
+    for version_calls in tested_missing_versions.values():
+        assert [call["test_repetition"] for call in version_calls] == [0, 0, 0]
+        assert [
+            call.get("repeating_test_repetition", False) for call in version_calls
+        ] == [False, True, True]
+
+
+def test_version_search_reuses_cached_result_around_unavailable_version(logger):
+    commits = make_commits(
+        jax=[("ref", 1)],
+        xla=[
+            ("good", 1),
+            ("cached-pass", 2),
+            ("no-result", 3),
+            ("bad", 4),
+        ],
+    )
+
+    def metric_result(version, value):
+        return wrap(
+            True,
+            {"xla": version, "jax": "ref"},
+            metrics={_METRIC_NAME: value},
+        )
+
+    unavailable = wrap(True, {"xla": "no-result", "jax": "ref"})
+    unavailable.result = TestExecutionOutcome.TEST_ERROR
+    unavailable.metrics = {}
+    unavailable.required_metric_retries_exhausted = True
+
+    result_cache = {
+        version_cache_key({"xla": "good", "jax": "ref"}): metric_result("good", 0),
+        version_cache_key({"xla": "cached-pass", "jax": "ref"}): metric_result(
+            "cached-pass", 0
+        ),
+        version_cache_key({"xla": "no-result", "jax": "ref"}): unavailable,
+        version_cache_key({"xla": "bad", "jax": "ref"}): metric_result("bad", 1),
+    }
+
+    def unexpected_execution(**kwargs):
+        pytest.fail(f"Unexpected execution: {kwargs}")
+
+    result, _, _ = version_search(
+        build_and_test=unexpected_execution,
+        versions=commits,
+        logger=logger,
+        skip_precondition_checks=True,
+        confirmation_iterations=0,
+        result_cache=result_cache,
+        classifier=MetricClassifier(
+            metric_name=_METRIC_NAME,
+            passing_values=[0],
+            failing_values=[1],
+        ),
+        metric_name=_METRIC_NAME,
+    )
+
+    assert result == {
+        "jax_ref": "ref",
+        "xla_good": "cached-pass,[no-result]",
+        "xla_bad": "[no-result],bad",
+    }
 
 
 start_date = datetime.datetime(2024, 10, 1)


### PR DESCRIPTION
- Include triage Dockerfile in package data.
- Include cherry picks in version slug strings.
- Fetch triage commits in plugin builds.
- Retry triage runs with missing metrics.
- --extra-build-jax-args.
- Do not share metric variances when given multiple seed values.