### PR TITLE
`set +x` before printing usage

### DIFF
--- a/.github/container/test-maxtext.sh
+++ b/.github/container/test-maxtext.sh
@@ -8,6 +8,7 @@ print_var() {
 }
 
 usage() {
+    set +x
     echo "Test MaxText throughput on sythetic data."
     echo ""
     echo "Usage: $0 [OPTIONS]"


### PR DESCRIPTION
Tracing commands can be useful for the rest of the script, but for the usage message it provides more noise than benefit.