### PR TITLE
alphafold3: bump tokamax pin

### DIFF
--- a/.github/container/Dockerfile.alphafold
+++ b/.github/container/Dockerfile.alphafold
@@ -17,10 +17,12 @@ RUN <<"EOF" bash -ex -o pipefail
 git-clone.sh ${URLREF_ALPHAFOLD} ${SRC_PATH_ALPHAFOLD}
 EOF
 
-
+# Remove JAX version pins; we use HEAD. Remove tokamax pin; the latest tokamax
+# release is more likely to be compatible with the HEAD of JAX.
 RUN <<"EOF" bash -ex -o pipefail
 sed -i '/"jax==.*"/d' ${SRC_PATH_ALPHAFOLD}/pyproject.toml
 sed -i '/"jax\[cuda12\]==.*"/d' ${SRC_PATH_ALPHAFOLD}/pyproject.toml
+sed -i 's/"tokamax==[^"]*"/"tokamax"/' ${SRC_PATH_ALPHAFOLD}/pyproject.toml
 echo "-e file://${SRC_PATH_ALPHAFOLD}" >> /opt/pip-tools.d/requirements-af.in
 EOF
 RUN cat ${SRC_PATH_ALPHAFOLD}/pyproject.toml

--- a/.github/container/Dockerfile.alphafold
+++ b/.github/container/Dockerfile.alphafold
@@ -17,12 +17,12 @@ RUN <<"EOF" bash -ex -o pipefail
 git-clone.sh ${URLREF_ALPHAFOLD} ${SRC_PATH_ALPHAFOLD}
 EOF
 
-# Remove JAX version pins; we use HEAD. Remove tokamax pin; the latest tokamax
-# release is more likely to be compatible with the HEAD of JAX.
+
 RUN <<"EOF" bash -ex -o pipefail
 sed -i '/"jax==.*"/d' ${SRC_PATH_ALPHAFOLD}/pyproject.toml
 sed -i '/"jax\[cuda12\]==.*"/d' ${SRC_PATH_ALPHAFOLD}/pyproject.toml
-sed -i 's/"tokamax==[^"]*"/"tokamax"/' ${SRC_PATH_ALPHAFOLD}/pyproject.toml
+# 0.0.12 is too old for JAX @ HEAD
+sed -i 's/"tokamax==0.0.12"/"tokamax==0.0.13"/' ${SRC_PATH_ALPHAFOLD}/pyproject.toml
 echo "-e file://${SRC_PATH_ALPHAFOLD}" >> /opt/pip-tools.d/requirements-af.in
 EOF
 RUN cat ${SRC_PATH_ALPHAFOLD}/pyproject.toml

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -8,7 +8,7 @@ on:
       timezone: "Europe/London"
   push:
     branches:
-      - 'pull-request/[0-9]+'
+      - 'pull-request/[0-9]+' # created by copy-pr-bot
     paths-ignore:
       - '**.md'
       - '.github/triage/**'

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -8,7 +8,7 @@ on:
       timezone: "Europe/London"
   push:
     branches:
-      - 'pull-request/[0-9]+' # created by copy-pr-bot
+      - 'pull-request/[0-9]+'
     paths-ignore:
       - '**.md'
       - '.github/triage/**'


### PR DESCRIPTION
https://github.com/jax-ml/jax/pull/40418 broke compatibility with tokamax 0.0.12, which is pinned in alphafold3: https://github.com/google-deepmind/alphafold3/blob/c0f97eda2f1f482fd94d3a38bece18c7069b4a5c/pyproject.toml#L26

https://github.com/openxla/tokamax/pull/989 is released in Tokamax 0.0.13.